### PR TITLE
ARGO-408 Receive Push Messages. Fix Msg Attributes

### DIFF
--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -9,12 +9,10 @@ type MockBroker struct {
 func (b *MockBroker) PopulateOne() {
 	msg1 := `{
   "messageId": "0",
-  "attributes": [
+  "attributes":
     {
-      "key": "foo",
-      "value": "bar"
-    }
-  ],
+      "foo":"bar"
+    },
   "data": "YmFzZTY0ZW5jb2RlZA==",
   "publishTime": "2016-02-24T11:55:09.786127994Z"
 }`
@@ -28,36 +26,30 @@ func (b *MockBroker) PopulateOne() {
 func (b *MockBroker) PopulateThree() {
 	msg1 := `{
   "messageId": "0",
-  "attributes": [
+  "attributes":
     {
-      "key": "foo",
-      "value": "bar"
-    }
-  ],
+      "foo":"bar"
+    },
   "data": "YmFzZTY0ZW5jb2RlZA==",
   "publishTime": "2016-02-24T11:55:09.786127994Z"
 }`
 
 	msg2 := `{
   "messageId": "1",
-  "attributes": [
+  "attributes":
     {
-      "key": "foo2",
-      "value": "bar2"
-    }
-  ],
+    	"foo2":"bar2"
+    },
   "data": "YmFzZTY0ZW5jb2RlZA==",
   "publishTime": "2016-02-24T11:55:09.827678754Z"
 }`
 
 	msg3 := `{
   "messageId": "2",
-  "attributes": [
+  "attributes":
     {
-      "key": "foo2",
-      "value": "bar2"
-    }
-  ],
+      "foo2":"bar2"
+    },
   "data": "YmFzZTY0ZW5jb2RlZA==",
   "publishTime": "2016-02-24T11:55:09.830417467Z"
 }`

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -563,20 +563,13 @@ definitions:
       name:
         type: string
         description: Name of the topic
-  Attribute:
-    type: object
-    properties:
-      key:
-        type: string
-      value:
-        type: string
+
   Message:
     type: object
     properties:
       attributes:
-        type: array
-        items:
-          $ref: '#/definitions/Attribute'
+        type: object
+
       data:
         type: string
         description: Message payload in Base64 encoding"
@@ -604,10 +597,9 @@ definitions:
             type: string
             description: id of the message
           attributes:
-            type: array
+            type: object
             description: key/value dictionary accompanying the message
-            items:
-              $ref: '#/definitions/Attribute'
+
           data:
             type: string
             description: base64 encoding of the message payload

--- a/doc/v1/docs/api_topics.md
+++ b/doc/v1/docs/api_topics.md
@@ -12,7 +12,7 @@ This request creates a new topic in a project with a PUT request
 
 ### Example request
 ```json
-curl -X PUT -H "Content-Type: application/json" 
+curl -X PUT -H "Content-Type: application/json"
  -d '' " https://{URL}/v1/projects/EGI/topics/monitoring?key=S3CR3T"`
 ```
 
@@ -138,16 +138,11 @@ The topic:publish endpoint publishes a message, or a list of messages to a speci
 {
 "messages": [
  	{
-  		"attributes": [
-   		{
-    			"key": "infrastructure",
-    			"value": "testing"
-   		},
-   		{
-"key": "description",
-	  		"value":"this message is used for testing purposes"
+  		"attributes": {
+        "attr1":"test1",
+        "attr2":"test2"
    		}
-  	],
+  	,
  "data":"U28geW91IHdlbnQgYWhlYWQgYW5kIGRlY29kZWQgdGhpcywgeW91IGNvdWxkbid0IHJlc2lzdCBlaCA/"
 
  	}

--- a/examples/flask_receive_endpoint/receiver.py
+++ b/examples/flask_receive_endpoint/receiver.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Example of a remote endpoint used to receive push messages
+# The endpoint is a simple flask app that by default listens to port 5000
+# It receives push messages that are delivered with http POST to `host.remote.node:5000/receive_here`
+# It dumps the message properties and the decoded payload to a local file `./api.dmp`
+#
+# To run the example endpoint issue:
+#  $ export FLASK_APP=receiver.py
+#  $ flask run
+
+
+from flask import Flask
+from flask import request
+import json
+import base64
+app = Flask(__name__)
+
+
+@app.route('/receive_here', methods=['POST'])
+def receive_msg():
+    try:
+        data = json.loads(request.get_data())
+        msg = data["message"]
+        with open("api.dump", "a") as fo:
+            fo.write("subscription:" + str(data["subscription"] + "\n"))
+            fo.write("message_id:" + str(msg["message_id"]) + "\n")
+            fo.write("attributes:" + str(msg["attributes"]) + "\n")
+            fo.write("data:" + str(base64.b64decode(msg["data"]))+ "\n")
+            fo.write("------\n")
+        return '', 201
+
+    except (KeyError, ValueError):
+        return '', 400

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -439,12 +439,11 @@ func (suite *HandlerTestSuite) TestPublish() {
 	postJSON := `{
   "messages": [
     {
-      "attributes": [
+      "attributes":
         {
-          "key": "foo",
-          "value": "bar"
+         "foo":"bar"
         }
-      ],
+      ,
       "data": "YmFzZTY0ZW5jb2RlZA=="
     }
   ]
@@ -480,30 +479,27 @@ func (suite *HandlerTestSuite) TestPublishMultiple() {
 	postJSON := `{
   "messages": [
     {
-      "attributes": [
+      "attributes":
         {
-          "key": "foo",
-          "value": "bar"
+          "foo":"bar"
         }
-      ],
+      ,
       "data": "YmFzZTY0ZW5jb2RlZA=="
     },
     {
-      "attributes": [
+      "attributes":
         {
-          "key": "foo2",
-          "value": "bar2"
+      		"foo2":"bar2"
         }
-      ],
+      ,
       "data": "YmFzZTY0ZW5jb2RlZA=="
     },
     {
-      "attributes": [
+      "attributes":
         {
-          "key": "foo2",
-          "value": "bar2"
+          "foo2":"bar2"
         }
-      ],
+      ,
       "data": "YmFzZTY0ZW5jb2RlZA=="
     }
   ]
@@ -655,12 +651,9 @@ func (suite *HandlerTestSuite) TestSubPullOne() {
          "ackId": "projects/ARGO/subscriptions/sub1:0",
          "message": {
             "messageId": "0",
-            "attributes": [
-               {
-                  "key": "foo",
-                  "value": "bar"
-               }
-            ],
+            "attributes": {
+               "foo": "bar"
+            },
             "data": "YmFzZTY0ZW5jb2RlZA==",
             "publishTime": "2016-02-24T11:55:09.786127994Z"
          }
@@ -819,12 +812,9 @@ func (suite *HandlerTestSuite) TestSubPullAll() {
          "ackId": "projects/ARGO/subscriptions/sub1:0",
          "message": {
             "messageId": "0",
-            "attributes": [
-               {
-                  "key": "foo",
-                  "value": "bar"
-               }
-            ],
+            "attributes": {
+               "foo": "bar"
+            },
             "data": "YmFzZTY0ZW5jb2RlZA==",
             "publishTime": "2016-02-24T11:55:09.786127994Z"
          }
@@ -833,12 +823,9 @@ func (suite *HandlerTestSuite) TestSubPullAll() {
          "ackId": "projects/ARGO/subscriptions/sub1:1",
          "message": {
             "messageId": "1",
-            "attributes": [
-               {
-                  "key": "foo2",
-                  "value": "bar2"
-               }
-            ],
+            "attributes": {
+               "foo2": "bar2"
+            },
             "data": "YmFzZTY0ZW5jb2RlZA==",
             "publishTime": "2016-02-24T11:55:09.827678754Z"
          }
@@ -847,12 +834,9 @@ func (suite *HandlerTestSuite) TestSubPullAll() {
          "ackId": "projects/ARGO/subscriptions/sub1:2",
          "message": {
             "messageId": "2",
-            "attributes": [
-               {
-                  "key": "foo2",
-                  "value": "bar2"
-               }
-            ],
+            "attributes": {
+               "foo2": "bar2"
+            },
             "data": "YmFzZTY0ZW5jb2RlZA==",
             "publishTime": "2016-02-24T11:55:09.830417467Z"
          }

--- a/messages/message.go
+++ b/messages/message.go
@@ -1,9 +1,12 @@
 package messages
 
 import (
+	"bytes"
 	b64 "encoding/base64"
 	"encoding/json"
 	"errors"
+	"sort"
+	"strings"
 )
 
 // RecMsg holds info for a received message
@@ -24,10 +27,16 @@ type MsgList struct {
 
 // Message struct used to hold message information
 type Message struct {
-	ID      string      `json:"messageId,omitempty"`
-	Attr    []Attribute `json:"attributes,omitempty"`  // used to hold attribute key/value store
-	Data    string      `json:"data"`                  // base64 encoded data payload
-	PubTime string      `json:"publishTime,omitempty"` // publish timedate of message
+	ID      string     `json:"messageId,omitempty"`
+	Attr    Attributes `json:"attributes,omitempty"`  // used to hold attribute key/value store
+	Data    string     `json:"data"`                  // base64 encoded data payload
+	PubTime string     `json:"publishTime,omitempty"` // publish timedate of message
+}
+
+// PushMsg contains structure for push messages
+type PushMsg struct {
+	Msg Message `json:"message"`
+	Sub string  `json:"subscription"`
 }
 
 // MsgIDs utility struct
@@ -35,18 +44,47 @@ type MsgIDs struct {
 	IDs []string `json:"messageIds"`
 }
 
-// Attribute representation as key/value
-type Attribute struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+// Attributes representation as key/value
+type Attributes map[string]string
+
+// MarshalJSON generates json string for Attributes type
+func (attr Attributes) MarshalJSON() ([]byte, error) {
+	var buff bytes.Buffer
+
+	// sort attribute keys
+	keys := make([]string, len(attr))
+	i := 0
+	for key := range attr {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+
+	// iterate over sorted keys and marshal to json
+	buff.WriteString("{")
+	for i, key := range keys {
+		if i != 0 {
+			buff.WriteString(", ")
+		}
+		buff.WriteString(strings.Join([]string{"\"", key, "\":\"", attr[key], "\""}, ""))
+	}
+
+	buff.WriteString("}")
+
+	return buff.Bytes(), nil
 }
+
+// type Attribute struct {
+// 	Key   string `json:"key"`
+// 	Value string `json:"value"`
+// }
 
 // Construct functions
 //////////////////////
 
 // New creates a new Message based on data string provided
 func New(data string) Message {
-	msg := Message{ID: "0", Attr: []Attribute{}, Data: data}
+	msg := Message{ID: "0", Attr: make(map[string]string), Data: data}
 
 	return msg
 }
@@ -74,36 +112,36 @@ func (msg *Message) GetDecoded() string {
 	return string(decoded[:])
 }
 
-// AttrExists checks if an attribute exists based on key. Returns also the index
-// of the attribute item in Attributes slice
-func (msg *Message) AttrExists(key string) (int, string) {
+// AttrExists checks if an attribute exists based on key. Returns also a boolean
+// if the attribute exists
+func (msg *Message) AttrExists(key string) (bool, string) {
 
-	for i, a := range msg.Attr {
-		if a.Key == key {
-			return i, a.Value
+	for k, value := range msg.Attr {
+		if k == key {
+			return true, value
 		}
 	}
 
-	return -1, ""
+	return false, ""
 
 }
 
 // InsertAttribute takes a key/value item and appends it in Message's attributes
 func (msg *Message) InsertAttribute(key string, value string) error {
-	i, _ := msg.AttrExists(key)
-	if i > -1 {
+	exists, _ := msg.AttrExists(key)
+	if exists {
 		return errors.New("Attribute already exists")
 	}
 
-	msg.Attr = append(msg.Attr, Attribute{Key: key, Value: value})
+	msg.Attr[key] = value
 	return nil
 }
 
 // UpdateAttribute updates an existing attribute based on key and new value
 func (msg *Message) UpdateAttribute(key string, value string) error {
-	i, _ := msg.AttrExists(key)
-	if i > -1 {
-		msg.Attr[i] = Attribute{Key: key, Value: value}
+	exists, _ := msg.AttrExists(key)
+	if exists {
+		msg.Attr[key] = value
 		return nil
 	}
 
@@ -112,9 +150,9 @@ func (msg *Message) UpdateAttribute(key string, value string) error {
 
 // RemoveAttribute takes a key and removes attribute if exists (based on key)
 func (msg *Message) RemoveAttribute(key string) error {
-	i, _ := msg.AttrExists(key)
-	if i > -1 {
-		msg.Attr = append(msg.Attr[:i], msg.Attr[i+1:]...)
+	exists, _ := msg.AttrExists(key)
+	if exists {
+		delete(msg.Attr, key)
 		return nil
 	}
 
@@ -123,13 +161,19 @@ func (msg *Message) RemoveAttribute(key string) error {
 
 // GetAttribute takes a key and return attribute value if exists (based on key)
 func (msg *Message) GetAttribute(key string) (string, error) {
-	i, value := msg.AttrExists(key)
-	if i > -1 {
+	exists, value := msg.AttrExists(key)
+	if exists {
 		return value, nil
 	}
 
 	return "", errors.New("Attribute doesn't exist")
 
+}
+
+// ExportJSON exports whole Message Structure as a json string
+func (pMsg *PushMsg) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(pMsg, "", "   ")
+	return string(output[:]), err
 }
 
 // ExportJSON exports whole Message Structure as a json string

--- a/messages/message_test.go
+++ b/messages/message_test.go
@@ -3,6 +3,7 @@ package messages
 import (
 	b64 "encoding/base64"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/ARGOeu/argo-messaging/Godeps/_workspace/src/github.com/stretchr/testify/suite"
@@ -26,7 +27,7 @@ func (suite *MsgTestSuite) TestAttributes() {
 
 	testMsg.InsertAttribute("bruce", "wayne")
 	testMsg.InsertAttribute("clark", "kent")
-	expAttr := []Attribute{{Key: "bruce", Value: "wayne"}, {Key: "clark", Value: "kent"}}
+	expAttr := Attributes{"bruce": "wayne", "clark": "kent"}
 	suite.Equal(expAttr, testMsg.Attr)
 	// Test GetAttribute
 	val1, err1 := testMsg.GetAttribute("clark")
@@ -54,41 +55,28 @@ func (suite *MsgTestSuite) TestAttributes() {
 func (suite *MsgTestSuite) TestLoadMsgJson() {
 	txtJSON := `{
    "messageId": "35",
-   "attributes": [
-     {
-       "key": "tick",
-       "value": "tock"
-     },
-     {
-       "key": "flip",
-       "value": "flop"
-     }
-   ],
+   "attributes": {"tick":"tock","flip":"flop"},
    "data": "aGVsbG8gd29ybGQh"
  }`
 
 	testMsg, err := LoadMsgJSON([]byte(txtJSON))
 	suite.Equal(nil, err)
 	suite.Equal("35", testMsg.ID)
-	expAttr := []Attribute{{Key: "tick", Value: "tock"}, {Key: "flip", Value: "flop"}}
+	expAttr := Attributes{"tick": "tock", "flip": "flop"}
 	suite.Equal(expAttr, testMsg.Attr)
 	suite.Equal("aGVsbG8gd29ybGQh", testMsg.Data)
+
+	fmt.Println(testMsg.Data)
 
 }
 
 func (suite *MsgTestSuite) TestExportJson() {
 	expJSON := `{
    "messageId": "0",
-   "attributes": [
-      {
-         "key": "foo",
-         "value": "bar"
-      },
-      {
-         "key": "color",
-         "value": "blue"
-      }
-   ],
+   "attributes": {
+      "color": "blue",
+      "foo": "bar"
+   },
    "data": "aGVsbG8gd29ybGQh"
 }`
 
@@ -100,6 +88,7 @@ func (suite *MsgTestSuite) TestExportJson() {
 	outJSON, err := testMsg.ExportJSON()
 	suite.Equal(nil, err)
 	suite.Equal(expJSON, outJSON)
+	fmt.Println(outJSON)
 
 }
 

--- a/push/push.go
+++ b/push/push.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ARGOeu/argo-messaging/brokers"
+	"github.com/ARGOeu/argo-messaging/messages"
 	"github.com/ARGOeu/argo-messaging/stores"
 	"github.com/ARGOeu/argo-messaging/subscriptions"
 )
@@ -75,7 +76,13 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	fullTopic := p.sub.Project + "." + p.sub.Topic
 	msgs := brk.Consume(fullTopic, p.sub.Offset)
 	if len(msgs) > 0 {
-		err := p.sndr.Send(msgs[0], p.endpoint)
+		// Generate push message template
+		pMsg := messages.PushMsg{}
+
+		pMsg.Msg, _ = messages.LoadMsgJSON([]byte(msgs[0]))
+		pMsg.Sub = p.sub.FullName
+		pMsgJSON, _ := pMsg.ExportJSON()
+		err := p.sndr.Send(pMsgJSON, p.endpoint)
 
 		if err == nil {
 			// Advance the offset


### PR DESCRIPTION
Push Message response is slighty different from pull (needs to contain subscription information) like: 
```json
{
  "message":{  },
  "subscription":"foo"
}
```

- [x] Create PushMsg JSON template for push requests
- [x] Optimize PushManager and Sender structures
- [x] Fix Message Attribute schema 
   from:
```json
   "attributes": [{"key":"...","value":"..."},{"key2":"...","value2":"..."}]
      to:
   "attributes":{"key":"value","key2":"value2"}
```
 - [x] update docs, swagger
 - [x] add example remote endpoint (used in push mode)

