### PR TITLE
ARGO-505 Check user existence before modifying topic ACL

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -3,8 +3,8 @@ package auth
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
 	"github.com/ARGOeu/argo-messaging/stores"
+	"github.com/stretchr/testify/suite"
 )
 
 type AuthTestSuite struct {
@@ -92,6 +92,16 @@ func (suite *AuthTestSuite) TestAuth() {
 	suite.Equal(false, IsPublisher([]string{"consumer"}))
 	suite.Equal(true, IsPublisher([]string{"consumer", "publisher"}))
 	suite.Equal(true, IsPublisher([]string{"publisher"}))
+
+	// Check ValidUsers mechanism
+	v, err := AreValidUsers("ARGO", []string{"UserA", "foo", "bar"}, store)
+	suite.Equal(false, v)
+	suite.Equal("User(s): foo, bar do not exist", err.Error())
+
+	// Check ValidUsers mechanism
+	v, err = AreValidUsers("ARGO", []string{"UserA", "UserB"}, store)
+	suite.Equal(true, v)
+	suite.Equal(nil, err)
 
 }
 

--- a/auth/users.go
+++ b/auth/users.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"errors"
+
 	"github.com/ARGOeu/argo-messaging/stores"
 	"github.com/ARGOeu/argo-messaging/subscriptions"
 	"github.com/ARGOeu/argo-messaging/topics"
@@ -46,6 +48,27 @@ func IsConsumer(roles []string) bool {
 	}
 
 	return false
+}
+
+// AreValidUsers accepts a user array of usernames and checks if users exist in the store
+func AreValidUsers(project string, users []string, store stores.Store) (bool, error) {
+	found, notFound := store.HasUsers(project, users)
+	if found {
+		return true, nil
+	}
+
+	var list string
+
+	for i, username := range notFound {
+		if i == 0 {
+			list = list + username
+		} else {
+			list = list + ", " + username
+		}
+
+	}
+	return false, errors.New("User(s): " + list + " do not exist")
+
 }
 
 // PerResource  (for topics and subscriptions)

--- a/doc/v1/docs/auth.md
+++ b/doc/v1/docs/auth.md
@@ -139,6 +139,18 @@ Success Response
 `200 OK`
 
 ### Errors
+If the to-be updated ACL contains users that are non-existent in the project the API returns the following error:
+`404 NOT_FOUND`
+```
+{
+   "error": {
+      "code": 404,
+      "message": "User(s): UserFoo1,UserFoo2 do not exist",
+      "status": "NOT_FOUND"
+   }
+}
+```
+
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
 
@@ -207,4 +219,16 @@ Success Response
 `200 OK`
 
 ### Errors
+If the to-be updated ACL contains users that are non-existent in the project the API returns the following error:
+`404 NOT_FOUND`
+```
+{
+   "error": {
+      "code": 404,
+      "message": "User(s): UserFoo1,UserFoo2 do not exist",
+      "status": "NOT_FOUND"
+   }
+}
+```
+
 Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/handlers.go
