### PR TITLE
ARGO 378- Create subscription request

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -75,6 +75,47 @@ paths:
           $ref: "#/responses/404"
         500:
           $ref: "#/responses/500"
+    put:
+      summary: Create a new subscription in a project
+      description: |
+        This request creates a new subscription in a project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+        - name: parameters
+          in: body
+          description: Parameters of the new subscription object
+          required: true
+          schema:
+           $ref: '#/definitions/SubParameters'
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: The new subscription object created
+          schema:
+            $ref: '#/definitions/Subscription'
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+
+
 
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:pull:
     post:
@@ -324,6 +365,12 @@ definitions:
       maxMessages:
         type: string
         description: Max number of messages to be consumed
+  SubParameters:
+    type: object
+    properties:
+      topic:
+        type: string
+        description: name of the topic this subscription will subscribe to
   Subscription:
     type: object
     properties:

--- a/routing.go
+++ b/routing.go
@@ -77,6 +77,7 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 var defaultRoutes = []APIRoute{
 	{"subscriptions:list", "GET", "/projects/{project}/subscriptions", SubListAll},
 	{"subscriptions:show", "GET", "/projects/{project}/subscriptions/{subscription}", SubListOne},
+	{"subscriptions:create", "PUT", "/projects/{project}/subscriptions/{subscription}", SubCreate},
 	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
 	{"topics:list", "GET", "/projects/{project}/topics", TopicListAll},
 	{"topics:show", "GET", "/projects/{project}/topics/{topic}", TopicListOne},

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -88,6 +88,47 @@ func (suite *SubTestSuite) TestLoadFromCfg() {
 
 }
 
+func (suite *SubTestSuite) TestCreateSubStore() {
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	mySubs := Subscriptions{}
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	mySubs.LoadFromStore(store)
+
+	sub, err := mySubs.CreateSub("ARGO", "sub1", "topic1", 0, store)
+	suite.Equal(Subscription{}, sub)
+	suite.Equal("exists", err.Error())
+
+	sub2, err2 := mySubs.CreateSub("ARGO", "subNew", "topicNew", 0, store)
+	expSub := New("ARGO", "subNew", "topicNew")
+	suite.Equal(expSub, sub2)
+	suite.Equal(nil, err2)
+}
+
+func (suite *SubTestSuite) TestExtractFullTopic() {
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	mySubs := Subscriptions{}
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	mySubs.LoadFromStore(store)
+
+	project, topic, err := ExtractFullTopicRef("projects/ARGO/topics/topic1")
+	suite.Equal("ARGO", project)
+	suite.Equal("topic1", topic)
+	suite.Equal(nil, err)
+
+	project2, topic2, err2 := ExtractFullTopicRef("proje/ARGO/topic/topic1")
+	suite.Equal("", project2)
+	suite.Equal("", topic2)
+	suite.Equal("wrong topic name declaration", err2.Error())
+
+	project3, topic3, err3 := ExtractFullTopicRef("projects/ARGO/topics/topic1/lalala")
+	suite.Equal("", project3)
+	suite.Equal("", topic3)
+	suite.Equal("wrong topic name declaration", err3.Error())
+
+}
+
 func (suite *SubTestSuite) TestExportJson() {
 	cfgAPI := config.NewAPICfg()
 	cfgAPI.LoadStrJSON(suite.cfgStr)

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -16,7 +16,7 @@ type Topic struct {
 
 // Topics holds a list of Topic items
 type Topics struct {
-	List []Topic `json:"topics"`
+	List []Topic `json:"topics,omitempty"`
 }
 
 // New creates a new topic based on name


### PR DESCRIPTION
# Goal
Implement Create Subscription request

The implementation of the request must adhere to the following signature
`PUT /v1/projects/PROJECT101/subscriptions/SUBNEW`
Post Body:
```json
{
  "topics":"/projects/PROJECT101/topics/TOPIC101"
}
```
if succesfull must return a topic object response like the following
```json
 {
      "name": "/projects/PROJECT101/subscriptions/SUBNEW",
      "topic":"/projects/PROJECT101/project/TOPIC101"
 }
```
and `code 200`

if topic exists an appropriate errorMsg must be returned with `code 409 `

# Implementations

- [x] Add subscriptions method Create
- [x] Add create sub handler
- [x] unit tests
- [x] swagger