### PR TITLE
ARGO-468 Allow admins to list and modify acls

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -51,14 +51,14 @@ func IsConsumer(roles []string) bool {
 // PerResource  (for topics and subscriptions)
 func PerResource(project string, resType string, resName string, user string, store stores.Store) bool {
 	if resType == "topic" {
-		tACL := topics.GetTopicACL(project, resName, store)
+		tACL, _ := topics.GetTopicACL(project, resName, store)
 		for _, item := range tACL.AuthUsers {
 			if item == user {
 				return true
 			}
 		}
 	} else if resType == "subscription" {
-		sACL := subscriptions.GetSubACL(project, resName, store)
+		sACL, _ := subscriptions.GetSubACL(project, resName, store)
 		for _, item := range sACL.AuthUsers {
 			if item == user {
 				return true

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -168,6 +168,82 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:acl:
+    get:
+      summary: List ACL of a given subscription
+      description: |
+        Show a list of authorized consumers on the given subscription
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the Subscription
+          required: true
+          type: string
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: An array of authorized users
+          schema:
+            $ref: '#/definitions/AuthUsers'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyAcl:
+    get:
+      summary: Modify ACL of a given subscription
+      description: |
+        Modify the list of authorized consumers on a subscription
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the subscription
+          required: true
+          type: string
+        - name: Authorized_users
+          in: body
+          description: List of authorized users
+          required: true
+          schema:
+           $ref: '#/definitions/AuthUsers'
+      tags:
+        - Topics
+      responses:
+        200:
+          description: An empty response if Authorized User list is succesfully updated
+          schema:
+            $ref: '#/definitions/AuthUsers'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
 
 
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:pull:
@@ -480,6 +556,82 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}/topics/{TOPIC}:acl:
+    get:
+      summary: List ACL of a given topic
+      description: |
+        Show a list of authorized producers on the given topic
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: TOPIC
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+      tags:
+        - Topics
+      responses:
+        200:
+          description: An array of authorized users
+          schema:
+            $ref: '#/definitions/AuthUsers'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+  /projects/{PROJECT}/topics/{TOPIC}:modifyAcl:
+    get:
+      summary: Modify ACL of a given topic
+      description: |
+        Modify the list of authorized producers on a topic
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: TOPIC
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+        - name: Authorized_users
+          in: body
+          description: List of authorized users
+          required: true
+          schema:
+           $ref: '#/definitions/AuthUsers'
+      tags:
+        - Topics
+      responses:
+        200:
+          description: An empty response if Authorized User list is succesfully updated
+          schema:
+            $ref: '#/definitions/AuthUsers'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
 parameters:
   ApiKey:
     name: key
@@ -520,6 +672,15 @@ responses:
       $ref: '#/definitions/ErrorMsg'
 
 definitions:
+
+  AuthUsers:
+    type: object
+    properties:
+      auth_users:
+        type: array
+        items:
+         type: string
+
   PullOptions:
     type: object
     properties:

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -73,6 +73,36 @@ Success Response
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+## [GET] Manage Subscriptions - Get a subscription's list of authorized users
+This request returns a list of authorized users to consume from the subscription
+
+### Request
+`GET /v1/projects/{project_name}/subscriptions/{sub_name}:acl``
+
+### Where
+- Project_name: Name of the project to get
+- Sub_name: The subscription name
+
+### Example request
+
+```json
+curl -H "Content-Type: application/json"  
+-d '' " https://{URL}/v1/projects/EGI/subscriptions/subscription:acl?key=S3CR3T"`
+```
+
+### Responses  
+
+Success Response
+`200 OK`
+```json
+{
+ "authorized_users": ["userC","userD"]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 
 ## [DELETE] Manage Subscriptions - Delete Subscriptions
 This request deletes a topic in a project with a DELETE request

--- a/doc/v1/docs/auth.md
+++ b/doc/v1/docs/auth.md
@@ -81,9 +81,152 @@ subscriptions:acknowledge | Allow user to acknowledge messages that has pulled w
 Messaging API provides the option to control in finer detail access on resources such as topics and subscriptions for users(clients) that are producers or subscribers. Each resource (topic/subscription) comes with an access list (ACL) that contains producers or subscribers that are eligible to use that resource (when publishing or pulling messages respectively). Users with the admin role are able to modify Access lists for topics and subscriptions on the project they belong. In order for the feature to be available Messaging API should have the config parameter `per_resource_auth` set to `true`
 
 # List ACL of a given topic
+The following request returns a list of authorized users (publishers) of a given topic
+
+### Request
+`GET /v1/projects/{project_name}/topics/{topic_name}:acl`
+
+### Where
+- Project_name: name of the project
+- topic_name: name of the topic
+
+
+
+### Example request
+
+```
+json
+curl -X POST -H "Content-Type: application/json"  
+-d { POSTDATA } https://{URL}/v1/projects/EGI/topics/monitoring:acl?key=S3CR3T"`
+```
+
+### Responses  
+
+Success Response
+`200 OK`
+```
+json
+{
+ "authorized_users": [
+  "UserA","UserB"
+ ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+
 
 # Modify ACL of a given topic
+The following request Modifies the authorized users list of a given topic
+
+### Request
+`POST /v1/projects/{project_name}/topics/{topic_name}:modifyAcl`
+
+### Where
+- Project_name: Name of the project
+- topic_name: name of the topic
+
+
+### Post data
+```
+json
+{
+"authorized_users": [
+ "UserX","UserY"
+]
+}
+```
+
+### Example request
+
+```
+json
+curl -X POST -H "Content-Type: application/json"  
+-d { POSTDATA } https://{URL}/v1/projects/EGI/topics/monitoring:modifyAcl?key=S3CR3T"`
+```
+
+### Responses  
+
+Success Response
+`200 OK`
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 
 # List ACL of a given subscription
+The following request returns a list of authorized users for a given subscription
+
+### Request
+`GET /v1/projects/{project_name}/subscriptions/{sub_name}:acl`
+
+### Where
+- Project_name: Name of the project
+- sub_name: name of the subscription
+
+
+
+### Example request
+
+```
+json
+curl -X POST -H "Content-Type: application/json"  
+-d { POSTDATA } https://{URL}/v1/projects/EGI/subscriptions/monitoring:acl?key=S3CR3T"`
+```
+
+### Responses  
+
+Success Response
+`200 OK`
+```
+json
+{
+ "authorized_users": [
+  "UserA","UserB"
+ ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 
 # Modify ACL of a given subscription
+
+The following request Modifies the authorized users list of a given subscription
+
+### Request
+`POST /v1/projects/{project_name}/subscriptions/{sub_name}:modifyAcl`
+
+### Where
+- Project_name: Name of the project
+- sub_name: name of the subpscription
+
+
+### Post data
+```
+json
+{
+"authorized_users": [
+ "UserX","UserY"
+]
+}
+```
+
+### Example request
+
+```
+json
+curl -X POST -H "Content-Type: application/json"  
+-d { POSTDATA } https://{URL}/v1/projects/EGI/subscriptions/monitoring:modifyAcl?key=S3CR3T"`
+```
+
+### Responses  
+
+Success Response
+`200 OK`
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/handlers.go
+++ b/handlers.go
@@ -359,6 +359,110 @@ func SubDelete(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// TopicModACL (PUT) modifies the ACL
+func TopicModACL(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+	urlVars := mux.Vars(r)
+
+	// Read POST JSON body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		respondErr(w, 500, "Bad Request body", "BAD_REQUEST")
+		return
+	}
+
+	// Parse pull options
+	postBody, err := topics.GetACLFromJSON(body)
+	if err != nil {
+		respondErr(w, 400, "Invalid Subscription ACL Arguments", "INVALID_ARGUMENT")
+		return
+	}
+
+	// Grab context references
+	refStr := context.Get(r, "str").(stores.Store)
+
+	// Get Result Object
+	subName := urlVars["topic"]
+	project := urlVars["project"]
+
+	err = topics.ModACL(project, subName, postBody.AuthUsers, refStr)
+
+	if err != nil {
+
+		if err.Error() == "not found" {
+			respondErr(w, 404, "Topic doesn't exist", "NOT_FOUND")
+			return
+		}
+
+		respondErr(w, 500, err.Error(), "INTERNAL")
+		return
+	}
+
+	respondOK(w, output)
+
+}
+
+// SubModACL (PUT) modifies the ACL
+func SubModACL(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+	urlVars := mux.Vars(r)
+
+	// Read POST JSON body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		respondErr(w, 500, "Bad Request body", "BAD_REQUEST")
+		return
+	}
+
+	// Parse pull options
+	postBody, err := subscriptions.GetACLFromJSON(body)
+	if err != nil {
+		respondErr(w, 400, "Invalid Subscription ACL Arguments", "INVALID_ARGUMENT")
+		return
+	}
+
+	// Grab context references
+	refStr := context.Get(r, "str").(stores.Store)
+
+	// Get Result Object
+	subName := urlVars["subscription"]
+	project := urlVars["project"]
+
+	err = subscriptions.ModACL(project, subName, postBody.AuthUsers, refStr)
+
+	if err != nil {
+
+		if err.Error() == "not found" {
+			respondErr(w, 404, "Subscription doesn't exist", "NOT_FOUND")
+			return
+		}
+
+		respondErr(w, 500, err.Error(), "INTERNAL")
+		return
+	}
+
+	respondOK(w, output)
+
+}
+
 // SubModPush (PUT) modifies the push configuration
 func SubModPush(w http.ResponseWriter, r *http.Request) {
 
@@ -625,6 +729,84 @@ func TopicListOne(w http.ResponseWriter, r *http.Request) {
 	// If not found
 	if res.Name == "" {
 		respondErr(w, 404, "Topic does not exist", "NOT_FOUND")
+		return
+	}
+
+	// Output result to JSON
+	resJSON, err := res.ExportJSON()
+	if err != nil {
+		respondErr(w, 500, "Error exporting data to JSON", "INTERNAL")
+		return
+	}
+
+	// Write response
+	output = []byte(resJSON)
+	respondOK(w, output)
+
+}
+
+// TopicACL (GET) one topic's authorized users
+func TopicACL(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+	urlVars := mux.Vars(r)
+
+	// Grab context references
+	refStr := context.Get(r, "str").(stores.Store)
+
+	// Get Result Object
+	res, err := topics.GetTopicACL(urlVars["project"], urlVars["topic"], refStr)
+
+	// If not found
+	if err != nil {
+		respondErr(w, 404, "Topic does not exist", "NOT_FOUND")
+		return
+	}
+
+	// Output result to JSON
+	resJSON, err := res.ExportJSON()
+	if err != nil {
+		respondErr(w, 500, "Error exporting data to JSON", "INTERNAL")
+		return
+	}
+
+	// Write response
+	output = []byte(resJSON)
+	respondOK(w, output)
+
+}
+
+// SubACL (GET) one topic's authorized users
+func SubACL(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+	urlVars := mux.Vars(r)
+
+	// Grab context references
+	refStr := context.Get(r, "str").(stores.Store)
+
+	// Get Result Object
+	res, err := subscriptions.GetSubACL(urlVars["project"], urlVars["subscription"], refStr)
+
+	// If not found
+	if err != nil {
+		respondErr(w, 404, "Subscription does not exist", "NOT_FOUND")
 		return
 	}
 

--- a/routing.go
+++ b/routing.go
@@ -71,9 +71,13 @@ var defaultRoutes = []APIRoute{
 	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
 	{"subscriptions:acknowledge", "POST", "/projects/{project}/subscriptions/{subscription}:acknowledge", SubAck},
 	{"subscriptions:modifyPushConfig", "POST", "/projects/{project}/subscriptions/{subscription}:modifyPushConfig", SubModPush},
+	{"subscriptions:acl", "GET", "/projects/{project}/subscriptions/{subscription}:acl", SubACL},
+	{"subscriptions:modifyAcl", "POST", "/projects/{project}/subscriptions/{subscription}:acl", SubACL},
 	{"topics:list", "GET", "/projects/{project}/topics", TopicListAll},
 	{"topics:show", "GET", "/projects/{project}/topics/{topic}", TopicListOne},
 	{"topics:create", "PUT", "/projects/{project}/topics/{topic}", TopicCreate},
 	{"topics:delete", "DELETE", "/projects/{project}/topics/{topic}", TopicDelete},
 	{"topics:publish", "POST", "/projects/{project}/topics/{topic}:publish", TopicPublish},
+	{"topics:acl", "GET", "/projects/{project}/topics/{topic}:acl", TopicACL},
+	{"topics:modifyAcl", "POST", "/projects/{project}/topics/{topic}:modifyAcl", TopicModACL},
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -49,6 +49,24 @@ func (mk *MockStore) Close() {
 	mk.Session = false
 }
 
+// ModACL changes the acl in a function
+func (mk *MockStore) ModACL(project string, resource string, name string, acl []string) error {
+	newAcl := QAcl{ACL: acl}
+	if resource == "topics" {
+		if _, exists := mk.TopicsACL[name]; exists {
+			mk.TopicsACL[name] = newAcl
+			return nil
+		}
+	} else if resource == "subscriptions" {
+		if _, exists := mk.SubsACL[name]; exists {
+			mk.SubsACL[name] = newAcl
+			return nil
+		}
+	}
+
+	return errors.New("not found")
+}
+
 // UpdateSubOffset updates the offset of the current subscription
 func (mk *MockStore) UpdateSubOffset(name string, offset int64) {
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -145,7 +145,7 @@ func (mong *MongoStore) QueryACL(project string, resource string, name string) (
 		return results[0], nil
 	}
 
-	return QAcl{}, errors.New("empty")
+	return QAcl{}, errors.New("not found")
 }
 
 // QueryTopics Query Subscription info from store
@@ -263,6 +263,14 @@ func (mong *MongoStore) RemoveTopic(project string, name string) error {
 func (mong *MongoStore) RemoveSub(project string, name string) error {
 	sub := bson.M{"project": project, "name": name}
 	return mong.RemoveResource("subscriptions", sub)
+}
+
+// ModACL modifies the push configuration
+func (mong *MongoStore) ModACL(project string, resource string, name string, acl []string) error {
+	db := mong.Session.DB(mong.Database)
+	c := db.C(resource)
+	err := c.Update(bson.M{"project": project, "name": name}, bson.M{"$set": bson.M{"acl": acl}})
+	return err
 }
 
 // ModSubPush modifies the push configuration

--- a/stores/store.go
+++ b/stores/store.go
@@ -19,6 +19,7 @@ type Store interface {
 	UpdateSubOffsetAck(name string, offset int64, ts string) error
 	ModSubPush(project string, name string, push string, rPolicy string, rPeriod int) error
 	QueryACL(project string, resource string, name string) (QAcl, error)
+	ModACL(project string, resource string, name string, acl []string) error
 	Clone() Store
 	Close()
 }

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -56,13 +56,28 @@ type SubACL struct {
 }
 
 // GetSubACL returns an authorized list of users for the topic
-func GetSubACL(project string, sub string, store stores.Store) SubACL {
-	subACL, _ := store.QueryACL(project, "subscription", sub)
+func GetSubACL(project string, sub string, store stores.Store) (SubACL, error) {
 	result := SubACL{}
+	subACL, err := store.QueryACL(project, "subscription", sub)
+	if err != nil {
+		return result, err
+	}
 	for _, item := range subACL.ACL {
 		result.AuthUsers = append(result.AuthUsers, item)
 	}
-	return result
+	return result, nil
+}
+
+// GetACLFromJSON retrieves SubACL info from JSON
+func GetACLFromJSON(input []byte) (SubACL, error) {
+	s := SubACL{}
+	err := json.Unmarshal([]byte(input), &s)
+	return s, err
+}
+
+// ModACL is called to modify a sub's acl
+func ModACL(project string, name string, acl []string, store stores.Store) error {
+	return store.ModACL(project, "subscriptions", name, acl)
 }
 
 // ExportJSON export subscription acl body to json for use in http response

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -301,19 +301,19 @@ func (suite *SubTestSuite) TestSubACL() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	sACL := GetSubACL("ARGO", "sub1", store)
+	sACL, _ := GetSubACL("ARGO", "sub1", store)
 	outJSON, _ := sACL.ExportJSON()
 	suite.Equal(expJSON01, outJSON)
 
-	sACL2 := GetSubACL("ARGO", "sub2", store)
+	sACL2, _ := GetSubACL("ARGO", "sub2", store)
 	outJSON2, _ := sACL2.ExportJSON()
 	suite.Equal(expJSON02, outJSON2)
 
-	sACL3 := GetSubACL("ARGO", "sub3", store)
+	sACL3, _ := GetSubACL("ARGO", "sub3", store)
 	outJSON3, _ := sACL3.ExportJSON()
 	suite.Equal(expJSON03, outJSON3)
 
-	sACL4 := GetSubACL("ARGO", "sub4", store)
+	sACL4, _ := GetSubACL("ARGO", "sub4", store)
 	outJSON4, _ := sACL4.ExportJSON()
 	suite.Equal(expJSON04, outJSON4)
 

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -59,13 +59,28 @@ func (tp *Topic) ExportJSON() (string, error) {
 }
 
 // GetTopicACL returns an authorized list of users for the topic
-func GetTopicACL(project string, topic string, store stores.Store) TopicACL {
-	topicACL, _ := store.QueryACL(project, "topic", topic)
+func GetTopicACL(project string, topic string, store stores.Store) (TopicACL, error) {
 	result := TopicACL{}
+	topicACL, err := store.QueryACL(project, "topic", topic)
+	if err != nil {
+		return result, err
+	}
 	for _, item := range topicACL.ACL {
 		result.AuthUsers = append(result.AuthUsers, item)
 	}
-	return result
+	return result, err
+}
+
+// GetACLFromJSON retrieves TopicACL info from JSON
+func GetACLFromJSON(input []byte) (TopicACL, error) {
+	s := TopicACL{}
+	err := json.Unmarshal([]byte(input), &s)
+	return s, err
+}
+
+// ModACL is called to modify a topic's acl
+func ModACL(project string, name string, acl []string, store stores.Store) error {
+	return store.ModACL(project, "topics", name, acl)
 }
 
 // ExportJSON export topic acl body to json for use in http response

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -155,15 +155,15 @@ func (suite *TopicTestSuite) TestTopicACL() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	tACL := GetTopicACL("ARGO", "topic1", store)
+	tACL, _ := GetTopicACL("ARGO", "topic1", store)
 	outJSON, _ := tACL.ExportJSON()
 	suite.Equal(expJSON01, outJSON)
 
-	tACL2 := GetTopicACL("ARGO", "topic2", store)
+	tACL2, _ := GetTopicACL("ARGO", "topic2", store)
 	outJSON2, _ := tACL2.ExportJSON()
 	suite.Equal(expJSON02, outJSON2)
 
-	tACL3 := GetTopicACL("ARGO", "topic3", store)
+	tACL3, _ := GetTopicACL("ARGO", "topic3", store)
 	outJSON3, _ := tACL3.ExportJSON()
 	suite.Equal(expJSON03, outJSON3)
 


### PR DESCRIPTION
# Goal
Implement requests to list and edit acls on resources (topics/subscriptions)

# Implementation
- [x] Implement `topic:acl` request to list authorized publishers
 - [x] update swagger and docs
 - [x] add unit tests
- [x] Implement `subscription:acl` request to list authorized consumers
 - [x] update swagger and docs
 - [x] add unit tests
- [x] Implement `topic:modifyAcl` request 
- [x] Implement `subscription:modifyAcl` request