+++ b/handlers.go
@@ -394,6 +394,13 @@ func TopicModACL(w http.ResponseWriter, r *http.Request) {
 	subName := urlVars["topic"]
 	project := urlVars["project"]
 
+	// check if user list contain valid users for the given project
+	_, err = auth.AreValidUsers(project, postBody.AuthUsers, refStr)
+	if err != nil {
+		respondErr(w, 404, err.Error(), "NOT_FOUND")
+		return
+	}
+
 	err = topics.ModACL(project, subName, postBody.AuthUsers, refStr)
 
 	if err != nil {
@@ -445,6 +452,13 @@ func SubModACL(w http.ResponseWriter, r *http.Request) {
 	// Get Result Object
 	subName := urlVars["subscription"]
 	project := urlVars["project"]
+
+	// check if user list contain valid users for the given project
+	_, err = auth.AreValidUsers(project, postBody.AuthUsers, refStr)
+	if err != nil {
+		respondErr(w, 404, err.Error(), "NOT_FOUND")
+		return
+	}
 
 	err = subscriptions.ModACL(project, subName, postBody.AuthUsers, refStr)
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -480,9 +479,71 @@ func (suite *HandlerTestSuite) TestTopicACL02() {
 
 }
 
+func (suite *HandlerTestSuite) TestModTopicACLWrong() {
+
+	postExp := `{"authorized_users":["UserX","UserFoo"]}`
+
+	expRes := `{
+   "error": {
+      "code": 404,
+      "message": "User(s): UserFoo do not exist",
+      "status": "NOT_FOUND"
+   }
+}`
+
+	req, err := http.NewRequest("POST", "http://localhost:8080/v1/projects/ARGO/topics/topic1:modAcl", bytes.NewBuffer([]byte(postExp)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := push.Manager{}
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:modAcl", WrapConfig(TopicModACL, cfgKafka, &brk, str, &mgr))
+	router.ServeHTTP(w, req)
+	suite.Equal(404, w.Code)
+	suite.Equal(expRes, w.Body.String())
+
+}
+
+func (suite *HandlerTestSuite) TestModSubACLWrong() {
+
+	postExp := `{"authorized_users":["UserX","UserFoo"]}`
+
+	expRes := `{
+   "error": {
+      "code": 404,
+      "message": "User(s): UserFoo do not exist",
+      "status": "NOT_FOUND"
+   }
+}`
+
+	req, err := http.NewRequest("POST", "http://localhost:8080/v1/projects/ARGO/subscriptions/sub101:modAcl", bytes.NewBuffer([]byte(postExp)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := push.Manager{}
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:modAcl", WrapConfig(SubModACL, cfgKafka, &brk, str, &mgr))
+	router.ServeHTTP(w, req)
+	suite.Equal(404, w.Code)
+	suite.Equal(expRes, w.Body.String())
+
+}
+
 func (suite *HandlerTestSuite) TestModTopicACL01() {
 
-	postExp := `{"authorized_users":["userX","userZ"]}`
+	postExp := `{"authorized_users":["UserX","UserZ"]}`
 
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/projects/ARGO/topics/topic1:modAcl", bytes.NewBuffer([]byte(postExp)))
 	if err != nil {
@@ -512,18 +573,18 @@ func (suite *HandlerTestSuite) TestModTopicACL01() {
 
 	expResp := `{
    "authorized_users": [
-      "userX",
-      "userZ"
+      "UserX",
+      "UserZ"
    ]
 }`
 
 	suite.Equal(expResp, w2.Body.String())
-	fmt.Println(w2.Body.String())
+
 }
 
 func (suite *HandlerTestSuite) TestModSubACL01() {
 
-	postExp := `{"authorized_users":["userX","userZ"]}`
+	postExp := `{"authorized_users":["UserX","UserZ"]}`
 
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/projects/ARGO/subscription/sub1:modAcl", bytes.NewBuffer([]byte(postExp)))
 	if err != nil {
@@ -553,13 +614,13 @@ func (suite *HandlerTestSuite) TestModSubACL01() {
 
 	expResp := `{
    "authorized_users": [
-      "userX",
-      "userZ"
+      "UserX",
+      "UserZ"
    ]
 }`
 
 	suite.Equal(expResp, w2.Body.String())
-	fmt.Println(w2.Body.String())
+
 }
 
 func (suite *HandlerTestSuite) TestSubACL01() {

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -49,6 +49,30 @@ func (mk *MockStore) Close() {
 	mk.Session = false
 }
 
+// HasUsers accepts a user array of usernames and returns the not found
+func (mk *MockStore) HasUsers(project string, users []string) (bool, []string) {
+
+	var notFound []string
+
+	// for each given username
+	for _, username := range users {
+		found := false
+		// loop through all found users
+		for _, user := range mk.UserList {
+			if username == user.Name {
+				found = true
+			}
+		}
+		// if not found add it to the notFound
+		if !found {
+			notFound = append(notFound, username)
+		}
+
+	}
+
+	return len(notFound) == 0, notFound
+}
+
 // ModACL changes the acl in a function
 func (mk *MockStore) ModACL(project string, resource string, name string, acl []string) error {
 	newAcl := QAcl{ACL: acl}
@@ -143,6 +167,11 @@ func (mk *MockStore) Initialize() {
 	// populate Users
 	qUsr := QUser{"Test", "Test@test.com", "ARGO", "S3CR3T", []string{"admin", "member"}}
 	mk.UserList = append(mk.UserList, qUsr)
+
+	mk.UserList = append(mk.UserList, QUser{"UserA", "foo-email", "ARGO", "S3CR3T", []string{"admin", "member"}})
+	mk.UserList = append(mk.UserList, QUser{"UserB", "foo-email", "ARGO", "S3CR3T", []string{"admin", "member"}})
+	mk.UserList = append(mk.UserList, QUser{"UserX", "foo-email", "ARGO", "S3CR3T", []string{"consumer", "member"}})
+	mk.UserList = append(mk.UserList, QUser{"UserZ", "foo-email", "ARGO", "S3CR3T", []string{"producer", "member"}})
 
 	qRole1 := QRole{"topics:list_all", []string{"admin", "reader", "publisher"}}
 	qRole2 := QRole{"topics:publish", []string{"admin", "publisher"}}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -123,6 +123,37 @@ func (mong *MongoStore) UpdateSubOffset(name string, offset int64) {
 
 }
 
+// HasUsers accepts a user array of usernames and returns the not found
+func (mong *MongoStore) HasUsers(project string, users []string) (bool, []string) {
+	db := mong.Session.DB(mong.Database)
+	var results []QUser
+	var notFound []string
+	c := db.C("users")
+
+	err := c.Find(bson.M{"project": project, "name": bson.M{"$in": users}}).All(&results)
+	if err != nil {
+		log.Fatalf("%s\t%s\t%s", "FATAL", "STORE", err.Error())
+	}
+
+	// for each given username
+	for _, username := range users {
+		found := false
+		// loop through all found users
+		for _, user := range results {
+			if username == user.Name {
+				found = true
+			}
+		}
+		// if not found add it to the notFound
+		if !found {
+			notFound = append(notFound, username)
+		}
+
+	}
+
+	return len(notFound) == 0, notFound
+}
+
 // QueryACL queries topic or subscription for a list of authorized users
 func (mong *MongoStore) QueryACL(project string, resource string, name string) (QAcl, error) {
 	db := mong.Session.DB(mong.Database)

--- a/stores/store.go
+++ b/stores/store.go
@@ -10,6 +10,7 @@ type Store interface {
 	InsertTopic(project string, name string) error
 	InsertSub(project string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
 	HasProject(project string) bool
+	HasUsers(project string, users []string) (bool, []string)
 	QueryOneSub(project string, sub string) (QSub, error)
 	QueryPushSubs() []QSub
 	HasResourceRoles(resource string, roles []string) bool

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -115,6 +115,15 @@ func (suite *StoreTestSuite) TestMockStore() {
 	QAcl08, err08 := store.QueryACL("ARGO", "subscr", "sub4ss")
 	suite.Equal(QAcl{}, QAcl08)
 	suite.Equal(errors.New("not found"), err08)
+
+	//Check has users
+	allFound, notFound := store.HasUsers("ARGO", []string{"UserA", "UserB", "FooUser"})
+	suite.Equal(false, allFound)
+	suite.Equal([]string{"FooUser"}, notFound)
+
+	allFound, notFound = store.HasUsers("ARGO", []string{"UserA", "UserB"})
+	suite.Equal(true, allFound)
+	suite.Equal([]string(nil), notFound)
 }
 
 func TestStoresTestSuite(t *testing.T) {

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -80,6 +80,7 @@ func GetACLFromJSON(input []byte) (TopicACL, error) {
 
 // ModACL is called to modify a topic's acl
 func ModACL(project string, name string, acl []string, store stores.Store) error {
+
 	return store.ModACL(project, "topics", name, acl)
 }
 


### PR DESCRIPTION
ARGO-506 Check user existence before modifying sub ACL

## Issue
When modifying an ACL, the list must not contain users that are non-existent

The response in the case of a modACL with non valid users:
`404 NOT_FOUND`
```
{
   "error": {
      "code": 404,
      "message": "User(s): UserFoo1,UserFoo2 do not exist",
      "status": "NOT_FOUND"
   }
}
```

## Implementation
- [x] Add store method HasUsers (for a given project)
- [x] Add auth method AllValidUsers (gets a user list and check if each one are existent users in the given project)
- [x] Add check if all users are valid in TopicModACL handler
- [x] Add check if all users are valid in SubModACL handler
- [x] Update docs

