### PR TITLE
ARGO-484 When a list of ack IDs is given, take into account the max ackId

### DIFF
--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -234,7 +234,7 @@ Please refer to section [Errors](api_errors.md) to see all possible Errors
 
 
 ## [POST] Sending an ACK
-This request sends an ack that the message has been  received
+Messages retrieved from a pull subscription can be acknowledged by sending message with an array of ackIDs. In the current implementation, the service will retrieve the ackID corresponding to the highest message offset and will consider that message and all previous messages as acknowledged by the consumer.
 
 ### Request
 `POST /v1/projects/{project_name}/subscriptions/{subscription_name}:acknowledge`

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -38,6 +38,7 @@ func (suite *HandlerTestSuite) SetupTest() {
 }
 
 func (suite *HandlerTestSuite) TestValidation() {
+	// nameValidations
 	suite.Equal(true, validName("topic101"))
 	suite.Equal(true, validName("topic_101"))
 	suite.Equal(true, validName("topic_101_another_thing"))
@@ -48,6 +49,15 @@ func (suite *HandlerTestSuite) TestValidation() {
 	suite.Equal(false, validName("spaces are not valid"))
 	suite.Equal(false, validName("topic/A"))
 	suite.Equal(false, validName("topic/B"))
+
+	// ackID validations
+	suite.Equal(true, validAckID("ARGO", "sub101", "projects/ARGO/subscriptions/sub101:5"))
+	suite.Equal(false, validAckID("ARGO", "sub101", "projects/ARGO/subscriptions/sub101:aaa"))
+	suite.Equal(false, validAckID("ARGO", "sub101", "projects/FARGO/subscriptions/sub101:5"))
+	suite.Equal(false, validAckID("ARGO", "sub101", "projects/ARGO/subscriptions/subF00:5"))
+	suite.Equal(false, validAckID("ARGO", "sub101", "falsepath/ARGO/subscriptions/sub101:5"))
+	suite.Equal(true, validAckID("FOO", "BAR", "projects/FOO/subscriptions/BAR:11155"))
+	suite.Equal(false, validAckID("FOO", "BAR", "projects/FOO//subscriptions/BAR:11155"))
 
 }
 

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -3,6 +3,7 @@ package subscriptions
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/ARGOeu/argo-messaging/stores"
@@ -277,4 +278,42 @@ func ExtractFullTopicRef(fTopicRef string) (string, string, error) {
 
 	return items[1], items[3], nil
 
+}
+
+// GetMaxAckID gets a list of ack ids and selects the maximum one
+func GetMaxAckID(ackIDs []string) (string, error) {
+	var max int64
+	var maxAckID string
+
+	for _, ackID := range ackIDs {
+
+		offNum, err := GetOffsetFromAckID(ackID)
+
+		if err != nil {
+			return "", errors.New("invalid argument")
+		}
+
+		if offNum >= max {
+			max = offNum
+			maxAckID = ackID
+		}
+
+	}
+
+	return maxAckID, nil
+
+}
+
+// GetOffsetFromAckID extracts an offset from an ackID
+func GetOffsetFromAckID(ackID string) (int64, error) {
+
+	var num int64
+	tokens := strings.Split(ackID, "/")
+	if len(tokens) != 4 {
+		return num, errors.New("invalid argument")
+	}
+	subTokens := strings.Split(tokens[3], ":")
+	num, err := strconv.ParseInt(subTokens[1], 10, 64)
+
+	return num, err
 }

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -327,6 +327,36 @@ func (suite *SubTestSuite) TestSubACL() {
 
 }
 
+func (suite *SubTestSuite) TestGetMaxAckID() {
+	ackIDs := []string{"projects/ARGO/subscriptions/sub1:2",
+		"projects/ARGO/subscriptions/sub1:4",
+		"projects/ARGO/subscriptions/sub1:1555",
+		"projects/ARGO/subscriptions/sub1:5",
+		"projects/ARGO/subscriptions/sub1:3"}
+
+	max, err := GetMaxAckID(ackIDs)
+	suite.Equal(nil, err)
+	suite.Equal("projects/ARGO/subscriptions/sub1:1555", max)
+
+}
+
+func (suite *SubTestSuite) TestGetOffsetFromAckID() {
+	ackIDs := []string{"projects/ARGO/subscriptions/sub1:2",
+		"projects/ARGO/subscriptions/sub1:4",
+		"projects/ARGO/subscriptions/sub1:1555",
+		"projects/ARGO/subscriptions/sub1:5",
+		"projects/ARGO/subscriptions/sub1:3"}
+
+	expOffsets := []int64{2, 4, 1555, 5, 3}
+
+	for i := range ackIDs {
+		off, err := GetOffsetFromAckID(ackIDs[i])
+		suite.Equal(nil, err)
+		suite.Equal(expOffsets[i], off)
+	}
+
+}
+
 func TestSubTestSuite(t *testing.T) {
 	suite.Run(t, new(SubTestSuite))
 }

--- a/validation.go
+++ b/validation.go
@@ -1,8 +1,34 @@
 package main
 
-import "regexp"
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
 
 func validName(name string) bool {
 	r, _ := regexp.Compile("^[a-zA-Z0-9_-]+$")
 	return r.Match([]byte(name))
+}
+
+// validAckID checks the validity of an AckID string against a given project and subscription
+func validAckID(project string, sub string, ackID string) bool {
+
+	tokens := strings.Split(ackID, "/")
+
+	if len(tokens) != 4 || tokens[0] != "projects" || tokens[1] != project || tokens[2] != "subscriptions" {
+		return false
+	}
+
+	subTokens := strings.Split(tokens[3], ":")
+	if len(subTokens) != 2 || subTokens[0] != sub {
+		return false
+	}
+	_, err := strconv.ParseInt(subTokens[1], 10, 64)
+	if err != nil {
+
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
### Issue

Subscription acknowledge request accepts a list of ackIds but only uses the ackId[0]. Instead the id with the maximum offset should be acknowledged

### Implementation
- [x] Add GetMaxAckID - returns the max AckID from a list of AckIDs
- [x] Add GetOffsetFromAckID - extracts offset from an AckID string
- [x] Add validAckID - returns true if an AckID is valid for a given project and subscription
- [x] Update unit tests
- [x] Update docs