### PR TITLE
ARGO-319 Broker Backend interface implementation

### DIFF
--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -1,0 +1,114 @@
+package brokers
+
+import "log"
+
+import "github.com/Shopify/sarama"
+
+// KafkaBroker struct
+type KafkaBroker struct {
+	Config   *sarama.Config
+	Producer sarama.SyncProducer
+	Client   sarama.Client
+	Consumer sarama.Consumer
+	Servers  []string
+}
+
+// CloseConnections closes open producer, consumer and client
+func (b *KafkaBroker) CloseConnections() {
+	// Close Producer
+	if err := b.Producer.Close(); err != nil {
+		log.Fatalln(err)
+	}
+	// Close Consumer
+	if err := b.Consumer.Close(); err != nil {
+		log.Fatalln(err)
+	}
+	// Close Client
+	if err := b.Client.Close(); err != nil {
+		log.Fatalln(err)
+	}
+
+}
+
+// Initialize the broker struct
+func (b *KafkaBroker) Initialize(peer string) {
+	b.Config = sarama.NewConfig()
+	b.Config.Producer.RequiredAcks = sarama.WaitForAll
+	b.Config.Producer.Retry.Max = 5
+	b.Servers = []string{peer}
+
+	var err error
+
+	b.Producer, err = sarama.NewSyncProducer(b.Servers, b.Config)
+	if err != nil {
+		// Should not reach here
+		panic(err)
+	}
+
+	b.Client, err = sarama.NewClient(b.Servers, nil)
+	if err != nil {
+		// Should not reach here
+		panic(err)
+	}
+
+	b.Consumer, err = sarama.NewConsumer(b.Servers, nil)
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+// Publish function publish a message to the broker
+func (b *KafkaBroker) Publish(topic string, payload string) (string, int, int) {
+
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.StringEncoder(payload),
+	}
+
+	partition, offset, err := b.Producer.SendMessage(msg)
+	if err != nil {
+		panic(err)
+	}
+
+	return topic, int(partition), int(offset)
+}
+
+// Consume function to consume a message from the broker
+func (b *KafkaBroker) Consume(topic string, offset int64) []string {
+
+	// Fetch offset
+	loff, err := b.Client.GetOffset(topic, 0, sarama.OffsetNewest)
+	if err != nil {
+		panic(err)
+	}
+
+	partitionConsumer, err := b.Consumer.ConsumePartition(topic, 0, offset)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err := partitionConsumer.Close(); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	messages := []string{}
+	var consumed int64
+ConsumerLoop:
+	for {
+		select {
+		case msg := <-partitionConsumer.Messages():
+			log.Printf("Consumed message offset %d\n", msg.Offset)
+			messages = append(messages, string(msg.Value[:]))
+			consumed++
+			if offset+consumed > loff-1 {
+				break ConsumerLoop
+			}
+
+		}
+	}
+
+	return messages
+}

--- a/brokers/kafka_test.go
+++ b/brokers/kafka_test.go
@@ -1,0 +1,28 @@
+package brokers
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigTestSuite) TestPublish() {
+
+	var broker KafkaBroker
+	broker.Config = sarama.NewConfig()
+	pr := mocks.NewSyncProducer(suite.T(), broker.Config)
+	pr.ExpectSendMessageAndSucceed()
+	broker.Producer = pr
+	broker.Publish("test-topic", "test-message")
+
+}
+
+func TestFactorsTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "server":"localhost:9092",
+  "topics":["topic1","topic2"]
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+// kafka Configuration
+type configKafka struct {
+	Server string
+	Topics []string
+}
+
+// Global Kafka configuration
+var Kafka configKafka
+
+// Load the configuration
+func Load() {
+
+	viper.SetConfigName("config")
+	viper.AddConfigPath("/etc/argo-messaging")
+	viper.AddConfigPath(".")
+
+	// Find and read the configuration file
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic(fmt.Errorf("Errod trying to read the configuration file: %s \n", err))
+	}
+
+	// Load Kafka configuration
+	Kafka.Server = viper.GetString("server")
+	Kafka.Topics = viper.GetStringSlice("topics")
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ARGOeu/argo-messaging/config"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigTestSuite) TestLoadConfiguration() {
+	config.Load()
+	suite.Equal("localhost:9092", config.Kafka.Server)
+	suite.Equal("topic1", config.Kafka.Topics[0])
+	suite.Equal("topic2", config.Kafka.Topics[1])
+}
+
+func TestFactorsTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}

--- a/init.go
+++ b/init.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/ARGOeu/argo-messaging/brokers"
+	"github.com/ARGOeu/argo-messaging/config"
+)
+
+// Globals
+var broker brokers.KafkaBroker
+
+func init() {
+	config.Load()
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+
+	"strconv"
+
+	"github.com/ARGOeu/argo-messaging/config"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	defer broker.CloseConnections()
+	broker.Initialize(config.Kafka.Server)
+	router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/", ReflectRoute)
+	router.HandleFunc("/v1/", ReflectRoute)
+	router.HandleFunc("/v1/pub/{topic}", RawPublish)
+	router.HandleFunc("/v1/sub/{topic}", RawConsume)
+	log.Fatal(http.ListenAndServe(":8080", router))
+}
+
+// ReflectRoute is a temporary function which confirms that the api is alive and reflects the route used
+func ReflectRoute(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "API alive!\nRoute: %q", html.EscapeString(r.URL.Path))
+}
+
+// RawPublish This is a temporary api call to test pub functionality until publish model is implemented
+func RawPublish(w http.ResponseWriter, r *http.Request) {
+	urlValues := r.URL.Query()
+	urlVars := mux.Vars(r)
+	m, p, o := broker.Publish(urlVars["topic"], urlValues.Get("message"))
+	fmt.Fprintf(w, "Message Published!")
+	fmt.Fprintf(w, "\nkafka endpoint: "+config.Kafka.Server)
+	fmt.Fprintf(w, "\nTopic:"+m)
+	fmt.Fprintf(w, "\nPartition: "+strconv.Itoa(p))
+	fmt.Fprintf(w, "\nOffset: "+strconv.Itoa(o))
+	fmt.Fprintf(w, "\nMessage:"+urlValues.Get("message"))
+}
+
+// RawConsume to test if we can consume
+func RawConsume(w http.ResponseWriter, r *http.Request) {
+	urlValues := r.URL.Query()
+	urlVars := mux.Vars(r)
+	offset, _ := strconv.ParseInt(urlValues.Get("offset"), 10, 64)
+	fmt.Fprintf(w, "\nkafka endpoint: "+config.Kafka.Server+"\n")
+	m := broker.Consume(urlVars["topic"], offset)
+	for index, value := range m {
+		fmt.Fprintf(w, "message "+strconv.Itoa(index)+" : "+value+"\n")
+	}
+
+}


### PR DESCRIPTION
### Goal
Implement Broker Backend interface for Messaging rest API
(pub/sub --> through rest --> to kafka broker network)

### Implementation

Implement a Kafka broker backend interface using sarama library 
This backend will exist behind a restAPI with restfull calls to Produce and Consume messages.
- Use sarama's SyncProducer to send message to a topic and close connection
- Since sarama's Consumer is Async and uses channels to consume data, a "sync" like Consume function is implemented. This function receives a topic and an offset (as input), checks topic's currentMaxOffset on broker and consumes all available messages till latest one and then closes the channel. The messages are returned as an array to the restAPI (as output)
- main function hosts temporarily a simple api frontend implementation with pub/sub calls which will be later replaced by specific API resource packages (topics,messages, etc...)