### PR TITLE
ARGO-507 Fix acl null value response

### DIFF
--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -82,6 +82,9 @@ func ModACL(project string, name string, acl []string, store stores.Store) error
 
 // ExportJSON export subscription acl body to json for use in http response
 func (sAcl *SubACL) ExportJSON() (string, error) {
+	if sAcl.AuthUsers == nil {
+		sAcl.AuthUsers = make([]string, 0)
+	}
 	output, err := json.MarshalIndent(sAcl, "", "   ")
 	return string(output[:]), err
 }

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
 	"github.com/ARGOeu/argo-messaging/config"
 	"github.com/ARGOeu/argo-messaging/stores"
+	"github.com/stretchr/testify/suite"
 )
 
 type SubTestSuite struct {
@@ -296,6 +296,10 @@ func (suite *SubTestSuite) TestSubACL() {
    ]
 }`
 
+	expJSON05 := `{
+   "authorized_users": []
+}`
+
 	APIcfg := config.NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)
 
@@ -316,6 +320,10 @@ func (suite *SubTestSuite) TestSubACL() {
 	sACL4, _ := GetSubACL("ARGO", "sub4", store)
 	outJSON4, _ := sACL4.ExportJSON()
 	suite.Equal(expJSON04, outJSON4)
+
+	sACL5 := SubACL{}
+	outJSON5, _ := sACL5.ExportJSON()
+	suite.Equal(expJSON05, outJSON5)
 
 }
 

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -54,6 +54,7 @@ func (tl *Topics) LoadFromStore(store stores.Store) {
 
 // ExportJSON exports whole Topic Structure as a json string
 func (tp *Topic) ExportJSON() (string, error) {
+
 	output, err := json.MarshalIndent(tp, "", "   ")
 	return string(output[:]), err
 }
@@ -85,6 +86,9 @@ func ModACL(project string, name string, acl []string, store stores.Store) error
 
 // ExportJSON export topic acl body to json for use in http response
 func (tAcl *TopicACL) ExportJSON() (string, error) {
+	if tAcl.AuthUsers == nil {
+		tAcl.AuthUsers = make([]string, 0)
+	}
 	output, err := json.MarshalIndent(tAcl, "", "   ")
 	return string(output[:]), err
 }

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
 	"github.com/ARGOeu/argo-messaging/config"
 	"github.com/ARGOeu/argo-messaging/stores"
+	"github.com/stretchr/testify/suite"
 )
 
 type TopicTestSuite struct {
@@ -150,6 +150,11 @@ func (suite *TopicTestSuite) TestTopicACL() {
       "userC"
    ]
 }`
+
+	expJSON04 := `{
+   "authorized_users": []
+}`
+
 	APIcfg := config.NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)
 
@@ -166,6 +171,10 @@ func (suite *TopicTestSuite) TestTopicACL() {
 	tACL3, _ := GetTopicACL("ARGO", "topic3", store)
 	outJSON3, _ := tACL3.ExportJSON()
 	suite.Equal(expJSON03, outJSON3)
+
+	tACL4 := TopicACL{}
+	outJSON4, _ := tACL4.ExportJSON()
+	suite.Equal(expJSON04, outJSON4)
 
 }
 


### PR DESCRIPTION
## Issue 
When removing all users from a topic, or a subscription the response returns null value. The response should return an empty array such as 
```
{ "authorized_users" : [] }

```

## Implementation
- [x] In TopicACL during ExportJSON, check if auth_user list is null and initialize it properly as empty array
- [x] In SubACL during ExportJSON, check if auth_user list is null and initialize it properly as empty array
- [x] Update unit tests