### PR TITLE
ARGO-376 Create topic request

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -21,9 +21,9 @@ func (suite *AuthTestSuite) TestMockStore() {
 	suite.Equal(true, Authorize("topics:list_all", []string{"admin", "reader"}, store))
 	suite.Equal(true, Authorize("topics:list_all", []string{"admin", "foo"}, store))
 	suite.Equal(false, Authorize("topics:list_all", []string{"foo"}, store))
-	suite.Equal(false, Authorize("topics:publish", []string{"reader"}, store))
 	suite.Equal(true, Authorize("topics:list_all", []string{"publisher"}, store))
 	suite.Equal(true, Authorize("topics:publish", []string{"publisher"}, store))
+	suite.Equal(false, Authorize("topics:publish", []string{"reader"}, store))
 
 }
 

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -145,6 +145,40 @@ paths:
           $ref: "#/responses/500"
 
   /projects/{PROJECT}/topics/{TOPIC}:
+    put:
+      summary: Create a new topic in a project
+      description: |
+        This request creates a new topic in a project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: TOPIC
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+      tags:
+        - Topics
+      responses:
+        200:
+          description: The new topic object created
+          schema:
+            $ref: '#/definitions/Topic'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+
     get:
       summary: List topics in a project
       description: |
@@ -236,6 +270,10 @@ responses:
       $ref: '#/definitions/ErrorMsg'
   404:
     description: Item not found
+    schema:
+      $ref: '#/definitions/ErrorMsg'
+  409:
+    description: Item already exists!
     schema:
       $ref: '#/definitions/ErrorMsg'
   500:

--- a/handlers.go
+++ b/handlers.go
@@ -131,6 +131,50 @@ func SubListOne(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// TopicCreate (PUT) creates a new  topic
+func TopicCreate(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+	urlVars := mux.Vars(r)
+
+	// Grab context references
+	refStr := context.Get(r, "str").(stores.Store)
+	// Initialize Topics
+	tp := topics.Topics{}
+	tp.LoadFromStore(refStr)
+
+	// Get Result Object
+	res, err := tp.CreateTopic(urlVars["project"], urlVars["topic"], refStr)
+	if err != nil {
+		if err.Error() == "exists" {
+			respondErr(w, 409, "Topic Already Exists")
+			return
+		}
+
+		respondErr(w, 500, err.Error())
+	}
+
+	// Output result to JSON
+	resJSON, err := res.ExportJSON()
+	if err != nil {
+		respondErr(w, 500, "Error Exporting Retrieved Data to JSON")
+		return
+	}
+
+	// Write response
+	output = []byte(resJSON)
+	respondOK(w, output)
+
+}
+
 // TopicListOne (GET) one topic
 func TopicListOne(w http.ResponseWriter, r *http.Request) {
 

--- a/routing.go
+++ b/routing.go
@@ -80,5 +80,6 @@ var defaultRoutes = []APIRoute{
 	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
 	{"topics:list", "GET", "/projects/{project}/topics", TopicListAll},
 	{"topics:show", "GET", "/projects/{project}/topics/{topic}", TopicListOne},
+	{"topics:create", "PUT", "/projects/{project}/topics/{topic}", TopicCreate},
 	{"topics:publish", "POST", "/projects/{project}/topics/{topic}:publish", TopicPublish},
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -107,6 +107,20 @@ func (mk *MockStore) HasProject(project string) bool {
 	return false
 }
 
+// InsertTopic inserts a new topic object to the store
+func (mk *MockStore) InsertTopic(project string, name string) error {
+	topic := QTopic{project, name}
+	mk.TopicList = append(mk.TopicList, topic)
+	return nil
+}
+
+// InsertSub inserts a new sub object to the store
+func (mk *MockStore) InsertSub(project string, name string, topic string, offset int64) error {
+	sub := QSub{project, name, topic, offset}
+	mk.SubList = append(mk.SubList, sub)
+	return nil
+}
+
 // QuerySubs Query Subscription info from store
 func (mk *MockStore) QuerySubs() []QSub {
 	return mk.SubList

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -159,6 +159,37 @@ func (mong *MongoStore) HasProject(project string) bool {
 	return false
 }
 
+// InsertTopic inserts a topic to the store
+func (mong *MongoStore) InsertTopic(project string, name string) error {
+	topic := QTopic{project, name}
+	return mong.InsertResource("topics", topic)
+}
+
+// InsertSub inserts a subscription to the store
+func (mong *MongoStore) InsertSub(project string, name string, topic string, offset int64) error {
+	sub := QSub{project, name, topic, offset}
+	return mong.InsertResource("subscriptions", sub)
+}
+
+// InsertResource inserts a new topic object to the datastore
+func (mong *MongoStore) InsertResource(col string, res interface{}) error {
+	session, err := mgo.Dial(mong.Server)
+	if err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	db := session.DB(mong.Database)
+	c := db.C(col)
+
+	err = c.Insert(res)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return err
+}
+
 // QuerySubs Query Subscription info from store
 func (mong *MongoStore) QuerySubs() []QSub {
 

--- a/stores/store.go
+++ b/stores/store.go
@@ -5,6 +5,8 @@ type Store interface {
 	Initialize(server string, database string)
 	QuerySubs() []QSub
 	QueryTopics() []QTopic
+	InsertTopic(project string, name string) error
+	InsertSub(project string, name string, topic string, offest int64) error
 	HasProject(project string) bool
 	HasResourceRoles(resource string, roles []string) bool
 	GetUserRoles(project string, token string) []string

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -44,6 +44,21 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"publisher"}))
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
+	store.InsertTopic("ARGO", "topicFresh")
+	store.InsertSub("ARGO", "subFresh", "topicFresh", 0)
+
+	eTopList2 := []QTopic{QTopic{"ARGO", "topic1"},
+		QTopic{"ARGO", "topic2"},
+		QTopic{"ARGO", "topic3"},
+		QTopic{"ARGO", "topicFresh"}}
+
+	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0},
+		QSub{"ARGO", "sub2", "topic2", 0},
+		QSub{"ARGO", "sub3", "topic3", 0},
+		QSub{"ARGO", "subFresh", "topicFresh", 0}}
+
+	suite.Equal(eTopList2, store.QueryTopics())
+	suite.Equal(eSubList2, store.QuerySubs())
 }
 
 func TestStoresTestSuite(t *testing.T) {

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -2,6 +2,7 @@ package topics
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/ARGOeu/argo-messaging/stores"
 )
