### PR TITLE
ARGO-375 Add Authentication to Messaging API

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/ARGOeu/argo-messaging/Godeps/_workspace/src/github.com/stretchr/testify/suite"
+	"github.com/ARGOeu/argo-messaging/stores"
+)
+
+type AuthTestSuite struct {
+	suite.Suite
+}
+
+func (suite *AuthTestSuite) TestMockStore() {
+
+	store := stores.NewMockStore("mockhost", "mockbase")
+	suite.Equal([]string{"admin", "member"}, Authenticate("ARGO", "S3CR3T", store))
+	suite.Equal([]string{}, Authenticate("ARGO", "falseSecret", store))
+
+	suite.Equal(true, Authorize("topics:list_all", []string{"admin"}, store))
+	suite.Equal(true, Authorize("topics:list_all", []string{"admin", "reader"}, store))
+	suite.Equal(true, Authorize("topics:list_all", []string{"admin", "foo"}, store))
+	suite.Equal(false, Authorize("topics:list_all", []string{"foo"}, store))
+	suite.Equal(false, Authorize("topics:publish", []string{"reader"}, store))
+	suite.Equal(true, Authorize("topics:list_all", []string{"publisher"}, store))
+	suite.Equal(true, Authorize("topics:publish", []string{"publisher"}, store))
+
+}
+
+func TestAuthTestSuite(t *testing.T) {
+	suite.Run(t, new(AuthTestSuite))
+}

--- a/auth/users.go
+++ b/auth/users.go
@@ -1,0 +1,27 @@
+package auth
+
+import "github.com/ARGOeu/argo-messaging/stores"
+
+// User is the struct that holds user information
+type User struct {
+	Name    string
+	Email   string
+	Project string
+	Token   string
+	Roles   []string
+}
+
+// Users holds a list of available users
+type Users struct {
+	List []Users
+}
+
+// Authenticate based on token
+func Authenticate(project string, token string, store stores.Store) []string {
+	return store.GetUserRoles(project, token)
+}
+
+// Authorize based on resource and  role information
+func Authorize(resource string, roles []string, store stores.Store) bool {
+	return store.HasResourceRoles(resource, roles)
+}

