### PR TITLE
ARGO-424 In pull mode keep connection alive until msg retrieval

### DIFF
--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -7,5 +7,5 @@ type Broker interface {
 	CloseConnections()
 	Publish(topic string, payload string) (string, int, int64)
 	GetOffset(topic string) int64
-	Consume(topic string, offset int64) []string
+	Consume(topic string, offset int64, imm bool) []string
 }

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -94,6 +94,6 @@ func (b *MockBroker) GetOffset(topic string) int64 {
 }
 
 // Consume function to consume a message from the broker
-func (b *MockBroker) Consume(topic string, offset int64) []string {
+func (b *MockBroker) Consume(topic string, offset int64, imm bool) []string {
 	return b.MsgList
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -526,6 +526,9 @@ definitions:
       maxMessages:
         type: string
         description: Max number of messages to be consumed
+      returnImmediately:
+        type: string
+        description: Set if should return immediately and close connection (if no messages are present) or wait until new messages
   SubParameters:
     type: object
     properties:

--- a/handlers.go
+++ b/handlers.go
@@ -807,7 +807,11 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 	targSub := sub.GetSubByName(urlVars["project"], urlVars["subscription"])
 
 	fullTopic := targSub.Project + "." + targSub.Topic
-	msgs := refBrk.Consume(fullTopic, targSub.Offset)
+	retImm := false
+	if pullInfo.RetImm == "true" {
+		retImm = true
+	}
+	msgs := refBrk.Consume(fullTopic, targSub.Offset, retImm)
 
 	var limit int
 	limit, err = strconv.Atoi(pullInfo.MaxMsg)

--- a/push/push.go
+++ b/push/push.go
@@ -73,7 +73,7 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	// Init Received Message List
 
 	fullTopic := p.sub.Project + "." + p.sub.Topic
-	msgs := brk.Consume(fullTopic, p.sub.Offset)
+	msgs := brk.Consume(fullTopic, p.sub.Offset, false)
 	if len(msgs) > 0 {
 		err := p.sndr.Send(msgs[0], p.endpoint)
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -41,7 +41,7 @@ func (mong *MongoStore) Clone() Store {
 func (mong *MongoStore) Initialize() {
 
 	session, err := mgo.Dial(mong.Server)
-	if err != nil && session != nil {
+	if err != nil {
 
 		log.Fatalf("%s\t%s\t%s", "FATAL", "STORE", err.Error())
 


### PR DESCRIPTION
## Goal
When handling subscriber pull requests allow the following:
- Keep the connection alive until messages are received
- Returned immediately (if parameter is set)

## Implementation
- [x] Refactor Broker Consume method to support this feature
- [x] Add support for returnImmediately in request handlers 
- [x] update unit tests, docs