@@ -77,6 +78,17 @@ func (tl *Topics) GetTopicsByProject(project string) Topics {
 	}
 
 	return result
+}
+
+// CreateTopic creates a new topic
+func (tl *Topics) CreateTopic(project string, name string, store stores.Store) (Topic, error) {
+	if tl.HasTopic(project, name) {
+		return Topic{}, errors.New("exists")
+	}
+
+	topicNew := New(project, name)
+	err := store.InsertTopic(project, name)
+	return topicNew, err
 }
 
 // HasTopic returns true if project & topic combination exist

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -42,6 +42,23 @@ func (suite *TopicTestSuite) TestGetTopicByName() {
 	suite.Equal(expTopic, result)
 }
 
+func (suite *TopicTestSuite) TestCreateTopicStore() {
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	myTopics := Topics{}
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	myTopics.LoadFromStore(store)
+
+	tp, err := myTopics.CreateTopic("ARGO", "topic1", store)
+	suite.Equal(Topic{}, tp)
+	suite.Equal("exists", err.Error())
+
+	tp2, err2 := myTopics.CreateTopic("ARGO", "topicNew", store)
+	expTopic := New("ARGO", "topicNew")
+	suite.Equal(expTopic, tp2)
+	suite.Equal(nil, err2)
+}
+
 func (suite *TopicTestSuite) TestHasProjectTopic() {
 	APIcfg := config.NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)


### PR DESCRIPTION
# Goal
Add Create topic request

The implementation of the request must adhere to the following signature
`PUT /v1/projects/PROJECT101/topic/TOPICNEW`
if succesfull must return a topic object response like the following
```json
 {
      "name": "/projects/PROJECT101/topics/TOPICNEW"
 }
```
and `code 200`

if topic exists an appropriate errorMsg must be returned with `code 409 `


# Implementations

- [x] Add store method InsertResource
- [x] Add store method InsertTopic
- [x] Add store method InsertSub
- [x] Add topic method Create
- [x] Add topic create handler
- [x] unit tests
- [x] swagger