--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -130,7 +130,7 @@ ConsumerLoop:
 	for {
 		select {
 		case msg := <-partitionConsumer.Messages():
-			log.Printf("Consumed message offset %d\n", msg.Offset)
+
 			messages = append(messages, string(msg.Value[:]))
 			consumed++
 			if offset+consumed > loff-1 {

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -85,7 +85,7 @@ func (b *MockBroker) Initialize(peer string) {
 // Publish function publish a message to the broker
 func (b *MockBroker) Publish(topic string, payload string) (string, int, int64) {
 	b.MsgList = append(b.MsgList, payload)
-	return "ARGO.mocktopic", 0, int64(len(b.MsgList))
+	return "ARGO.topic1", 0, int64(len(b.MsgList))
 }
 
 // GetOffset returns a current topic's offset

--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
   "broker_host":"localhost:9092",
   "store_host":"localhost",
-  "store_db":"argo_msg"
+  "store_db":"argo_msg",
+  "use_authorization":true,
+  "use_authentication":true
 }

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,8 @@ type APICfg struct {
 	BrokerHost string
 	StoreHost  string
 	StoreDB    string
+	Authen     bool
+	Author     bool
 }
 
 // NewAPICfg creates a new kafka configuration object
@@ -51,7 +53,10 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_db", cfg.StoreDB)
-
+	cfg.Authen = viper.GetBool("use_authentication")
+	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authentication", cfg.Authen)
+	cfg.Author = viper.GetBool("use_authorization")
+	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
 }
 
 // LoadStrJSON Loads configuration from a JSON string
@@ -65,5 +70,9 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_db", cfg.StoreDB)
+	cfg.Authen = viper.GetBool("use_authentication")
+	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authentication", cfg.Authen)
+	cfg.Author = viper.GetBool("use_authorization")
+	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
 
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,7 @@
 {
   "broker_host":"localhost:9092",
   "store_host":"localhost",
-  "store_db":"argo_msg"
+  "store_db":"argo_msg",
+  "use_authorization":true,
+  "use_authentication":true
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,9 @@ func (suite *ConfigTestSuite) SetupTest() {
 	{
 	  "broker_host":"localhost:9092",
 		"store_host":"localhost",
-		"store_db":"argo_msg"
+		"store_db":"argo_msg",
+		"use_authorization":true,
+		"use_authentication":true
 	}
 	`
 
@@ -32,12 +34,16 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	suite.Equal("localhost:9092", APIcfg.BrokerHost)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
+	suite.Equal(true, APIcfg.Authen)
+	suite.Equal(true, APIcfg.Author)
 
 	// test "LOAD" param
 	APIcfg2 := NewAPICfg("LOAD")
 	suite.Equal("localhost:9092", APIcfg2.BrokerHost)
 	suite.Equal("localhost", APIcfg2.StoreHost)
 	suite.Equal("argo_msg", APIcfg2.StoreDB)
+	suite.Equal(true, APIcfg2.Authen)
+	suite.Equal(true, APIcfg2.Author)
 
 }
 
@@ -47,6 +53,8 @@ func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	suite.Equal("localhost:9092", APIcfg.BrokerHost)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
+	suite.Equal(true, APIcfg.Authen)
+	suite.Equal(true, APIcfg.Author)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -19,6 +19,7 @@ paths:
       description: |
         The subscriptions endpoint returns a list of available subscriptions for a given project
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: PROJECT
           in: path
           description: Name of the project
@@ -33,6 +34,14 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Subscription'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
 
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:
     get:
@@ -40,6 +49,7 @@ paths:
       description: |
         Lists information about a specific subscription belonging to a specific project
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: PROJECT
           in: path
           description: Name of the project
@@ -57,6 +67,14 @@ paths:
           description: An array of Subscriptions
           schema:
             $ref: '#/definitions/Subscription'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
 
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:pull:
     post:
@@ -87,6 +105,14 @@ paths:
           description: An array of received messages
           schema:
             $ref: '#/definitions/ReceivedMessages'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
 
   /projects/{PROJECT}/topics:
     get:
@@ -94,6 +120,7 @@ paths:
       description: |
         The Topics endpoint returns a list of available topics for a given project
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: PROJECT
           in: path
           description: Name of the project
@@ -108,6 +135,14 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Topic'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
 
   /projects/{PROJECT}/topics/{TOPIC}:
     get:
@@ -115,6 +150,7 @@ paths:
       description: |
         The Topics endpoint returns a list of available topics for a given project
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: PROJECT
           in: path
           description: Name of the project
@@ -132,12 +168,22 @@ paths:
           description: A topic object
           schema:
             $ref: '#/definitions/Topic'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/topics/{TOPIC}:publish:
     post:
       summary: List topics in a project
       description: |
         The topic:publish endpoint publish a message to a specific topic
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: PROJECT
           in: path
           description: Name of the project
@@ -161,6 +207,41 @@ paths:
           description: An array of messageIDs
           schema:
             $ref: '#/definitions/MessageIDs'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+parameters:
+  ApiKey:
+    name: key
+    in: query
+    description: user key token for authentication
+    required: true
+    type: string
+    default: SecretKey123
+
+responses:
+  401:
+    description: Unauthorized user based on key
+    schema:
+      $ref: '#/definitions/ErrorMsg'
+  403:
+    description: Access Forbidden for the user on the resource
+    schema:
+      $ref: '#/definitions/ErrorMsg'
+  404:
+    description: Item not found
+    schema:
+      $ref: '#/definitions/ErrorMsg'
+  500:
+    description: Internal Error
+    schema:
+      $ref: '#/definitions/ErrorMsg'
 
 definitions:
   PullOptions:
@@ -248,3 +329,34 @@ definitions:
          type: array
          items:
            type: string
+
+  ErrorMsg:
+    type: object
+    properties:
+      error:
+        type: object
+        properties:
+          code:
+            type: string
+            description: code of the error
+          message:
+            type: string
+            description: general message of the error
+          errors:
+            type: array
+            description: list of errors occured
+            items:
+              type: object
+              properties:
+                message:
+                  type: string
+                  description: error message
+                domain:
+                  type: string
+                  description: where the error happened
+                reason:
+                  type: string
+                  description: reason given for the error
+          status:
+            type: string
+            description: status of the error

--- a/routing.go
+++ b/routing.go
@@ -39,7 +39,18 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 		// prepare handle wrappers
 		var handler http.HandlerFunc
 		handler = route.Handler
+
 		handler = WrapLog(handler, route.Name)
+
+		if cfg.Author && cfg.Authen {
+
+			handler = WrapAuthorize(handler, route.Name)
+		}
+
+		if cfg.Authen {
+
+			handler = WrapAuthenticate(handler)
+		}
 		handler = WrapConfig(handler, cfg, brk, str)
 
 		ar.Router.
@@ -49,6 +60,14 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 			Handler(handler)
 	}
 
+	if cfg.Authen {
+		log.Printf("INFO\tAPI\tAPI Authentication mechanism enabled")
+	}
+
+	if cfg.Author {
+		log.Printf("INFO\tAPI\tAPI Authorization mechanism enabled")
+	}
+
 	log.Printf("INFO\tAPI\tAPI Router initialized! Ready to start listening...")
 	// Return reference to API object
 	return &ar
@@ -56,10 +75,10 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 
 // Global list populated with default routes
 var defaultRoutes = []APIRoute{
-	{"Subscriptions List All", "GET", "/projects/{project}/subscriptions", SubListAll},
-	{"Subscriptions List One", "GET", "/projects/{project}/subscriptions/{subscription}", SubListOne},
-	{"Subscriptions Pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
-	{"Topics List All", "GET", "/projects/{project}/topics", TopicListAll},
-	{"Topics List One", "GET", "/projects/{project}/topics/{topic}", TopicListOne},
-	{"Topics Publish", "POST", "/projects/{project}/topics/{topic}:publish", TopicPublish},
+	{"subscriptions:list", "GET", "/projects/{project}/subscriptions", SubListAll},
+	{"subscriptions:show", "GET", "/projects/{project}/subscriptions/{subscription}", SubListOne},
+	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
+	{"topics:list", "GET", "/projects/{project}/topics", TopicListAll},
+	{"topics:show", "GET", "/projects/{project}/topics/{topic}", TopicListOne},
+	{"topics:publish", "POST", "/projects/{project}/topics/{topic}:publish", TopicPublish},
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -2,11 +2,14 @@ package stores
 
 // MockStore holds configuration
 type MockStore struct {
-	Server    string
-	Database  string
-	SubList   []QSubs
-	TopicList []QTopics
-	Session   bool
+	Server      string
+	Database    string
+	SubList     []QSub
+	TopicList   []QTopic
+	ProjectList []QProject
+	UserList    []QUser
+	RoleList    []QRole
+	Session     bool
 }
 
 // NewMockStore creates new mock store
@@ -32,28 +35,84 @@ func (mk *MockStore) Initialize(server string, database string) {
 	mk.Server = server
 	mk.Database = database
 	// populate topics
-	qtop1 := QTopics{"ARGO", "topic1"}
-	qtop2 := QTopics{"ARGO", "topic2"}
-	qtop3 := QTopics{"ARGO", "topic3"}
+	qtop1 := QTopic{"ARGO", "topic1"}
+	qtop2 := QTopic{"ARGO", "topic2"}
+	qtop3 := QTopic{"ARGO", "topic3"}
 	mk.TopicList = append(mk.TopicList, qtop1)
 	mk.TopicList = append(mk.TopicList, qtop2)
 	mk.TopicList = append(mk.TopicList, qtop3)
 
 	// populate Subscriptions
-	qsub1 := QSubs{"ARGO", "sub1", "topic1", 0}
-	qsub2 := QSubs{"ARGO", "sub2", "topic2", 0}
-	qsub3 := QSubs{"ARGO", "sub3", "topic3", 0}
+	qsub1 := QSub{"ARGO", "sub1", "topic1", 0}
+	qsub2 := QSub{"ARGO", "sub2", "topic2", 0}
+	qsub3 := QSub{"ARGO", "sub3", "topic3", 0}
 	mk.SubList = append(mk.SubList, qsub1)
 	mk.SubList = append(mk.SubList, qsub2)
 	mk.SubList = append(mk.SubList, qsub3)
+
+	// populate Projects
+	qPr := QProject{"ARGO"}
+	mk.ProjectList = append(mk.ProjectList, qPr)
+
+	// populate Users
+	qUsr := QUser{"Test", "Test@test.com", "ARGO", "S3CR3T", []string{"admin", "member"}}
+	mk.UserList = append(mk.UserList, qUsr)
+
+	qRole1 := QRole{"topics:list_all", []string{"admin", "reader", "publisher"}}
+	qRole2 := QRole{"topics:publish", []string{"admin", "publisher"}}
+	mk.RoleList = append(mk.RoleList, qRole1)
+	mk.RoleList = append(mk.RoleList, qRole2)
+
+}
+
+// GetUserRoles returns the roles of a user in a project
+func (mk *MockStore) GetUserRoles(project string, token string) []string {
+	for _, item := range mk.UserList {
+		if item.Project == project && item.Token == token {
+			return item.Roles
+		}
+	}
+
+	return []string{}
+}
+
+//HasResourceRoles returns the roles of a user in a project
+func (mk *MockStore) HasResourceRoles(resource string, roles []string) bool {
+
+	for _, item := range mk.RoleList {
+		if item.Name == resource {
+			for _, subitem := range item.Roles {
+				for _, roleItem := range roles {
+					if roleItem == subitem {
+						return true
+					}
+				}
+			}
+		}
+
+	}
+
+	return false
+
+}
+
+// HasProject returns true if project exists in store
+func (mk *MockStore) HasProject(project string) bool {
+	for _, item := range mk.ProjectList {
+		if item.Name == project {
+			return true
+		}
+	}
+
+	return false
 }
 
 // QuerySubs Query Subscription info from store
-func (mk *MockStore) QuerySubs() []QSubs {
+func (mk *MockStore) QuerySubs() []QSub {
 	return mk.SubList
 }
 
 // QueryTopics Query Subscription info from store
-func (mk *MockStore) QueryTopics() []QTopics {
+func (mk *MockStore) QueryTopics() []QTopic {
 	return mk.TopicList
 }

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -1,0 +1,35 @@
+package stores
+
+// QSub are the results of the Qsub query
+type QSub struct {
+	Project string `bson:"project"`
+	Name    string `bson:"name"`
+	Topic   string `bson:"topic"`
+	Offset  int64  `bson:"offset"`
+}
+
+// QUser are the results of the QUser query
+type QUser struct {
+	Name    string   `bson:"name"`
+	Email   string   `bson:"email"`
+	Project string   `bson:"project"`
+	Token   string   `bson:"token"`
+	Roles   []string `bson:"roles"`
+}
+
+// QRole holds roles resources relationships
+type QRole struct {
+	Name  string   `bson:"name"`
+	Roles []string `bson:"roles"`
+}
+
+// QProject are the results of the QProject query
+type QProject struct {
+	Name string `bson:"name"`
+}
+
+// QTopic are the results of the QTopic query
+type QTopic struct {
+	Project string `bson:"project"`
+	Name    string `bson:"name"`
+}

--- a/stores/store.go
+++ b/stores/store.go
@@ -3,8 +3,11 @@ package stores
 // Store encapsulates the generic store interface
 type Store interface {
 	Initialize(server string, database string)
-	QuerySubs() []QSubs
-	QueryTopics() []QTopics
+	QuerySubs() []QSub
+	QueryTopics() []QTopic
+	HasProject(project string) bool
+	HasResourceRoles(resource string, roles []string) bool
+	GetUserRoles(project string, token string) []string
 	UpdateSubOffset(name string, offset int64)
 	Close()
 }

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -16,16 +16,33 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("mockhost", store.Server)
 	suite.Equal("mockbase", store.Database)
 
-	eTopList := []QTopics{QTopics{"ARGO", "topic1"},
-		QTopics{"ARGO", "topic2"},
-		QTopics{"ARGO", "topic3"}}
+	eTopList := []QTopic{QTopic{"ARGO", "topic1"},
+		QTopic{"ARGO", "topic2"},
+		QTopic{"ARGO", "topic3"}}
 
-	eSubList := []QSubs{QSubs{"ARGO", "sub1", "topic1", 0},
-		QSubs{"ARGO", "sub2", "topic2", 0},
-		QSubs{"ARGO", "sub3", "topic3", 0}}
+	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0},
+		QSub{"ARGO", "sub2", "topic2", 0},
+		QSub{"ARGO", "sub3", "topic3", 0}}
 
 	suite.Equal(eTopList, store.QueryTopics())
 	suite.Equal(eSubList, store.QuerySubs())
+
+	// Test Project
+	suite.Equal(true, store.HasProject("ARGO"))
+	suite.Equal(false, store.HasProject("FOO"))
+
+	// Test user
+	suite.Equal([]string{"admin", "member"}, store.GetUserRoles("ARGO", "S3CR3T"))
+	suite.Equal([]string{}, store.GetUserRoles("ARGO", "SecretKey"))
+
+	// Test roles
+	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin"}))
+	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin", "reader"}))
+	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin", "foo"}))
+	suite.Equal(false, store.HasResourceRoles("topics:list_all", []string{"foo"}))
+	suite.Equal(false, store.HasResourceRoles("topics:publish", []string{"reader"}))
+	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"publisher"}))
+	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
 }
 

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -95,3 +95,13 @@ func (sl *Subscriptions) GetSubsByProject(project string) Subscriptions {
 
 	return result
 }
+
+// HasSub returns true if project & subscription combination exist
+func (sl *Subscriptions) HasSub(project string, name string) bool {
+	res := sl.GetSubByName(project, name)
+	if res.Name != "" {
+		return true
+	}
+
+	return false
+}

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -43,6 +43,17 @@ func (suite *SubTestSuite) TestGetSubByName() {
 	suite.Equal(expSub, result)
 }
 
+func (suite *SubTestSuite) TestHasProjectTopic() {
+	cfgAPI := config.NewAPICfg()
+	cfgAPI.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(cfgAPI.StoreHost, cfgAPI.StoreDB)
+	mySubs := Subscriptions{}
+	mySubs.LoadFromStore(store)
+
+	suite.Equal(false, mySubs.HasSub("ARGO", "FOO"))
+	suite.Equal(true, mySubs.HasSub("ARGO", "sub1"))
+}
+
 func (suite *SubTestSuite) TestGetSubsByProject() {
 	cfgAPI := config.NewAPICfg()
 	cfgAPI.LoadStrJSON(suite.cfgStr)

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -78,3 +78,13 @@ func (tl *Topics) GetTopicsByProject(project string) Topics {
 
 	return result
 }
+
+// HasTopic returns true if project & topic combination exist
+func (tl *Topics) HasTopic(project string, name string) bool {
+	res := tl.GetTopicByName(project, name)
+	if res.Name != "" {
+		return true
+	}
+
+	return false
+}

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -42,6 +42,17 @@ func (suite *TopicTestSuite) TestGetTopicByName() {
 	suite.Equal(expTopic, result)
 }
 
+func (suite *TopicTestSuite) TestHasProjectTopic() {
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	myTopics := Topics{}
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	myTopics.LoadFromStore(store)
+
+	suite.Equal(false, myTopics.HasTopic("ARGO", "FOO"))
+	suite.Equal(true, myTopics.HasTopic("ARGO", "topic1"))
+}
+
 func (suite *TopicTestSuite) TestGetTopicsByProject() {
 	APIcfg := config.NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)


### PR DESCRIPTION
### Goals

- [x] Add Authentication mechanism 
- [x] Add also authorization (role based system)

### Authentication
In each request a api key token is provided as url parameter (spec)
e.g. GET `/v1/project/PROJECT101/topics?key=T0K3N`

Authentication mechanism checks in store if the project/key combination corresponds to an existing
user. 

Authentication is performed through a WrapAuthentication wrapper that can be appended to handler chain on demand. A configuration parameter is used `use_authentication:true` to enable/disable the use of authentication on the API

### Authorization

After the user has been authenticated, there is an authorization process based on roles to see if the user has access to the resource. In the store there are entries in the roles collection like the following
```json
{ "resource": "topics:list", "roles": ["admin","reader","publisher"] }
```
After authentication the role list of a user is passed to the authorization module and the latter decides if the resource is accessible or not. A configuration parameter is used `use_authorization:true` to enable/disable role authorization on the API

_Note_: thus the api can be started with authentication:on/off and authorization:on/off (provided authentication is also on)

## Implementations

- [x] Add Checks for project exists in store. Use for verification in handlers (topic:publish, subscription:pull)
- [x] Add Checks for project/topic , project/subscription exists. Use for verification in handlers (topic:publish, subscription:pull)
- [x] Update unittests
- [x] Add auth package
- [x] Implement Authentication wrapper to check if a token corresponds to a user of project
- [x] Implement Authorization wrapper to check if resource is accessible based on role given

- [x] swagger updated