### PR TITLE
ARGO-422 Support for configurable retry policy

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -560,6 +560,19 @@ definitions:
       pushEndpoint:
         type: string
         description: endpoint url for endpoint to push messages
+      retryPolicy:
+        $ref: '#/definitions/RetryPolicy'
+
+  RetryPolicy:
+    type: object
+    properties:
+     type:
+       type: string
+       description: type of the retry policy used (Only linear policy supported)
+     period:
+       type: integer
+       description: period of retry policy in milliseconds
+
   Topic:
     type: object
     properties:

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -106,28 +106,33 @@ This request modifies the push configuration of a subscription
 `POST /v1/projects/{project_name}/subscriptions/{subscription_name}:modifyPushConfig`
 
 ### Post body:
-```json
+```
+json
 {
-  "pushConfig": {"pushEndpoint": ""}
+  "pushConfig": {  "pushEndpoint": "",
+                   "retryPolicy": { "type": "linear", "period": 300 }
+  }
 }
 ```
 
 ### Where
 - Project_name: Name of the project
 - subscription_name: The subscription name to consume
-- pushConfig: configuration including pushEndpoint for the remote endpoint to receive the messages
+- pushConfig: configuration including pushEndpoint for the remote endpoint to receive the messages. Also includes retryPolicy (type of retryPolicy and period parameters)
 
 
 ### Example request
 
 `curl -X POST -H "Content-Type: application/json"  
 -d POSTDATA http://{URL}/v1/projects/EGI/subscriptions/alert_engine:modifyPushConfig?key=S3CR3T"
-```
+`
 
 ### post body:
 ```json
 {
-  "pushConfig": {"pushEndpoint": "host:example.com:8080/path/to/hook"}
+  "pushConfig": {"pushEndpoint": "host:example.com:8080/path/to/hook",
+                 "retryPolicy":  { "type": "linear", "period": 300 }
+  }
 }
 ```
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -51,7 +51,8 @@ func (suite *HandlerTestSuite) TestSubCreate() {
    "name": "/projects/ARGO/subscriptions/subNew",
    "topic": "/projects/ARGO/topics/topic1",
    "pushConfig": {
-      "pushEndpoint": ""
+      "pushEndpoint": "",
+      "retryPolicy": {}
    },
    "ackDeadlineSeconds": 10
 }`
@@ -166,7 +167,8 @@ func (suite *HandlerTestSuite) TestSubListOne() {
    "name": "/projects/ARGO/subscriptions/sub1",
    "topic": "/projects/ARGO/topics/topic1",
    "pushConfig": {
-      "pushEndpoint": ""
+      "pushEndpoint": "",
+      "retryPolicy": {}
    },
    "ackDeadlineSeconds": 10
 }`
@@ -183,6 +185,7 @@ func (suite *HandlerTestSuite) TestSubListOne() {
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
+
 }
 
 func (suite *HandlerTestSuite) TestSubListAll() {
@@ -198,7 +201,8 @@ func (suite *HandlerTestSuite) TestSubListAll() {
          "name": "/projects/ARGO/subscriptions/sub1",
          "topic": "/projects/ARGO/topics/topic1",
          "pushConfig": {
-            "pushEndpoint": ""
+            "pushEndpoint": "",
+            "retryPolicy": {}
          },
          "ackDeadlineSeconds": 10
       },
@@ -206,7 +210,8 @@ func (suite *HandlerTestSuite) TestSubListAll() {
          "name": "/projects/ARGO/subscriptions/sub2",
          "topic": "/projects/ARGO/topics/topic2",
          "pushConfig": {
-            "pushEndpoint": ""
+            "pushEndpoint": "",
+            "retryPolicy": {}
          },
          "ackDeadlineSeconds": 10
       },
@@ -214,7 +219,8 @@ func (suite *HandlerTestSuite) TestSubListAll() {
          "name": "/projects/ARGO/subscriptions/sub3",
          "topic": "/projects/ARGO/topics/topic3",
          "pushConfig": {
-            "pushEndpoint": ""
+            "pushEndpoint": "",
+            "retryPolicy": {}
          },
          "ackDeadlineSeconds": 10
       },
@@ -222,7 +228,11 @@ func (suite *HandlerTestSuite) TestSubListAll() {
          "name": "/projects/ARGO/subscriptions/sub4",
          "topic": "/projects/ARGO/topics/topic4",
          "pushConfig": {
-            "pushEndpoint": "endpoint.foo"
+            "pushEndpoint": "endpoint.foo",
+            "retryPolicy": {
+               "type": "linear",
+               "period": 300
+            }
          },
          "ackDeadlineSeconds": 10
       }
@@ -873,10 +883,12 @@ func (suite *HandlerTestSuite) TestValidationInSubs() {
    "name": "/projects/ARGO/subscriptions/sub1",
    "topic": "/projects/ARGO/topics/topic1",
    "pushConfig": {
-      "pushEndpoint": ""
+      "pushEndpoint": "",
+      "retryPolicy": {}
    },
    "ackDeadlineSeconds": 10
 }`
+
 	invProject := `{
    "error": {
       "code": 400,

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -38,7 +38,7 @@ func (mk *MockStore) UpdateSubOffset(name string, offset int64) {
 }
 
 // ModSubPush modifies the subscription ack
-func (mk *MockStore) ModSubPush(project string, name string, push string) error {
+func (mk *MockStore) ModSubPush(project string, name string, push string, rPolicy string, rPeriod int) error {
 	return nil
 }
 
@@ -92,10 +92,10 @@ func (mk *MockStore) Initialize() {
 	mk.TopicList = append(mk.TopicList, qtop3)
 
 	// populate Subscriptions
-	qsub1 := QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10}
-	qsub2 := QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10}
-	qsub3 := QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10}
-	qsub4 := QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10}
+	qsub1 := QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300}
+	qsub2 := QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300}
+	qsub3 := QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300}
+	qsub4 := QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300}
 	mk.SubList = append(mk.SubList, qsub1)
 	mk.SubList = append(mk.SubList, qsub2)
 	mk.SubList = append(mk.SubList, qsub3)
