### PR TITLE
ARGO-414 Enforce HTTPS

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
+  "bind_ip":"",
   "port":8080,
-  "broker_hosts":["localhost:9092"],
+  "broker_hosts":["as03.hadoop:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
   "use_authentication":true,
-  "use_ack":true
+  "use_ack":true,
+  "certificate":"/etc/pki/tls/certs/localhost.crt",
+  "certificate_key":"/etc/pki/tls/private/localhost.key"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 // APICfg holds kafka configuration
 type APICfg struct {
 	// values
+	BindIP      string
 	Port        int
 	BrokerHosts []string
 	StoreHost   string
@@ -18,6 +19,8 @@ type APICfg struct {
 	Authen      bool
 	Author      bool
 	Ack         bool
+	Cert        string
+	CertKey     string
 }
 
 // NewAPICfg creates a new kafka configuration object
@@ -49,6 +52,8 @@ func (cfg *APICfg) Load() {
 	}
 
 	// Load Kafka configuration
+	cfg.BindIP = viper.GetString("bind_ip")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - bind_ip", cfg.BindIP)
 	cfg.Port = viper.GetInt("port")
 	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
 	cfg.BrokerHosts = viper.GetStringSlice("broker_hosts")
@@ -63,6 +68,11 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
 	cfg.Ack = viper.GetBool("use_ack")
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
+	cfg.Cert = viper.GetString("certificate")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
+	cfg.CertKey = viper.GetString("certificate_key")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
+
 }
 
 // LoadStrJSON Loads configuration from a JSON string
@@ -70,6 +80,8 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	viper.SetConfigType("json")
 	viper.ReadConfig(bytes.NewBuffer([]byte(input)))
 	// Load Kafka configuration
+	cfg.BindIP = viper.GetString("bind_ip")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - bind_ip", cfg.BindIP)
 	cfg.Port = viper.GetInt("port")
 	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
 	cfg.BrokerHosts = viper.GetStringSlice("broker_hosts")
@@ -84,5 +96,9 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
 	cfg.Ack = viper.GetBool("use_ack")
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
+	cfg.Cert = viper.GetString("certificate")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
+	cfg.CertKey = viper.GetString("certificate_key")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
 
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,9 +1,12 @@
 {
+  "bind_ip":"",
   "port":8080,
   "broker_hosts":["localhost:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
   "use_authentication":true,
-  "use_ack":true
+  "use_ack":true,
+  "certificate":"/etc/pki/tls/certs/localhost.crt",
+  "certificate_key":"/etc/pki/tls/private/localhost.key"
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,13 +15,16 @@ type ConfigTestSuite struct {
 
 func (suite *ConfigTestSuite) SetupTest() {
 	suite.cfgStr = `{
+	  "bind_ip":"",
 	  "port":8080,
 		"broker_hosts":["localhost:9092"],
 		"store_host":"localhost",
 		"store_db":"argo_msg",
 		"use_authorization":true,
 		"use_authentication":true,
-		"use_ack":true
+		"use_ack":true,
+		"certificate":"/etc/pki/tls/certs/localhost.crt",
+		"certificate_key":"/etc/pki/tls/private/localhost.key"
 	}`
 
 	log.SetOutput(ioutil.Discard)
@@ -48,7 +51,9 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	suite.Equal(true, APIcfg2.Author)
 	suite.Equal(8080, APIcfg.Port)
 	suite.Equal(true, APIcfg.Ack)
-
+	suite.Equal("", APIcfg.BindIP)
+	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
+	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
 }
 
 func (suite *ConfigTestSuite) TestLoadStringJSON() {
@@ -61,6 +66,9 @@ func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	suite.Equal(true, APIcfg.Author)
 	suite.Equal(8080, APIcfg.Port)
 	suite.Equal(true, APIcfg.Ack)
+	suite.Equal("", APIcfg.BindIP)
+	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
+	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -15,13 +15,16 @@ The ARGO Messaging Service main configuration file is config.json. An example co
 
 ```json
 {
+  "bind_ip":"",
   "port":8080,
   "broker_host":"localhost:9092",
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
   "use_authentication":true,
-  "use_ack":true
+  "use_ack":true,
+  "certificate":"/etc/pki/tls/certs/localhost.crt",
+  "certificate_key":"/etc/pki/tls/private/localhost.key"
 }
 ```
 
@@ -29,6 +32,7 @@ The ARGO Messaging Service main configuration file is config.json. An example co
 
 Parameter | Description
 --------- | -----------
+bind_ip | the ip address to listen to.
 port | The port where the API will listen to
 broker_host | Address:port of the broker instance
 store_host | Address:port of the datastore server
@@ -36,5 +40,7 @@ store_db | Database name used on the datastore server
 use_authorization | If true, API will boot with support for authorization
 use_authentication | If true, API will boot with support for authentication
 use_ack | If true, API will boot with acknowledgement support when consuming messages
+certificate | path to the node's TLS certificate file
+certificate_key | path to the certificate's private key
 
 **Location of config.json**: API will look first for config.json locally in the folder where the executable runs and then in the ` /etc/argo-messaging/`  location.


### PR DESCRIPTION
## Goal
Enforce HTTPS in ARGO Messaging API

## Implementation
- [x] Add bind_ip, certificate, and certificate_key config parameters
- [x] Init and configure server object with TLS config properties
- [x] Update unit tests
- [x] Update docs (on config parameters)