### PR TITLE
ARGO-466 ARGO-467 Enable Publish/Pull authorization per topic/subscri…

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -11,11 +11,15 @@ type AuthTestSuite struct {
 	suite.Suite
 }
 
-func (suite *AuthTestSuite) TestMockStore() {
+func (suite *AuthTestSuite) TestAuth() {
 
 	store := stores.NewMockStore("mockhost", "mockbase")
-	suite.Equal([]string{"admin", "member"}, Authenticate("ARGO", "S3CR3T", store))
-	suite.Equal([]string{}, Authenticate("ARGO", "falseSecret", store))
+	authen01, user01 := Authenticate("ARGO", "S3CR3T", store)
+	authen02, user02 := Authenticate("ARGO", "falseSECRET", store)
+	suite.Equal("userA", user01)
+	suite.Equal("", user02)
+	suite.Equal([]string{"admin", "member"}, authen01)
+	suite.Equal([]string{}, authen02)
 
 	suite.Equal(true, Authorize("topics:list_all", []string{"admin"}, store))
 	suite.Equal(true, Authorize("topics:list_all", []string{"admin", "reader"}, store))
@@ -25,6 +29,69 @@ func (suite *AuthTestSuite) TestMockStore() {
 	suite.Equal(true, Authorize("topics:list_all", []string{"admin"}, store))
 	suite.Equal(true, Authorize("topics:list_all", []string{"publisher"}, store))
 	suite.Equal(true, Authorize("topics:publish", []string{"publisher"}, store))
+
+	// Check user authorization per topic
+	//
+	// topic1: userA, userB
+	// topic2: userA, userB, userD
+	// topic3: userC
+
+	// Check authorization per topic for userA
+	suite.Equal(true, PerResource("ARGO", "topic", "topic1", "userA", store))
+	suite.Equal(true, PerResource("ARGO", "topic", "topic2", "userA", store))
+	suite.Equal(false, PerResource("ARGO", "topic", "topic3", "userA", store))
+
+	// Check authorization per topic for userB
+	suite.Equal(true, PerResource("ARGO", "topic", "topic1", "userB", store))
+	suite.Equal(true, PerResource("ARGO", "topic", "topic2", "userB", store))
+	suite.Equal(false, PerResource("ARGO", "topic", "topic3", "userB", store))
+
+	// Check authorization per topic for userC
+	suite.Equal(false, PerResource("ARGO", "topic", "topic1", "userC", store))
+	suite.Equal(false, PerResource("ARGO", "topic", "topic2", "userC", store))
+	suite.Equal(true, PerResource("ARGO", "topic", "topic3", "userC", store))
+
+	// Check authorization per topic for userD
+	suite.Equal(false, PerResource("ARGO", "topic", "topic1", "userD", store))
+	suite.Equal(true, PerResource("ARGO", "topic", "topic2", "userD", store))
+	suite.Equal(false, PerResource("ARGO", "topic", "topic3", "userD", store))
+
+	// Check user authorization per subscription
+	//
+	// sub1: userA, userB
+	// sub2: userA, userC
+	// sub3: userA, userB, userD
+	// sub4: userB, userD
+
+	// Check authorization per subscription for userA
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub1", "userA", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub2", "userA", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub3", "userA", store))
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub4", "userA", store))
+
+	// Check authorization per subscription for userB
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub1", "userB", store))
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub2", "userB", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub3", "userB", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub4", "userB", store))
+	// Check authorization per subscription for userC
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub1", "userC", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub2", "userC", store))
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub3", "userC", store))
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub4", "userC", store))
+	// Check authorization per subscription for userD
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub1", "userD", store))
+	suite.Equal(false, PerResource("ARGO", "subscription", "sub2", "userD", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub3", "userD", store))
+	suite.Equal(true, PerResource("ARGO", "subscription", "sub4", "userD", store))
+
+	suite.Equal(true, IsConsumer([]string{"consumer"}))
+	suite.Equal(true, IsConsumer([]string{"consumer", "publisher"}))
+	suite.Equal(false, IsConsumer([]string{"publisher"}))
+
+	suite.Equal(false, IsPublisher([]string{"consumer"}))
+	suite.Equal(true, IsPublisher([]string{"consumer", "publisher"}))
+	suite.Equal(true, IsPublisher([]string{"publisher"}))
 
 }
 

--- a/auth/users.go
+++ b/auth/users.go
@@ -1,6 +1,10 @@
 package auth
 
-import "github.com/ARGOeu/argo-messaging/stores"
+import (
+	"github.com/ARGOeu/argo-messaging/stores"
+	"github.com/ARGOeu/argo-messaging/subscriptions"
+	"github.com/ARGOeu/argo-messaging/topics"
+)
 
 // User is the struct that holds user information
 type User struct {
@@ -17,8 +21,52 @@ type Users struct {
 }
 
 // Authenticate based on token
-func Authenticate(project string, token string, store stores.Store) []string {
-	return store.GetUserRoles(project, token)
+func Authenticate(project string, token string, store stores.Store) ([]string, string) {
+	roles, user := store.GetUserRoles(project, token)
+	return roles, user
+}
+
+// IsPublisher Checks if a user is publisher
+func IsPublisher(roles []string) bool {
+	for _, role := range roles {
+		if role == "publisher" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsConsumer Checks if a user is consumer
+func IsConsumer(roles []string) bool {
+	for _, role := range roles {
+		if role == "consumer" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// PerResource  (for topics and subscriptions)
+func PerResource(project string, resType string, resName string, user string, store stores.Store) bool {
+	if resType == "topic" {
+		tACL := topics.GetTopicACL(project, resName, store)
+		for _, item := range tACL.AuthUsers {
+			if item == user {
+				return true
+			}
+		}
+	} else if resType == "subscription" {
+		sACL := subscriptions.GetSubACL(project, resName, store)
+		for _, item := range sACL.AuthUsers {
+			if item == user {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // Authorize based on resource and  role information

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type APICfg struct {
 	StoreDB   string
 	Cert      string
 	CertKey   string
+	ResAuth   bool
 }
 
 // NewAPICfg creates a new kafka configuration object
@@ -100,6 +101,8 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
 	cfg.CertKey = viper.GetString("certificate_key")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
+	cfg.ResAuth = viper.GetBool("per_resource_auth")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - per_resource_auth", cfg.CertKey)
 
 }
 
@@ -122,5 +125,7 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
 	cfg.CertKey = viper.GetString("certificate_key")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
+	cfg.ResAuth = viper.GetBool("per_resource_auth")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - per_resource_auth", cfg.CertKey)
 
 }

--- a/config/config.json
+++ b/config/config.json
@@ -5,5 +5,6 @@
   "store_host":"localhost",
   "store_db":"argo_msg",
   "certificate":"/etc/pki/tls/certs/localhost.crt",
-  "certificate_key":"/etc/pki/tls/private/localhost.key"
+  "certificate_key":"/etc/pki/tls/private/localhost.key",
+  "per_resource_auth":"true"
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,8 @@ func (suite *ConfigTestSuite) SetupTest() {
 		"store_host":"localhost",
 		"store_db":"argo_msg",
 		"certificate":"/etc/pki/tls/certs/localhost.crt",
-		"certificate_key":"/etc/pki/tls/private/localhost.key"
+		"certificate_key":"/etc/pki/tls/private/localhost.key",
+		"per_resource_auth":"true"
 	}`
 
 	log.SetOutput(ioutil.Discard)
@@ -45,6 +46,7 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	suite.Equal("", APIcfg.BindIP)
 	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
 	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
+	suite.Equal(true, APIcfg.ResAuth)
 }
 
 func (suite *ConfigTestSuite) TestLoadStringJSON() {
@@ -57,6 +59,7 @@ func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	suite.Equal("", APIcfg.BindIP)
 	suite.Equal("/etc/pki/tls/certs/localhost.crt", APIcfg.Cert)
 	suite.Equal("/etc/pki/tls/private/localhost.key", APIcfg.CertKey)
+	suite.Equal(true, APIcfg.ResAuth)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -21,7 +21,8 @@ The ARGO Messaging Service main configuration file is config.json. An example co
   "store_host":"localhost",
   "store_db":"argo_msg",
   "certificate":"/etc/pki/tls/certs/localhost.crt",
-  "certificate_key":"/etc/pki/tls/private/localhost.key"
+  "certificate_key":"/etc/pki/tls/private/localhost.key",
+  "per_resource_auth":true
 }
 ```
 
@@ -31,10 +32,11 @@ Parameter | Description
 --------- | -----------
 bind_ip | the ip address to listen to.
 port | The port where the API will listen to
-zookeeper_hosts | List of zookeeper instances that are used to sync kafka 
+zookeeper_hosts | List of zookeeper instances that are used to sync kafka
 store_host | Address:port of the datastore server
 store_db | Database name used on the datastore server
 certificate | path to the node's TLS certificate file
 certificate_key | path to the certificate's private key
+per_resource_auth | enable authorization per resource (topic/subscription)
 
 **Location of config.json**: API will look first for config.json locally in the folder where the executable runs and then in the ` /etc/argo-messaging/`  location.

--- a/doc/v1/docs/auth.md
+++ b/doc/v1/docs/auth.md
@@ -75,3 +75,15 @@ subscriptions:create | Allow user to create a new subscription when using `PUT /
 subscriptions:delete | Allow user to delete an existing subscription when using `DELETE /projects/PROJECT_A/subscriptions/SUB_A`
 subscriptions:pull | Allow user to pull messages from a subscription when using `POST /projects/PROJECT_A/subscriptions/SUB_A:pull`
 subscriptions:acknowledge | Allow user to acknowledge messages that has pulled when using `POST /projects/PROJECT_A/subscriptions/SUB_A:acknowledge`
+
+# Per Resource Authorization
+
+Messaging API provides the option to control in finer detail access on resources such as topics and subscriptions for users(clients) that are producers or subscribers. Each resource (topic/subscription) comes with an access list (ACL) that contains producers or subscribers that are eligible to use that resource (when publishing or pulling messages respectively). Users with the admin role are able to modify Access lists for topics and subscriptions on the project they belong. In order for the feature to be available Messaging API should have the config parameter `per_resource_auth` set to `true`
+
+# List ACL of a given topic
+
+# Modify ACL of a given topic
+
+# List ACL of a given subscription
+
+# Modify ACL of a given subscription

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -24,13 +24,14 @@ type HandlerTestSuite struct {
 
 func (suite *HandlerTestSuite) SetupTest() {
 	suite.cfgStr = `{
-	  "port":8080,
-		"broker_hosts":["localhost:9092"],
-		"store_host":"localhost",
-		"store_db":"argo_msg",
-		"use_authorization":true,
-		"use_authentication":true,
-		"use_ack":true
+	"bind_ip":"",
+	"port":8080,
+	"zookeeper_hosts":["localhost"],
+	"store_host":"localhost",
+	"store_db":"argo_msg",
+	"certificate":"/etc/pki/tls/certs/localhost.crt",
+	"certificate_key":"/etc/pki/tls/private/localhost.key",
+	"per_resource_auth":"true"
 	}`
 
 	log.SetOutput(ioutil.Discard)
@@ -491,7 +492,7 @@ func (suite *HandlerTestSuite) TestPublish() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapMockAuthConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expJSON, w.Body.String())
@@ -550,7 +551,7 @@ func (suite *HandlerTestSuite) TestPublishMultiple() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapMockAuthConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expJSON, w.Body.String())
@@ -599,7 +600,7 @@ func (suite *HandlerTestSuite) TestPublishError() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapMockAuthConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(400, w.Code)
 	suite.Equal(expJSON, w.Body.String())
@@ -651,7 +652,7 @@ func (suite *HandlerTestSuite) TestPublishNoTopic() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:publish", WrapMockAuthConfig(TopicPublish, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expJSON, w.Body.String())
@@ -694,7 +695,7 @@ func (suite *HandlerTestSuite) TestSubPullOne() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:pull", WrapConfig(SubPull, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:pull", WrapMockAuthConfig(SubPull, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expJSON, w.Body.String())
@@ -812,7 +813,7 @@ func (suite *HandlerTestSuite) TestSubError() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:pull", WrapConfig(SubPull, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:pull", WrapMockAuthConfig(SubPull, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expJSON, w.Body.String())
@@ -877,7 +878,7 @@ func (suite *HandlerTestSuite) TestSubPullAll() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:pull", WrapConfig(SubPull, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:pull", WrapMockAuthConfig(SubPull, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expJSON, w.Body.String())

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -14,6 +14,11 @@ type QSub struct {
 	RetPeriod    int    `bson:"retry_period"`
 }
 
+// QAcl holds a list of authorized users queried from topic or subscription collections
+type QAcl struct {
+	ACL []string `bson:"acl"`
+}
+
 // QUser are the results of the QUser query
 type QUser struct {
 	Name    string   `bson:"name"`

--- a/stores/store.go
+++ b/stores/store.go
@@ -13,11 +13,12 @@ type Store interface {
 	QueryOneSub(project string, sub string) (QSub, error)
 	QueryPushSubs() []QSub
 	HasResourceRoles(resource string, roles []string) bool
-	GetUserRoles(project string, token string) []string
+	GetUserRoles(project string, token string) ([]string, string)
 	UpdateSubOffset(name string, offset int64)
 	UpdateSubPull(name string, offset int64, ts string)
 	UpdateSubOffsetAck(name string, offset int64, ts string) error
 	ModSubPush(project string, name string, push string, rPolicy string, rPeriod int) error
+	QueryACL(project string, resource string, name string) (QAcl, error)
 	Clone() Store
 	Close()
 }

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -50,6 +50,27 @@ type AckIDs struct {
 	IDs []string `json:"AckIds"`
 }
 
+// SubACL holds the authorized users for a topic
+type SubACL struct {
+	AuthUsers []string `json:"authorized_users"`
+}
+
+// GetSubACL returns an authorized list of users for the topic
+func GetSubACL(project string, sub string, store stores.Store) SubACL {
+	subACL, _ := store.QueryACL(project, "subscription", sub)
+	result := SubACL{}
+	for _, item := range subACL.ACL {
+		result.AuthUsers = append(result.AuthUsers, item)
+	}
+	return result
+}
+
+// ExportJSON export subscription acl body to json for use in http response
+func (sAcl *SubACL) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(sAcl, "", "   ")
+	return string(output[:]), err
+}
+
 // GetAckFromJSON retrieves ack ids from json
 func GetAckFromJSON(input []byte) (AckIDs, error) {
 	s := AckIDs{}

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -14,6 +14,11 @@ type Topic struct {
 	FullName string `json:"name"`
 }
 
+// TopicACL holds the authorized users for a topic
+type TopicACL struct {
+	AuthUsers []string `json:"authorized_users"`
+}
+
 // Topics holds a list of Topic items
 type Topics struct {
 	List []Topic `json:"topics,omitempty"`
@@ -50,6 +55,22 @@ func (tl *Topics) LoadFromStore(store stores.Store) {
 // ExportJSON exports whole Topic Structure as a json string
 func (tp *Topic) ExportJSON() (string, error) {
 	output, err := json.MarshalIndent(tp, "", "   ")
+	return string(output[:]), err
+}
+
+// GetTopicACL returns an authorized list of users for the topic
+func GetTopicACL(project string, topic string, store stores.Store) TopicACL {
+	topicACL, _ := store.QueryACL(project, "topic", topic)
+	result := TopicACL{}
+	for _, item := range topicACL.ACL {
+		result.AuthUsers = append(result.AuthUsers, item)
+	}
+	return result
+}
+
+// ExportJSON export topic acl body to json for use in http response
+func (tAcl *TopicACL) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(tAcl, "", "   ")
 	return string(output[:]), err
 }
 

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -129,6 +129,46 @@ func (suite *TopicTestSuite) TestExportJson() {
 
 }
 
+func (suite *TopicTestSuite) TestTopicACL() {
+	expJSON01 := `{
+   "authorized_users": [
+      "userA",
+      "userB"
+   ]
+}`
+
+	expJSON02 := `{
+   "authorized_users": [
+      "userA",
+      "userB",
+      "userD"
+   ]
+}`
+
+	expJSON03 := `{
+   "authorized_users": [
+      "userC"
+   ]
+}`
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+
+	tACL := GetTopicACL("ARGO", "topic1", store)
+	outJSON, _ := tACL.ExportJSON()
+	suite.Equal(expJSON01, outJSON)
+
+	tACL2 := GetTopicACL("ARGO", "topic2", store)
+	outJSON2, _ := tACL2.ExportJSON()
+	suite.Equal(expJSON02, outJSON2)
+
+	tACL3 := GetTopicACL("ARGO", "topic3", store)
+	outJSON3, _ := tACL3.ExportJSON()
+	suite.Equal(expJSON03, outJSON3)
+
+}
+
 func TestTopicsTestSuite(t *testing.T) {
 	suite.Run(t, new(TopicTestSuite))
 }


### PR DESCRIPTION
…ption

# Goal
Enable per topic and per subscription access when publishing/consuming.

# Implementation
- [x] Add ACL support for topics and subscription in the store package
- [x] Add ACL support in topic/subscription packages
- [x] Add PerResource Authorization on auth package
- [x] User PerResource Authorization in topic:publish handler and subscription:pull handler
- [x] Add config parameter `per_resource_auth` in config to globally enable/disable the mechanism 
- [x] Update/Add unit tests
- [x] Update Doc