### PR TITLE
ARGO-490 Fix delete subscription bug

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -423,6 +423,7 @@ func SubModPush(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		refMgr.Stop(project, subName)
+		refMgr.Remove(project, subName)
 	}
 
 	// Write empty response if anything ok


### PR DESCRIPTION
## Issue
Delete subscription caused a null pointer exception in pusher before stopping it

## Fix 
- [x] Check if subscription info object is null and stop
- [x] Remove a pusher when a push subscription stops