@@ -182,8 +182,8 @@ func (mk *MockStore) InsertTopic(project string, name string) error {
 }
 
 // InsertSub inserts a new sub object to the store
-func (mk *MockStore) InsertSub(project string, name string, topic string, offset int64, ack int, push string) error {
-	sub := QSub{project, name, topic, offset, 0, "", push, ack}
+func (mk *MockStore) InsertSub(project string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
+	sub := QSub{project, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod}
 	mk.SubList = append(mk.SubList, sub)
 	return nil
 }

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -223,8 +223,8 @@ func (mong *MongoStore) InsertTopic(project string, name string) error {
 }
 
 // InsertSub inserts a subscription to the store
-func (mong *MongoStore) InsertSub(project string, name string, topic string, offset int64, ack int, push string) error {
-	sub := QSub{project, name, topic, offset, 0, "", push, ack}
+func (mong *MongoStore) InsertSub(project string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
+	sub := QSub{project, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod}
 	return mong.InsertResource("subscriptions", sub)
 }
 
@@ -241,11 +241,11 @@ func (mong *MongoStore) RemoveSub(project string, name string) error {
 }
 
 // ModSubPush modifies the push configuration
-func (mong *MongoStore) ModSubPush(project string, name string, push string) error {
+func (mong *MongoStore) ModSubPush(project string, name string, push string, rPolicy string, rPeriod int) error {
 	db := mong.Session.DB(mong.Database)
 	c := db.C("subscriptions")
 
-	err := c.Update(bson.M{"project": project, "name": name}, bson.M{"$set": bson.M{"push_endpoint": push}})
+	err := c.Update(bson.M{"project": project, "name": name}, bson.M{"$set": bson.M{"push_endpoint": push, "retry_policy": rPolicy, "retry_period": rPeriod}})
 	return err
 }
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -10,6 +10,8 @@ type QSub struct {
 	PendingAck   string `bson:"pending_ack"`
 	PushEndpoint string `bson:"push_endpoint"`
 	Ack          int    `bson:"ack"`
+	RetPolicy    string `bson:"retry_policy"`
+	RetPeriod    int    `bson:"retry_period"`
 }
 
 // QUser are the results of the QUser query

--- a/stores/store.go
+++ b/stores/store.go
@@ -8,7 +8,7 @@ type Store interface {
 	RemoveTopic(project string, name string) error
 	RemoveSub(project string, name string) error
 	InsertTopic(project string, name string) error
-	InsertSub(project string, name string, topic string, offest int64, ack int, push string) error
+	InsertSub(project string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
 	HasProject(project string) bool
 	QueryOneSub(project string, sub string) (QSub, error)
 	QueryPushSubs() []QSub
@@ -17,7 +17,7 @@ type Store interface {
 	UpdateSubOffset(name string, offset int64)
 	UpdateSubPull(name string, offset int64, ts string)
 	UpdateSubOffsetAck(name string, offset int64, ts string) error
-	ModSubPush(project string, name string, push string) error
+	ModSubPush(project string, name string, push string, rPolicy string, rPeriod int) error
 	Clone() Store
 	Close()
 }

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -20,10 +20,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 		QTopic{"ARGO", "topic2"},
 		QTopic{"ARGO", "topic3"}}
 
-	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10},
-		QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10},
-		QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10},
-		QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10}}
+	eSubList := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300},
+		QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300},
+		QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300},
+		QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300}}
 
 	suite.Equal(eTopList, store.QueryTopics())
 	suite.Equal(eSubList, store.QuerySubs())
@@ -47,18 +47,18 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
 	store.InsertTopic("ARGO", "topicFresh")
-	store.InsertSub("ARGO", "subFresh", "topicFresh", 0, 10, "")
+	store.InsertSub("ARGO", "subFresh", "topicFresh", 0, 10, "", "linear", 300)
 
 	eTopList2 := []QTopic{QTopic{"ARGO", "topic1"},
 		QTopic{"ARGO", "topic2"},
 		QTopic{"ARGO", "topic3"},
 		QTopic{"ARGO", "topicFresh"}}
 
-	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10},
-		QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10},
-		QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10},
-		QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10},
-		QSub{"ARGO", "subFresh", "topicFresh", 0, 0, "", "", 10}}
+	eSubList2 := []QSub{QSub{"ARGO", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300},
+		QSub{"ARGO", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300},
+		QSub{"ARGO", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300},
+		QSub{"ARGO", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300},
+		QSub{"ARGO", "subFresh", "topicFresh", 0, 0, "", "", 10, "linear", 300}}
 
 	suite.Equal(eTopList2, store.QueryTopics())
 	suite.Equal(eSubList2, store.QuerySubs())


### PR DESCRIPTION
## Goal
Add support for configurable retry policy. If a user changes the retry policy restart the push subscription with the new policy at hand

## Implementation
- [x] Add subscription retry policy information
eg:
```json
{
   "name": "/projects/ARGO/subscriptions/sub1",
   "topic": "/projects/ARGO/topics/topic1",
   "pushConfig": {
      "pushEndpoint": "example.foo",
      "retryPolicy": {
         "type": "linear",
         "period": 300
      }
   },
   "ackDeadlineSeconds": 10
}
```

- [x] modify push mechanism to read policy information
- [x] modify pushers to accept a restart event (along with stop, start)
- [x] update docs, swagger