### PR TITLE
ARGO-437 Make Auth and Ack mechanisms mandatory

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,12 +1,9 @@
 {
   "bind_ip":"",
   "port":8080,
-  "broker_hosts":["as03.hadoop:9092"],
+  "broker_hosts":["localhost:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
-  "use_authorization":true,
-  "use_authentication":true,
-  "use_ack":true,
   "certificate":"/etc/pki/tls/certs/localhost.crt",
   "certificate_key":"/etc/pki/tls/private/localhost.key"
 }

--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
+  "bind_ip":"",
   "port":8080,
-  "broker_hosts":["localhost:9092"],
+  "broker_hosts":["as03.hadoop:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
   "use_authentication":true,
-  "use_ack":true
+  "use_ack":true,
+  "certificate":"/etc/pki/tls/certs/localhost.crt",
+  "certificate_key":"/etc/pki/tls/private/localhost.key"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 // APICfg holds kafka configuration
 type APICfg struct {
 	// values
+	BindIP      string
 	Port        int
 	BrokerHosts []string
 	StoreHost   string
@@ -18,6 +19,8 @@ type APICfg struct {
 	Authen      bool
 	Author      bool
 	Ack         bool
+	Cert        string
+	CertKey     string
 }
 
 // NewAPICfg creates a new kafka configuration object
@@ -49,6 +52,8 @@ func (cfg *APICfg) Load() {
 	}
 
 	// Load Kafka configuration
+	cfg.BindIP = viper.GetString("bind_ip")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - bind_ip", cfg.BindIP)
 	cfg.Port = viper.GetInt("port")
 	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
 	cfg.BrokerHosts = viper.GetStringSlice("broker_hosts")
@@ -63,6 +68,11 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
 	cfg.Ack = viper.GetBool("use_ack")
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
+	cfg.Cert = viper.GetString("certificate")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
+	cfg.CertKey = viper.GetString("certificate_key")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
+
 }
 
 // LoadStrJSON Loads configuration from a JSON string
@@ -70,6 +80,8 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	viper.SetConfigType("json")
 	viper.ReadConfig(bytes.NewBuffer([]byte(input)))
 	// Load Kafka configuration
+	cfg.BindIP = viper.GetString("bind_ip")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - bind_ip", cfg.BindIP)
 	cfg.Port = viper.GetInt("port")
 	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
 	cfg.BrokerHosts = viper.GetStringSlice("broker_hosts")
@@ -84,5 +96,9 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
 	cfg.Ack = viper.GetBool("use_ack")
 	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
+	cfg.Cert = viper.GetString("certificate")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
+	cfg.CertKey = viper.GetString("certificate_key")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
 
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,9 +16,6 @@ type APICfg struct {
 	BrokerHosts []string
 	StoreHost   string
 	StoreDB     string
-	Authen      bool
-	Author      bool
-	Ack         bool
 	Cert        string
 	CertKey     string
 }
@@ -62,12 +59,6 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_db", cfg.StoreDB)
-	cfg.Authen = viper.GetBool("use_authentication")
-	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authentication", cfg.Authen)
-	cfg.Author = viper.GetBool("use_authorization")
-	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
-	cfg.Ack = viper.GetBool("use_ack")
-	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
 	cfg.Cert = viper.GetString("certificate")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
 	cfg.CertKey = viper.GetString("certificate_key")
@@ -90,12 +81,6 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_db", cfg.StoreDB)
-	cfg.Authen = viper.GetBool("use_authentication")
-	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authentication", cfg.Authen)
-	cfg.Author = viper.GetBool("use_authorization")
-	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_authorization", cfg.Author)
-	cfg.Ack = viper.GetBool("use_ack")
-	log.Printf("%s\t%s\t%s:%t", "INFO", "CONFIG", "Parameter Loaded - use_ack", cfg.Ack)
 	cfg.Cert = viper.GetString("certificate")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
 	cfg.CertKey = viper.GetString("certificate_key")

--- a/config/config.json
+++ b/config/config.json
@@ -4,9 +4,6 @@
   "broker_hosts":["localhost:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
-  "use_authorization":true,
-  "use_authentication":true,
-  "use_ack":true,
   "certificate":"/etc/pki/tls/certs/localhost.crt",
   "certificate_key":"/etc/pki/tls/private/localhost.key"
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,9 +1,12 @@
 {
+  "bind_ip":"",
   "port":8080,
   "broker_hosts":["localhost:9092"],
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
   "use_authentication":true,
-  "use_ack":true
+  "use_ack":true,
+  "certificate":"/etc/pki/tls/certs/localhost.crt",
+  "certificate_key":"/etc/pki/tls/private/localhost.key"
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,13 +15,16 @@ type ConfigTestSuite struct {
 
 func (suite *ConfigTestSuite) SetupTest() {
 	suite.cfgStr = `{
+	  "bind_ip":"",
 	  "port":8080,
 		"broker_hosts":["localhost:9092"],
 		"store_host":"localhost",
 		"store_db":"argo_msg",
 		"use_authorization":true,
 		"use_authentication":true,
-		"use_ack":true
+		"use_ack":true,
+		"certificate":"/etc/pki/tls/certs/localhost.crt",
+		"certificate_key":"/etc/pki/tls/private/localhost.key"
 	}`
 
 	log.SetOutput(ioutil.Discard)
@@ -48,7 +51,9 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	suite.Equal(true, APIcfg2.Author)
 	suite.Equal(8080, APIcfg.Port)
 	suite.Equal(true, APIcfg.Ack)
-
+	suite.Equal("", APIcfg.BindIP)
+	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
+	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
 }
 
 func (suite *ConfigTestSuite) TestLoadStringJSON() {
@@ -61,6 +66,9 @@ func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	suite.Equal(true, APIcfg.Author)
 	suite.Equal(8080, APIcfg.Port)
 	suite.Equal(true, APIcfg.Ack)
+	suite.Equal("", APIcfg.BindIP)
+	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
+	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,9 +20,6 @@ func (suite *ConfigTestSuite) SetupTest() {
 		"broker_hosts":["localhost:9092"],
 		"store_host":"localhost",
 		"store_db":"argo_msg",
-		"use_authorization":true,
-		"use_authentication":true,
-		"use_ack":true,
 		"certificate":"/etc/pki/tls/certs/localhost.crt",
 		"certificate_key":"/etc/pki/tls/private/localhost.key"
 	}`
@@ -37,20 +34,14 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	suite.Equal([]string{"localhost:9092"}, APIcfg.BrokerHosts)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
-	suite.Equal(true, APIcfg.Authen)
-	suite.Equal(true, APIcfg.Author)
 	suite.Equal(8080, APIcfg.Port)
-	suite.Equal(true, APIcfg.Ack)
 
 	// test "LOAD" param
 	APIcfg2 := NewAPICfg("LOAD")
 	suite.Equal([]string{"localhost:9092"}, APIcfg2.BrokerHosts)
 	suite.Equal("localhost", APIcfg2.StoreHost)
 	suite.Equal("argo_msg", APIcfg2.StoreDB)
-	suite.Equal(true, APIcfg2.Authen)
-	suite.Equal(true, APIcfg2.Author)
 	suite.Equal(8080, APIcfg.Port)
-	suite.Equal(true, APIcfg.Ack)
 	suite.Equal("", APIcfg.BindIP)
 	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
 	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
@@ -62,10 +53,7 @@ func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	suite.Equal([]string{"localhost:9092"}, APIcfg.BrokerHosts)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
-	suite.Equal(true, APIcfg.Authen)
-	suite.Equal(true, APIcfg.Author)
 	suite.Equal(8080, APIcfg.Port)
-	suite.Equal(true, APIcfg.Ack)
 	suite.Equal("", APIcfg.BindIP)
 	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
 	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -20,9 +20,6 @@ The ARGO Messaging Service main configuration file is config.json. An example co
   "broker_host":"localhost:9092",
   "store_host":"localhost",
   "store_db":"argo_msg",
-  "use_authorization":true,
-  "use_authentication":true,
-  "use_ack":true,
   "certificate":"/etc/pki/tls/certs/localhost.crt",
   "certificate_key":"/etc/pki/tls/private/localhost.key"
 }
@@ -37,9 +34,6 @@ port | The port where the API will listen to
 broker_host | Address:port of the broker instance
 store_host | Address:port of the datastore server
 store_db | Database name used on the datastore server
-use_authorization | If true, API will boot with support for authorization
-use_authentication | If true, API will boot with support for authentication
-use_ack | If true, API will boot with acknowledgement support when consuming messages
 certificate | path to the node's TLS certificate file
 certificate_key | path to the certificate's private key
 

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -15,13 +15,16 @@ The ARGO Messaging Service main configuration file is config.json. An example co
 
 ```json
 {
+  "bind_ip":"",
   "port":8080,
   "broker_host":"localhost:9092",
   "store_host":"localhost",
   "store_db":"argo_msg",
   "use_authorization":true,
   "use_authentication":true,
-  "use_ack":true
+  "use_ack":true,
+  "certificate":"/etc/pki/tls/certs/localhost.crt",
+  "certificate_key":"/etc/pki/tls/private/localhost.key"
 }
 ```
 
@@ -29,6 +32,7 @@ The ARGO Messaging Service main configuration file is config.json. An example co
 
 Parameter | Description
 --------- | -----------
+bind_ip | the ip address to listen to.
 port | The port where the API will listen to
 broker_host | Address:port of the broker instance
 store_host | Address:port of the datastore server
@@ -36,5 +40,7 @@ store_db | Database name used on the datastore server
 use_authorization | If true, API will boot with support for authorization
 use_authentication | If true, API will boot with support for authentication
 use_ack | If true, API will boot with acknowledgement support when consuming messages
+certificate | path to the node's TLS certificate file
+certificate_key | path to the certificate's private key
 
 **Location of config.json**: API will look first for config.json locally in the folder where the executable runs and then in the ` /etc/argo-messaging/`  location.

--- a/handlers.go
+++ b/handlers.go
@@ -56,7 +56,6 @@ func WrapConfig(hfn http.HandlerFunc, cfg *config.APICfg, brk brokers.Broker, st
 
 		nStr := str.Clone()
 		defer nStr.Close()
-		context.Set(r, "cfg", cfg)
 		context.Set(r, "brk", brk)
 		context.Set(r, "str", nStr)
 
@@ -692,7 +691,6 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 	// Grab context references
 	refBrk := context.Get(r, "brk").(brokers.Broker)
 	refStr := context.Get(r, "str").(stores.Store)
-	refCfg := context.Get(r, "cfg").(*config.APICfg)
 
 	// Create Subscriptions Object
 	sub := subscriptions.Subscriptions{}
@@ -756,16 +754,11 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Advance Offset forward as many messages received in RecList array
-	if refCfg.Ack == false {
-		refStr.UpdateSubOffset(targSub.Name, int64(len(recList.RecMsgs))+targSub.Offset)
-	} else {
-		// Stamp time to UTC Z to seconds
-		zSec := "2006-01-02T15:04:05Z"
-		t := time.Now()
-		ts := t.Format(zSec)
-		refStr.UpdateSubPull(targSub.Name, int64(len(recList.RecMsgs))+targSub.Offset, ts)
-	}
+	// Stamp time to UTC Z to seconds
+	zSec := "2006-01-02T15:04:05Z"
+	t := time.Now()
+	ts := t.Format(zSec)
+	refStr.UpdateSubPull(targSub.Name, int64(len(recList.RecMsgs))+targSub.Offset, ts)
 
 	output = []byte(resJSON)
 	respondOK(w, output)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -168,7 +168,6 @@ func (suite *HandlerTestSuite) TestSubListOne() {
 
 	cfgKafka := config.NewAPICfg()
 	cfgKafka.LoadStrJSON(suite.cfgStr)
-	cfgKafka.Ack = true
 
 	brk := brokers.MockBroker{}
 	str := stores.NewMockStore("whatever", "argo_mgs")

--- a/routing.go
+++ b/routing.go
@@ -43,15 +43,8 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 
 		handler = WrapLog(handler, route.Name)
 
-		if cfg.Author && cfg.Authen {
-
-			handler = WrapAuthorize(handler, route.Name)
-		}
-
-		if cfg.Authen {
-
-			handler = WrapAuthenticate(handler)
-		}
+		handler = WrapAuthorize(handler, route.Name)
+		handler = WrapAuthenticate(handler)
 
 		handler = WrapValidate(handler)
 		handler = WrapConfig(handler, cfg, brk, str)
@@ -61,14 +54,6 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, routes
 			Methods(route.Method).
 			Path(route.Path).
 			Handler(context.ClearHandler(handler))
-	}
-
-	if cfg.Authen {
-		log.Printf("INFO\tAPI\tAPI Authentication mechanism enabled")
-	}
-
-	if cfg.Author {
-		log.Printf("INFO\tAPI\tAPI Authorization mechanism enabled")
 	}
 
 	log.Printf("INFO\tAPI\tAPI Router initialized! Ready to start listening...")


### PR DESCRIPTION
## Goal
Messaging API configuration maintained the following boolean flags:
`use_authentication`, `use_authorization` and `use_ack` to demonstrate flexibility on being able to enable/disable various mechanisms on the request handling chain. Since those features must be always enabled it is prefered to remove the configuration options and set the mechanisms always on

## Implementation
- [x] Remove use_authentication and use_authorization flag checking during router construction. Authentication and Authorization wrappers are always enabled
- [x] Remove use_ack check during subscription:pull handling. Every pull operation now requires acknowledgement. 
- [x] Remove parameters from config.json file and from config structure. 
- [x] Update documentation and unit tests accordingly