### PR TITLE
ARGO-528 Use the default cipher suite

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,17 +34,7 @@ func main() {
 
 	//Configure TLS support only
 	config := &tls.Config{
-		MinVersion: tls.VersionTLS10,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		},
+		MinVersion:               tls.VersionTLS10,
 		PreferServerCipherSuites: true,
 	}
 


### PR DESCRIPTION
The default cipher suite in the crypto/tls package contains secure
ciphers, which are compatible with centos5 without compromising the
security of the server