### PR TITLE
ARGO-499 Respond with Error when message exceeds kafka's max allowed 

### DIFF
--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -7,7 +7,7 @@ type Broker interface {
 	InitConfig()
 	Initialize(peers []string)
 	CloseConnections()
-	Publish(topic string, payload messages.Message) (string, string, int, int64)
+	Publish(topic string, payload messages.Message) (string, string, int, int64, error)
 	GetOffset(topic string) int64
 	Consume(topic string, offset int64, imm bool) []string
 }

--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -8,8 +8,8 @@ import (
 )
 
 import (
-	"github.com/Shopify/sarama"
 	"github.com/ARGOeu/argo-messaging/messages"
+	"github.com/Shopify/sarama"
 )
 
 type topicLock struct {
@@ -119,7 +119,7 @@ func (b *KafkaBroker) Initialize(peers []string) {
 }
 
 // Publish function publish a message to the broker
-func (b *KafkaBroker) Publish(topic string, msg messages.Message) (string, string, int, int64) {
+func (b *KafkaBroker) Publish(topic string, msg messages.Message) (string, string, int, int64, error) {
 
 	off := b.GetOffset(topic)
 	msg.ID = strconv.FormatInt(off, 10)
@@ -138,10 +138,10 @@ func (b *KafkaBroker) Publish(topic string, msg messages.Message) (string, strin
 
 	partition, offset, err := b.Producer.SendMessage(msgFinal)
 	if err != nil {
-		panic(err)
+		return msg.ID, topic, int(partition), offset, err
 	}
 
-	return msg.ID, topic, int(partition), offset
+	return msg.ID, topic, int(partition), offset, nil
 
 }
 

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -81,12 +81,12 @@ func (b *MockBroker) Initialize(peers []string) {
 }
 
 // Publish function publish a message to the broker
-func (b *MockBroker) Publish(topic string, msg messages.Message) (string, string, int, int64) {
+func (b *MockBroker) Publish(topic string, msg messages.Message) (string, string, int, int64, error) {
 	payload, _ := msg.ExportJSON()
 	b.MsgList = append(b.MsgList, payload)
 	off := b.GetOffset(topic) - 1
 	msgID := strconv.FormatInt(off, 10)
-	return msgID, "ARGO.topic1", 0, int64(len(b.MsgList))
+	return msgID, "ARGO.topic1", 0, int64(len(b.MsgList)), nil
 }
 
 // GetOffset returns a current topic's offset

--- a/doc/v1/docs/api_errors.md
+++ b/doc/v1/docs/api_errors.md
@@ -21,6 +21,7 @@ Invalid Topics Name | 400 | ```{"error":{"code":400,"message":"Invalid topics na
 Topic Doesn't Exist | 404 | ```{"error":{"code":404,"message":"Topic does not exist","status":"NOT_FOUND"}}``` | Show specific Topic  (GET)
 Invalid Topic ACL arguments | 400 | ```{"error":{"code":400,"message":"Invalid Topic ACL Arguments","status":"INVALID_ARGUMENT"}}``` | Modify Topic ACL (POST)
 Subscription Doesn't Exist | 404 | ```{"error":{"code":404,"message":"Subscription does not exist","status":"NOT_FOUND"}}``` | Show specific Subscription  (GET)
+Message size to large | 413 | ```{"error":{"code":413,"message":"Message size too large","status":"INVALID_ARGUMENT"}}``` | Topic Publish (POST)
 Invalid Subscription Arguments | 400 | ```{"error":{"code":404,"message":"Invalid Subscription Arguments","status":"INVALID_ARGUMENT"}}``` | Create Subscription (POST), Modify Push Configuration (POST)
 Invalid Subscription ACL arguments | 400 | ```{"error":{"code":400,"message":"Invalid Subscription ACL Arguments","status":"INVALID_ARGUMENT"}}``` | Modify Subscription ACL (POST)
 Invalid ACK Parameter | 400 | ```{"error":{"code":400,"message":"Invalid ack parameter","status":"INVALID_ARGUMENT"}}``` | Subscription Acknowledge (POST)

--- a/handlers.go
+++ b/handlers.go
@@ -980,7 +980,16 @@ func TopicPublish(w http.ResponseWriter, r *http.Request) {
 		// Get offset and set it as msg
 		fullTopic := urlVars["project"] + "." + urlVars["topic"]
 
-		msgID, rTop, _, _ := refBrk.Publish(fullTopic, msg)
+		msgID, rTop, _, _, err := refBrk.Publish(fullTopic, msg)
+
+		if err != nil {
+			if err.Error() == "kafka server: Message was too large, server rejected it to avoid allocation error." {
+				respondErr(w, 413, "Message size too large", "INVALID_ARGUMENT")
+				return
+			}
+			respondErr(w, 500, err.Error(), "INTERNAL")
+			return
+		}
 		msg.ID = msgID
 		// Assertions for Succesfull Publish
 		if rTop != fullTopic {


### PR DESCRIPTION
### Issue
When message size exceeds kafka allowed size API service breaks and closes connection. Instead it should return through http a proper error message

### Implementation
Catch kafka message size error and respond accordingly:
Issue a response with `413` status code 
and the following error message:
```
{
  "error": {
    "code": 413,
    "message": "Message size too large",
    "status": "INVALID_ARGUMENT"
  }
}
```
- [x] Refactor publish functionality in broker interface to return an error
- [x] Refactor Topic Publish handler to examine errors returned from publish operation and respond accordingly
- [x] Update api-errors doc
