### PR TITLE
ARGO-472 Fix push ack http status code from 101 to 102

### DIFF
--- a/push/sender.go
+++ b/push/sender.go
@@ -44,7 +44,7 @@ func (hs *HTTPSender) Send(msg string, endpoint string) error {
 	resp, err := hs.Client.Do(req)
 
 	if err == nil {
-		if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 204 && resp.StatusCode != 101 {
+		if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 204 && resp.StatusCode != 102 {
 			err = errors.New("Endpoint Responded: not delivered")
 		}
 		log.Println("message Delivered")


### PR DESCRIPTION
### Issue
Should accept http status code = 102 as valid ack (instead of 101)