### PR TITLE
ARGO-398 Add Ack Request and Align Error Messages

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -23,5 +23,12 @@ func Authenticate(project string, token string, store stores.Store) []string {
 
 // Authorize based on resource and  role information
 func Authorize(resource string, roles []string, store stores.Store) bool {
+	// check if _admin_ is in roles
+	for _, role := range roles {
+		if role == "_admin_" {
+			return true
+		}
+	}
+
 	return store.HasResourceRoles(resource, roles)
 }

--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -3,7 +3,7 @@ package brokers
 // Broker  Encapsulates the generic broker interface
 type Broker interface {
 	InitConfig()
-	Initialize(peer string)
+	Initialize(peers []string)
 	CloseConnections()
 	Publish(topic string, payload string) (string, int, int64)
 	GetOffset(topic string) int64

--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -31,9 +31,9 @@ func (b *KafkaBroker) CloseConnections() {
 }
 
 // NewKafkaBroker creates a new kafka broker object
-func NewKafkaBroker(peer string) *KafkaBroker {
+func NewKafkaBroker(peers []string) *KafkaBroker {
 	brk := KafkaBroker{}
-	brk.Initialize(peer)
+	brk.Initialize(peers)
 	return &brk
 }
 
@@ -43,32 +43,33 @@ func (b *KafkaBroker) InitConfig() {
 }
 
 // Initialize the broker struct
-func (b *KafkaBroker) Initialize(peer string) {
+func (b *KafkaBroker) Initialize(peers []string) {
 	b.Config = sarama.NewConfig()
 	b.Config.Producer.RequiredAcks = sarama.WaitForAll
 	b.Config.Producer.Retry.Max = 5
-	b.Servers = []string{peer}
+	b.Servers = peers
 
 	var err error
-
-	b.Producer, err = sarama.NewSyncProducer(b.Servers, b.Config)
-	if err != nil {
-		// Should not reach here
-		panic(err)
-	}
 
 	b.Client, err = sarama.NewClient(b.Servers, nil)
 	if err != nil {
 		// Should not reach here
-		panic(err)
+		log.Fatalf("%s\t%s\t%s", "FATAL", "BROKER", err.Error())
+	}
+
+	b.Producer, err = sarama.NewSyncProducer(b.Servers, b.Config)
+	if err != nil {
+		// Should not reach here
+		log.Fatalf("%s\t%s\t%s", "FATAL", "BROKER", err.Error())
+
 	}
 
 	b.Consumer, err = sarama.NewConsumer(b.Servers, nil)
 	if err != nil {
-		panic(err)
+		log.Fatalf("%s\t%s\t%s", "FATAL", "BROKER", err.Error())
 	}
 
-	log.Printf("%s\t%s\t%s:%s", "INFO", "BROKER", "Kafka Backend Initialized! Kafka server", peer)
+	log.Printf("%s\t%s\t%s:%s", "INFO", "BROKER", "Kafka Backend Initialized! Kafka node list", peers)
 
 }
 

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -78,7 +78,7 @@ func (b *MockBroker) InitConfig() {
 }
 
 // Initialize the broker struct
-func (b *MockBroker) Initialize(peer string) {
+func (b *MockBroker) Initialize(peers []string) {
 	b.MsgList = make([]string, 0)
 }
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,9 @@
 {
-  "broker_host":"localhost:9092",
+  "port":8080,
+  "broker_hosts":["localhost:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
-  "use_authentication":true
+  "use_authentication":true,
+  "use_ack":true
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,11 +11,13 @@ import (
 // APICfg holds kafka configuration
 type APICfg struct {
 	// values
-	BrokerHost string
-	StoreHost  string
-	StoreDB    string
-	Authen     bool
-	Author     bool
+	Port        int
+	BrokerHosts []string
+	StoreHost   string
+	StoreDB     string
+	Authen      bool
+	Author      bool
+	Ack         bool
 }
 
 // NewAPICfg creates a new kafka configuration object
@@ -47,8 +49,10 @@ func (cfg *APICfg) Load() {
 	}
 
 	// Load Kafka configuration
-	cfg.BrokerHost = viper.GetString("broker_host")
-	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - broker_host", cfg.BrokerHost)
+	cfg.Port = viper.GetInt("port")
+	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
+	cfg.BrokerHosts = viper.GetStringSlice("broker_hosts")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - broker_host", cfg.BrokerHosts)
 	cfg.StoreHost = viper.GetString("store_host")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
@@ -57,6 +61,8 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authentication", cfg.Authen)
 	cfg.Author = viper.GetBool("use_authorization")
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
+	cfg.Ack = viper.GetBool("use_ack")
+	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
 }
 
 // LoadStrJSON Loads configuration from a JSON string
@@ -64,8 +70,10 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	viper.SetConfigType("json")
 	viper.ReadConfig(bytes.NewBuffer([]byte(input)))
 	// Load Kafka configuration
-	cfg.BrokerHost = viper.GetString("broker_host")
-	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - broker_host", cfg.BrokerHost)
+	cfg.Port = viper.GetInt("port")
+	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
+	cfg.BrokerHosts = viper.GetStringSlice("broker_hosts")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - broker_host", cfg.BrokerHosts)
 	cfg.StoreHost = viper.GetString("store_host")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
@@ -74,5 +82,7 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authentication", cfg.Authen)
 	cfg.Author = viper.GetBool("use_authorization")
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
+	cfg.Ack = viper.GetBool("use_ack")
+	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
 
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,9 @@
 {
-  "broker_host":"localhost:9092",
+  "port":8080,
+  "broker_hosts":["localhost:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
-  "use_authentication":true
+  "use_authentication":true,
+  "use_ack":true
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,47 +14,53 @@ type ConfigTestSuite struct {
 }
 
 func (suite *ConfigTestSuite) SetupTest() {
-	suite.cfgStr = `
-	{
-	  "broker_host":"localhost:9092",
+	suite.cfgStr = `{
+	  "port":8080,
+		"broker_hosts":["localhost:9092"],
 		"store_host":"localhost",
 		"store_db":"argo_msg",
 		"use_authorization":true,
-		"use_authentication":true
-	}
-	`
+		"use_authentication":true,
+		"use_ack":true
+	}`
 
 	log.SetOutput(ioutil.Discard)
 }
 
 func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	APIcfg := NewAPICfg()
-	suite.Equal("", APIcfg.BrokerHost)
+	suite.Equal([]string(nil), APIcfg.BrokerHosts)
 	APIcfg.Load()
-	suite.Equal("localhost:9092", APIcfg.BrokerHost)
+	suite.Equal([]string{"localhost:9092"}, APIcfg.BrokerHosts)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
 	suite.Equal(true, APIcfg.Authen)
 	suite.Equal(true, APIcfg.Author)
+	suite.Equal(8080, APIcfg.Port)
+	suite.Equal(true, APIcfg.Ack)
 
 	// test "LOAD" param
 	APIcfg2 := NewAPICfg("LOAD")
-	suite.Equal("localhost:9092", APIcfg2.BrokerHost)
+	suite.Equal([]string{"localhost:9092"}, APIcfg2.BrokerHosts)
 	suite.Equal("localhost", APIcfg2.StoreHost)
 	suite.Equal("argo_msg", APIcfg2.StoreDB)
 	suite.Equal(true, APIcfg2.Authen)
 	suite.Equal(true, APIcfg2.Author)
+	suite.Equal(8080, APIcfg.Port)
+	suite.Equal(true, APIcfg.Ack)
 
 }
 
 func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	APIcfg := NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)
-	suite.Equal("localhost:9092", APIcfg.BrokerHost)
+	suite.Equal([]string{"localhost:9092"}, APIcfg.BrokerHosts)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
 	suite.Equal(true, APIcfg.Authen)
 	suite.Equal(true, APIcfg.Author)
+	suite.Equal(8080, APIcfg.Port)
+	suite.Equal(true, APIcfg.Ack)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -43,6 +43,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Subscription'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -76,6 +78,8 @@ paths:
           description: An array of Subscriptions
           schema:
             $ref: '#/definitions/Subscription'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -113,6 +117,8 @@ paths:
           description: The new subscription object created
           schema:
             $ref: '#/definitions/Subscription'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -123,6 +129,7 @@ paths:
           $ref: "#/responses/409"
         500:
           $ref: "#/responses/500"
+
     delete:
       summary: Delete an existing subscription in a project
       description: |
@@ -148,6 +155,8 @@ paths:
             type: string
             default: ""
             description: empty string
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -190,12 +199,56 @@ paths:
           description: An array of received messages
           schema:
             $ref: '#/definitions/ReceivedMessages'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
           $ref: "#/responses/403"
         404:
           $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:acknowledge:
+    post:
+      summary: Acknowledge the succesfull delivery of pulled messages
+      description: |
+        Use ackId to inform the api that the messages have been correctly received
+      parameters:
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the subscription
+          required: true
+          type: string
+        - name: Ack Options
+          in: body
+          description: Parameters to be used during acknowledgement
+          required: true
+          schema:
+           $ref: '#/definitions/AckIDs'
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: An array of received messages
+          schema:
+            $ref: '#/definitions/ReceivedMessages'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        408:
+          $ref: "#/responses/408"
         500:
           $ref: "#/responses/500"
 
@@ -220,6 +273,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Topic'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -254,6 +309,8 @@ paths:
           description: A topic object
           schema:
             $ref: '#/definitions/Topic'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -285,6 +342,8 @@ paths:
           description: The new topic object created
           schema:
             $ref: '#/definitions/Topic'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -320,6 +379,8 @@ paths:
             type: string
             default: ""
             description: empty string
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -330,6 +391,79 @@ paths:
           $ref: "#/responses/409"
         500:
           $ref: "#/responses/500"
+    put:
+      summary: Create a new topic in a project
+      description: |
+        This request creates a new topic in a project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: TOPIC
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+      tags:
+        - Topics
+      responses:
+        200:
+          description: The new topic object created
+          schema:
+            $ref: '#/definitions/Topic'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+    delete:
+      summary: Delete an existing topic in a project
+      description: |
+        This request deletes an existing topic in a project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: TOPIC
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+      tags:
+        - Topics
+      responses:
+        200:
+          description: Empty response if the topic is successfully deleted
+          schema:
+            type: string
+            default: ""
+            description: empty string
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+
 
 
   /projects/{PROJECT}/topics/{TOPIC}:publish:
@@ -362,6 +496,8 @@ paths:
           description: An array of messageIDs
           schema:
             $ref: '#/definitions/MessageIDs'
+        400:
+          $ref: "#/responses/400"
         401:
           $ref: "#/responses/401"
         403:
@@ -381,6 +517,10 @@ parameters:
     default: SecretKey123
 
 responses:
+  400:
+    description: Invalid argument used
+    schema:
+      $ref: '#/definitions/ErrorMsg'
   401:
     description: Unauthorized user based on key
     schema:
@@ -391,6 +531,10 @@ responses:
       $ref: '#/definitions/ErrorMsg'
   404:
     description: Item not found
+    schema:
+      $ref: '#/definitions/ErrorMsg'
+  408:
+    description: Server timed out waiting for the request
     schema:
       $ref: '#/definitions/ErrorMsg'
   409:
@@ -468,6 +612,9 @@ definitions:
   ReceivedMessage:
     type: object
     properties:
+      ackId:
+        type: string
+        description: AckId to be used in acknowledge request
       message:
         type: object
         properties:
@@ -490,7 +637,15 @@ definitions:
   MessageIDs:
      type: object
      properties:
-       messageIDs:
+       messageIds:
+         type: array
+         items:
+           type: string
+
+  AckIDs:
+     type: object
+     properties:
+       ackIds:
          type: array
          items:
            type: string
@@ -507,21 +662,6 @@ definitions:
           message:
             type: string
             description: general message of the error
-          errors:
-            type: array
-            description: list of errors occured
-            items:
-              type: object
-              properties:
-                message:
-                  type: string
-                  description: error message
-                domain:
-                  type: string
-                  description: where the error happened
-                reason:
-                  type: string
-                  description: reason given for the error
           status:
             type: string
             description: status of the error

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/ARGOeu/argo-messaging/brokers"
 	"github.com/ARGOeu/argo-messaging/config"
@@ -14,7 +15,7 @@ func main() {
 	cfg := config.NewAPICfg("LOAD")
 
 	// create and initialize broker based on configuration
-	broker := brokers.NewKafkaBroker(cfg.BrokerHost)
+	broker := brokers.NewKafkaBroker(cfg.BrokerHosts)
 	defer broker.CloseConnections()
 
 	// create the store
@@ -24,5 +25,5 @@ func main() {
 	API := NewRouting(cfg, broker, store, defaultRoutes)
 
 	// Start http server listening using API.Router
-	log.Fatal(http.ListenAndServe(":8080", API.Router))
+	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(cfg.Port), API.Router))
 }

--- a/messages/message.go
+++ b/messages/message.go
@@ -8,7 +8,8 @@ import (
 
 // RecMsg holds info for a received message
 type RecMsg struct {
-	Msg Message `json:"message"`
+	AckID string  `json:"ackId,omitempty"`
+	Msg   Message `json:"message"`
 }
 
 // RecList holds the array of the receivedMessages - subscription related
@@ -24,14 +25,14 @@ type MsgList struct {
 // Message struct used to hold message information
 type Message struct {
 	ID      string      `json:"messageId,omitempty"`
-	Attr    []Attribute `json:"attributes"`            // used to hold attribute key/value store
+	Attr    []Attribute `json:"attributes,omitempty"`  // used to hold attribute key/value store
 	Data    string      `json:"data"`                  // base64 encoded data payload
 	PubTime string      `json:"publishTime,omitempty"` // publish timedate of message
 }
 
 // MsgIDs utility struct
 type MsgIDs struct {
-	IDs []string `json:"messageIDs"`
+	IDs []string `json:"messageIds"`
 }
 
 // Attribute representation as key/value

--- a/routing.go
+++ b/routing.go
@@ -51,6 +51,8 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 
 			handler = WrapAuthenticate(handler)
 		}
+
+		handler = WrapValidate(handler)
 		handler = WrapConfig(handler, cfg, brk, str)
 
 		ar.Router.
@@ -78,8 +80,9 @@ var defaultRoutes = []APIRoute{
 	{"subscriptions:list", "GET", "/projects/{project}/subscriptions", SubListAll},
 	{"subscriptions:show", "GET", "/projects/{project}/subscriptions/{subscription}", SubListOne},
 	{"subscriptions:create", "PUT", "/projects/{project}/subscriptions/{subscription}", SubCreate},
-	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
 	{"subscriptions:delete", "DELETE", "/projects/{project}/subscriptions/{subscription}", SubDelete},
+	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
+	{"subscriptions:acknowledge", "POST", "/projects/{project}/subscriptions/{subscription}:acknowledge", SubAck},
 	{"topics:list", "GET", "/projects/{project}/topics", TopicListAll},
 	{"topics:show", "GET", "/projects/{project}/topics/{topic}", TopicListOne},
 	{"topics:create", "PUT", "/projects/{project}/topics/{topic}", TopicCreate},

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -2,10 +2,13 @@ package stores
 
 // QSub are the results of the Qsub query
 type QSub struct {
-	Project string `bson:"project"`
-	Name    string `bson:"name"`
-	Topic   string `bson:"topic"`
-	Offset  int64  `bson:"offset"`
+	Project    string `bson:"project"`
+	Name       string `bson:"name"`
+	Topic      string `bson:"topic"`
+	Offset     int64  `bson:"offset"`
+	NextOffset int64  `bson:"next_offset"`
+	PendingAck string `bson:"pending_ack"`
+	Ack        int    `bson:"ack"`
 }
 
 // QUser are the results of the QUser query

--- a/stores/store.go
+++ b/stores/store.go
@@ -8,10 +8,12 @@ type Store interface {
 	RemoveTopic(project string, name string) error
 	RemoveSub(project string, name string) error
 	InsertTopic(project string, name string) error
-	InsertSub(project string, name string, topic string, offest int64) error
+	InsertSub(project string, name string, topic string, offest int64, ack int) error
 	HasProject(project string) bool
 	HasResourceRoles(resource string, roles []string) bool
 	GetUserRoles(project string, token string) []string
 	UpdateSubOffset(name string, offset int64)
+	UpdateSubPull(name string, offset int64, ts string)
+	UpdateSubOffsetAck(name string, offset int64, ts string) error
 	Close()
 }

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -20,9 +20,9 @@ func (suite *StoreTestSuite) TestMockStore() {
 		QTopic{"ARGO", "topic2"},
 		QTopic{"ARGO", "topic3"}}
 
-	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0},
-		QSub{"ARGO", "sub2", "topic2", 0},
-		QSub{"ARGO", "sub3", "topic3", 0}}
+	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", 10},
+		QSub{"ARGO", "sub2", "topic2", 0, 0, "", 10},
+		QSub{"ARGO", "sub3", "topic3", 0, 0, "", 10}}
 
 	suite.Equal(eTopList, store.QueryTopics())
 	suite.Equal(eSubList, store.QuerySubs())
@@ -46,17 +46,17 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
 	store.InsertTopic("ARGO", "topicFresh")
-	store.InsertSub("ARGO", "subFresh", "topicFresh", 0)
+	store.InsertSub("ARGO", "subFresh", "topicFresh", 0, 10)
 
 	eTopList2 := []QTopic{QTopic{"ARGO", "topic1"},
 		QTopic{"ARGO", "topic2"},
 		QTopic{"ARGO", "topic3"},
 		QTopic{"ARGO", "topicFresh"}}
 
-	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0},
-		QSub{"ARGO", "sub2", "topic2", 0},
-		QSub{"ARGO", "sub3", "topic3", 0},
-		QSub{"ARGO", "subFresh", "topicFresh", 0}}
+	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", 10},
+		QSub{"ARGO", "sub2", "topic2", 0, 0, "", 10},
+		QSub{"ARGO", "sub3", "topic3", 0, 0, "", 10},
+		QSub{"ARGO", "subFresh", "topicFresh", 0, 0, "", 10}}
 
 	suite.Equal(eTopList2, store.QueryTopics())
 	suite.Equal(eSubList2, store.QuerySubs())

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,8 @@
+package main
+
+import "regexp"
+
+func validName(name string) bool {
+	r, _ := regexp.Compile("^\\w+?$")
+	return r.Match([]byte(name))
+}


### PR DESCRIPTION
- [x] Add Optional Ack request. With Ack request subscriber can validate that he indeed received the messages and API cant progress to the next offset. If Ack is turned off in confuguration progression is automatic during consumption
- [x]  Revisit the set of available Error Messages and try to make them consistent in each case
- [x] Minor fixes, refactorings