### PR TITLE
ARGO-436 Implement Push workers

### DIFF
--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -104,6 +104,7 @@ func (b *KafkaBroker) Consume(topic string, offset int64) []string {
 
 	// Fetch offset
 	loff, err := b.Client.GetOffset(topic, 0, sarama.OffsetNewest)
+	log.Println("tryiing topic:", topic)
 	if err != nil {
 		panic(err)
 	}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -211,6 +211,14 @@ func (suite *HandlerTestSuite) TestSubListAll() {
             "pushEndpoint": ""
          },
          "ackDeadlineSeconds": 10
+      },
+      {
+         "name": "/projects/ARGO/subscriptions/sub4",
+         "topic": "/projects/ARGO/topics/topic4",
+         "pushConfig": {
+            "pushEndpoint": "endpoint.foo"
+         },
+         "ackDeadlineSeconds": 10
       }
    ]
 }`

--- a/main.go
+++ b/main.go
@@ -5,11 +5,21 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/ARGOeu/argo-messaging/brokers"
 	"github.com/ARGOeu/argo-messaging/config"
+	"github.com/ARGOeu/argo-messaging/push"
 	"github.com/ARGOeu/argo-messaging/stores"
 )
+
+func testPushers(mgr *push.Manager) {
+	time.Sleep(5 * time.Second)
+	mgr.Stop("ARGO/sub1")
+	time.Sleep(5 * time.Second)
+	mgr.Shoutout()
+	panic("examine traces")
+}
 
 func main() {
 	// create and load configuration object

--- a/push/push.go
+++ b/push/push.go
@@ -1,0 +1,202 @@
+package push
+
+import (
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/ARGOeu/argo-messaging/brokers"
+	"github.com/ARGOeu/argo-messaging/stores"
+	"github.com/ARGOeu/argo-messaging/subscriptions"
+)
+
+// Pusher holds information for the pusher routine and subscription
+type Pusher struct {
+	id       int
+	sub      subscriptions.Subscription
+	endpoint string
+	stop     chan bool
+	rate     time.Duration // in milliseconds
+	running  bool
+	sndr     Sender
+}
+
+// Manager manages all pusher routines
+type Manager struct {
+	list   map[string]*Pusher // map using as key the string = "{project}/{sub}"
+	broker brokers.Broker     // Reference to backend broker
+	store  stores.Store       // Reference to backend store
+}
+
+// Push method of pusher object to consume and push messages
+func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
+	log.Println("pid", p.id, "pushing")
+	// update sub details
+	subs := subscriptions.Subscriptions{}
+	subs.LoadOne(p.sub.Project, p.sub.Name, store.Clone())
+	p.sub = subs.List[0]
+	// Init Received Message List
+
+	fullTopic := p.sub.Project + "." + p.sub.Topic
+	msgs := brk.Consume(fullTopic, p.sub.Offset)
+	if len(msgs) > 0 {
+		err := p.sndr.Send(p.endpoint, msgs[0])
+		if err != nil {
+			// Advance the offset
+			store.UpdateSubOffset(p.sub.Name, 1+p.sub.Offset)
+
+		}
+	} else {
+		log.Println("pid:", p.id, "empty")
+	}
+}
+
+// Shoutout prints manager stats
+func (mgr *Manager) Shoutout() {
+	for k := range mgr.list {
+		item := mgr.list[k]
+		log.Println("--- pid:", item.id, "running:", item.running)
+	}
+}
+
+// NewManager creates a new manager object for managing push routines
+func NewManager(brk brokers.Broker, str stores.Store) *Manager {
+	mgr := Manager{}
+	mgr.broker = brk
+	mgr.store = str
+	mgr.list = make(map[string]*Pusher)
+	log.Println("Manager Initialized")
+	return &mgr
+}
+
+func splitPSub(psub string) (string, string, error) {
+	tokens := strings.Split(psub, "/")
+	if len(tokens) != 2 {
+		return "", "", errors.New("Wrong project/subscription definition")
+	}
+
+	return tokens[0], tokens[1], nil
+}
+
+// isSet returns true if broker and store has been set
+func (mgr *Manager) isSet() bool {
+	if mgr.broker != nil && mgr.store != nil {
+		return true
+	}
+
+	return false
+}
+
+// Get returns a pusher
+func (mgr *Manager) Get(psub string) (*Pusher, error) {
+	if p, ok := mgr.list[psub]; ok {
+		return p, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// Stop stops a push subscription
+func (mgr *Manager) Stop(psub string) error {
+	// Check if mgr is set
+	if !mgr.isSet() {
+		return errors.New("Push Manager not set")
+	}
+
+	if p, err := mgr.Get(psub); err == nil {
+		if p.running == false {
+			log.Println("Already stopped", p.id, "state:", p.running)
+			return errors.New("Already Stoped")
+		}
+		log.Println("Trying to stop:", p.id)
+		p.stop <- true
+		return nil
+	}
+
+	return errors.New("Not Found")
+}
+
+// Add a new push subscription
+func (mgr *Manager) Add(psub string, sndr Sender) error {
+	// Check if mgr is set
+	if !mgr.isSet() {
+		return errors.New("Push Manager not set")
+	}
+	// Check if subscription exists
+
+	project, subname, err := splitPSub(psub)
+
+	if err != nil {
+		return err
+	}
+
+	subs := subscriptions.Subscriptions{}
+
+	err = subs.LoadOne(project, subname, mgr.store.Clone())
+
+	if err != nil {
+		return errors.New("No sub found")
+	}
+
+	// Create new pusher
+
+	pushr := Pusher{}
+	pushr.id = len(mgr.list)
+	pushr.sub = subs.List[0]
+	pushr.running = false
+	pushr.stop = make(chan bool, 2)
+	pushr.rate = 300 * time.Millisecond
+	pushr.sndr = sndr
+
+	mgr.list[psub] = &pushr
+	log.Println("Push Subscription Added")
+
+	return nil
+
+}
+
+// Launch Launches a new puhser
+func (mgr *Manager) Launch(psub string) error {
+	// Check if mgr is set
+	if !mgr.isSet() {
+		return errors.New("Push Manager not set")
+	}
+
+	if p, err := mgr.Get(psub); err == nil {
+		if p.running == true {
+			return errors.New("Already Running")
+		}
+		p.launch(mgr.broker, mgr.store)
+		return nil
+	}
+
+	return errors.New("Not Found")
+}
+
+// Launch the pusher activity
+func (p *Pusher) launch(brk brokers.Broker, store stores.Store) {
+	log.Println("pusher:", p.id, "launching...")
+	p.running = true
+	go Activity(p, brk, store)
+}
+
+//Activity the push subscription
+func Activity(p *Pusher, brk brokers.Broker, store stores.Store) error {
+
+	for {
+		rate := time.After(p.rate)
+		select {
+		case <-p.stop:
+			{
+				log.Println("pusher:", p.id, "Stoping...")
+				p.running = false
+				return nil
+			}
+		case <-rate:
+			{
+				p.push(brk, store)
+			}
+		}
+	}
+
+}

--- a/push/push_test.go
+++ b/push/push_test.go
@@ -1,0 +1,64 @@
+package push
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/ARGOeu/argo-messaging/Godeps/_workspace/src/github.com/stretchr/testify/suite"
+	"github.com/ARGOeu/argo-messaging/brokers"
+	"github.com/ARGOeu/argo-messaging/config"
+	"github.com/ARGOeu/argo-messaging/stores"
+)
+
+type PushTestSuite struct {
+	suite.Suite
+	cfgStr string
+}
+
+func (suite *PushTestSuite) SetupTest() {
+	suite.cfgStr = `{
+	  "port":8080,
+		"broker_hosts":["localhost:9092"],
+		"store_host":"localhost",
+		"store_db":"argo_msg",
+		"use_authorization":true,
+		"use_authentication":true,
+		"use_ack":true
+	}`
+
+	log.SetOutput(ioutil.Discard)
+}
+
+func (suite *PushTestSuite) TestPusher() {
+	sndr := NewMockSender(false)
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	pushMgr := NewManager(nil, nil)
+	suite.Equal(false, pushMgr.isSet())
+	pushMgr = NewManager(&brk, str)
+	suite.Equal(true, pushMgr.isSet())
+	err := pushMgr.Add("ARGO/tralala", sndr)
+	suite.Equal(errors.New("No sub found"), err)
+	err = pushMgr.Add("ARGO/sub4", sndr)
+	suite.Equal(nil, err)
+	p, err := pushMgr.Get("foo/bar")
+	suite.Equal(errors.New("not found"), err)
+	suite.Equal(true, p == nil)
+	p, err = pushMgr.Get("ARGO/sub4")
+	suite.Equal(nil, err)
+	suite.Equal(0, p.id)
+	suite.Equal("ARGO", p.sub.Project)
+	suite.Equal("topic4", p.sub.Topic)
+	suite.Equal("/projects/ARGO/subscriptions/sub4", p.sub.FullName)
+	suite.Equal("/projects/ARGO/topics/topic4", p.sub.FullTopic)
+	suite.Equal(10, p.sub.Ack)
+	suite.Equal("endpoint.foo", p.sub.PushCfg.Pend)
+}
+
+func TestPushTestSuite(t *testing.T) {
+	suite.Run(t, new(PushTestSuite))
+}

--- a/push/sender.go
+++ b/push/sender.go
@@ -1,0 +1,70 @@
+package push
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// Sender is inteface for sending messages to remote endpoints
+type Sender interface {
+	Send(msg string, endpoint string) error
+}
+
+// HTTPSender sends msgs through http
+type HTTPSender struct {
+	Client http.Client
+}
+
+// MockSender mocks sending messages to remote endpoints
+type MockSender struct {
+	ClientFail   bool
+	LastMsg      string
+	LastEndpoint string
+}
+
+// NewHTTPSender creates a new HTTPSender. Specify timeout in seconds
+func NewHTTPSender(timeoutSec int) *HTTPSender {
+	timeout := time.Duration(timeoutSec) * time.Second
+	client := http.Client{Timeout: timeout}
+	snd := HTTPSender{Client: client}
+	return &snd
+}
+
+// Send sends a message through HTTP
+func (hs *HTTPSender) Send(msg string, endpoint string) error {
+	var jsonStr = []byte(msg)
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hs.Client.Do(req)
+	defer resp.Body.Close()
+
+	if err == nil {
+		if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 204 && resp.StatusCode != 101 {
+			err = errors.New("not delivered")
+		}
+	}
+
+	return err
+}
+
+// NewMockSender creates a new Mock sender
+func NewMockSender(fail bool) *MockSender {
+
+	snd := MockSender{ClientFail: fail}
+	return &snd
+}
+
+// Send sends a message through HTTP
+func (ms *MockSender) Send(msg string, endpoint string) error {
+	if ms.ClientFail == true {
+		return errors.New("endpoint not reachable")
+	}
+
+	ms.LastMsg = msg
+	ms.LastEndpoint = endpoint
+
+	return nil
+}

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -87,12 +87,14 @@ func (mk *MockStore) Initialize() {
 	mk.TopicList = append(mk.TopicList, qtop3)
 
 	// populate Subscriptions
-	qsub1 := QSub{"ARGO", "sub1", "topic1", 0, 0, "", 10}
-	qsub2 := QSub{"ARGO", "sub2", "topic2", 0, 0, "", 10}
-	qsub3 := QSub{"ARGO", "sub3", "topic3", 0, 0, "", 10}
+	qsub1 := QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10}
+	qsub2 := QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10}
+	qsub3 := QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10}
+	qsub4 := QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10}
 	mk.SubList = append(mk.SubList, qsub1)
 	mk.SubList = append(mk.SubList, qsub2)
 	mk.SubList = append(mk.SubList, qsub3)
+	mk.SubList = append(mk.SubList, qsub4)
 
 	// populate Projects
 	qPr := QProject{"ARGO"}
@@ -107,6 +109,17 @@ func (mk *MockStore) Initialize() {
 	mk.RoleList = append(mk.RoleList, qRole1)
 	mk.RoleList = append(mk.RoleList, qRole2)
 
+}
+
+// QueryOneSub returns one sub exactly
+func (mk *MockStore) QueryOneSub(project string, sub string) (QSub, error) {
+	for _, item := range mk.SubList {
+		if item.Name == sub && item.Project == project {
+			return item, nil
+		}
+	}
+
+	return QSub{}, errors.New("empty")
 }
 
 // Clone the store
@@ -165,7 +178,7 @@ func (mk *MockStore) InsertTopic(project string, name string) error {
 
 // InsertSub inserts a new sub object to the store
 func (mk *MockStore) InsertSub(project string, name string, topic string, offset int64, ack int) error {
-	sub := QSub{project, name, topic, offset, 0, "", ack}
+	sub := QSub{project, name, topic, offset, 0, "", "", ack}
 	mk.SubList = append(mk.SubList, sub)
 	return nil
 }

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -27,7 +27,7 @@ func NewMongoStore(server string, db string) *MongoStore {
 // Close is used to close session
 func (mong *MongoStore) Close() {
 	mong.Session.Close()
-	log.Printf("Session Closed...")
+	// log.Printf("Session Closed...")
 }
 
 // Clone the store with  a cloned session
@@ -181,6 +181,24 @@ func (mong *MongoStore) GetUserRoles(project string, token string) []string {
 
 }
 
+// QueryOneSub queries and returns specific sub of project
+func (mong *MongoStore) QueryOneSub(project string, sub string) (QSub, error) {
+
+	db := mong.Session.DB(mong.Database)
+	c := db.C("subscriptions")
+	var results []QSub
+	err := c.Find(bson.M{"project": project, "name": sub}).All(&results)
+	if err != nil {
+		log.Fatalf("%s\t%s\t%s", "FATAL", "STORE", err.Error())
+	}
+
+	if len(results) > 0 {
+		return results[0], nil
+	}
+
+	return QSub{}, errors.New("empty")
+}
+
 // HasProject Returns true if project exists
 func (mong *MongoStore) HasProject(project string) bool {
 
@@ -206,7 +224,7 @@ func (mong *MongoStore) InsertTopic(project string, name string) error {
 
 // InsertSub inserts a subscription to the store
 func (mong *MongoStore) InsertSub(project string, name string, topic string, offset int64, ack int) error {
-	sub := QSub{project, name, topic, offset, 0, "", ack}
+	sub := QSub{project, name, topic, offset, 0, "", "", ack}
 	return mong.InsertResource("subscriptions", sub)
 }
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -2,13 +2,14 @@ package stores
 
 // QSub are the results of the Qsub query
 type QSub struct {
-	Project    string `bson:"project"`
-	Name       string `bson:"name"`
-	Topic      string `bson:"topic"`
-	Offset     int64  `bson:"offset"`
-	NextOffset int64  `bson:"next_offset"`
-	PendingAck string `bson:"pending_ack"`
-	Ack        int    `bson:"ack"`
+	Project      string `bson:"project"`
+	Name         string `bson:"name"`
+	Topic        string `bson:"topic"`
+	Offset       int64  `bson:"offset"`
+	NextOffset   int64  `bson:"next_offset"`
+	PendingAck   string `bson:"pending_ack"`
+	PushEndpoint string `bson:"push_endpoint"`
+	Ack          int    `bson:"ack"`
 }
 
 // QUser are the results of the QUser query

--- a/stores/store.go
+++ b/stores/store.go
@@ -10,6 +10,7 @@ type Store interface {
 	InsertTopic(project string, name string) error
 	InsertSub(project string, name string, topic string, offest int64, ack int) error
 	HasProject(project string) bool
+	QueryOneSub(project string, sub string) (QSub, error)
 	HasResourceRoles(resource string, roles []string) bool
 	GetUserRoles(project string, token string) []string
 	UpdateSubOffset(name string, offset int64)

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -20,9 +20,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 		QTopic{"ARGO", "topic2"},
 		QTopic{"ARGO", "topic3"}}
 
-	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", 10},
-		QSub{"ARGO", "sub2", "topic2", 0, 0, "", 10},
-		QSub{"ARGO", "sub3", "topic3", 0, 0, "", 10}}
+	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10},
+		QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10},
+		QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10},
+		QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10}}
 
 	suite.Equal(eTopList, store.QueryTopics())
 	suite.Equal(eSubList, store.QuerySubs())
@@ -53,10 +54,11 @@ func (suite *StoreTestSuite) TestMockStore() {
 		QTopic{"ARGO", "topic3"},
 		QTopic{"ARGO", "topicFresh"}}
 
-	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", 10},
-		QSub{"ARGO", "sub2", "topic2", 0, 0, "", 10},
-		QSub{"ARGO", "sub3", "topic3", 0, 0, "", 10},
-		QSub{"ARGO", "subFresh", "topicFresh", 0, 0, "", 10}}
+	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10},
+		QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10},
+		QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10},
+		QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10},
+		QSub{"ARGO", "subFresh", "topicFresh", 0, 0, "", "", 10}}
 
 	suite.Equal(eTopList2, store.QueryTopics())
 	suite.Equal(eSubList2, store.QuerySubs())
@@ -75,6 +77,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 	err = store.RemoveSub("ARGO", "subFresh")
 	suite.Equal("not found", err.Error())
 
+	sb, err := store.QueryOneSub("ARGO", "sub1")
+	suite.Equal(sb, eSubList[0])
 }
 
 func TestStoresTestSuite(t *testing.T) {

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -95,8 +95,28 @@ func (sl *Subscriptions) LoadFromStore(store stores.Store) {
 		curSub.Offset = item.Offset
 		curSub.NextOffset = item.NextOffset
 		curSub.Ack = item.Ack
+		curSub.PushCfg = PushConfig{item.PushEndpoint}
+
 		sl.List = append(sl.List, curSub)
 	}
+
+}
+
+// LoadOne loads one subscription
+func (sl *Subscriptions) LoadOne(project string, subname string, store stores.Store) error {
+	defer store.Close()
+	sl.List = []Subscription{}
+	sub, err := store.QueryOneSub(project, subname)
+	if err != nil {
+		return errors.New("not found")
+	}
+	curSub := New(sub.Project, sub.Name, sub.Topic)
+	curSub.Offset = sub.Offset
+	curSub.NextOffset = sub.NextOffset
+	curSub.Ack = sub.Ack
+	curSub.PushCfg = PushConfig{sub.PushEndpoint}
+	sl.List = append(sl.List, curSub)
+	return nil
 
 }
 

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -69,10 +69,13 @@ func (suite *SubTestSuite) TestGetSubsByProject() {
 	expSub1 := New("ARGO", "sub1", "topic1")
 	expSub2 := New("ARGO", "sub2", "topic2")
 	expSub3 := New("ARGO", "sub3", "topic3")
+	expSub4 := New("ARGO", "sub4", "topic4")
+	expSub4.PushCfg = PushConfig{"endpoint.foo"}
 	expSubs := Subscriptions{}
 	expSubs.List = append(expSubs.List, expSub1)
 	expSubs.List = append(expSubs.List, expSub2)
 	expSubs.List = append(expSubs.List, expSub3)
+	expSubs.List = append(expSubs.List, expSub4)
 	suite.Equal(expSubs, result)
 }
 
@@ -85,10 +88,13 @@ func (suite *SubTestSuite) TestLoadFromCfg() {
 	expSub1 := New("ARGO", "sub1", "topic1")
 	expSub2 := New("ARGO", "sub2", "topic2")
 	expSub3 := New("ARGO", "sub3", "topic3")
+	expSub4 := New("ARGO", "sub4", "topic4")
+	expSub4.PushCfg = PushConfig{"endpoint.foo"}
 	expSubs := Subscriptions{}
 	expSubs.List = append(expSubs.List, expSub1)
 	expSubs.List = append(expSubs.List, expSub2)
 	expSubs.List = append(expSubs.List, expSub3)
+	expSubs.List = append(expSubs.List, expSub4)
 	suite.Equal(expSubs, mySubs)
 
 }
@@ -193,6 +199,14 @@ func (suite *SubTestSuite) TestExportJson() {
          "topic": "/projects/ARGO/topics/topic3",
          "pushConfig": {
             "pushEndpoint": ""
+         },
+         "ackDeadlineSeconds": 10
+      },
+      {
+         "name": "/projects/ARGO/subscriptions/sub4",
+         "topic": "/projects/ARGO/topics/topic4",
+         "pushConfig": {
+            "pushEndpoint": "endpoint.foo"
          },
          "ackDeadlineSeconds": 10
       }


### PR DESCRIPTION
## Goal 
Implement Push workers. Each push worker is a task responsible for running the following repeated activity:
- Check if the subscription's topic has new messages and consume them
- Send messages at a variable rate (slow-start) to the specified endpoint

## Implementation
Implement Push workers as go routines. 
- [x] Implement a new package push
- [x] Implement a Pusher Struct (holding information for each push worker)
- [x] Implement a Manager Struct (to handle a list of active push workers)
- [x] Add Pusher Methods 
- [x] Add Manager Methods
- [x] Add Push main activity method
- [x] Unit tests