### PR TITLE
ARGO-512 API Call to delete a project

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -161,6 +161,39 @@ paths:
         500:
           $ref: "#/responses/500"
 
+    delete:
+      summary: Delete an existing project
+      description: |
+        This request deletes an existing project and clears all it's contained topics and subscriptions
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+      tags:
+        - Projects
+      responses:
+        200:
+          description: Empty response if the project is succesfully deleted
+          schema:
+            type: string
+            default: ""
+            description: empty string
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/subscriptions:
     get:
       summary: List subscriptions in a project

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -22,7 +22,10 @@ If successful, the response contains a list of all available projects
 Success Response
 `200 OK`
 
-```json
+
+```
+json
+
 {
  "projects": [
     {
@@ -50,12 +53,14 @@ Success Response
 }
 ```
 
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 
 ## [GET] Manage Projects - List a specific project
 This request lists information about a specific project
 
 ### Request
-
 ```
 GET "/v1/projects/{project_name}"
 ```
@@ -66,8 +71,9 @@ GET "/v1/projects/{project_name}"
 
 ### Example request
 ```
+
 curl -X GET -H "Content-Type: application/json"
-  "https://{URL}/v1/projects/PROJECT_NEW?key=S3CR3T"
+  "https://{URL}/v1/projects/BRAND_NEW?key=S3CR3T"
 ```
 
 ### Responses  
@@ -76,7 +82,9 @@ If successful, the response contains information about the specific project
 Success Response
 `200 OK`
 
-```json
+```
+json
+>>>>>>> ARGO-510 Implement API Call to create projects
 {
    "name": "BRAND_NEW",
    "created_on": "2009-11-10T23:00:00Z",
@@ -86,10 +94,14 @@ Success Response
 }
 ```
 
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [POST] Manage Projects - Create new project
 This request creates a new project with the given project_name with a POST request
 
 ### Request
+
 ```
 POST "/v1/projects/{project_name}"
 ```
@@ -106,6 +118,7 @@ POST "/v1/projects/{project_name}"
 ```
 
 ### Example request
+
 
 ```
 curl -X POST -H "Content-Type: application/json"
@@ -170,6 +183,33 @@ Success Response
  "description": "description project updated"
 }
 ```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+
+## [DELETE] Manage Projects - Delete Project
+This request deletes a specific project
+
+### Request
+```json
+DELETE "/v1/projects/{project_name}"
+```
+
+### Where
+- Project_name: Name of the project to delete
+
+### Example request
+
+```json
+curl -X DELETE -H "Content-Type: application/json"  
+-d '' "https://{URL}/v1/projects/EGI?key=S3CR3T"
+```
+
+### Responses  
+
+Success Response
+Code: `200 OK`, Empty response if successful.
 
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -62,6 +62,28 @@ func (suite *HandlerTestSuite) TestValidation() {
 
 }
 
+func (suite *HandlerTestSuite) TestProjectDelete() {
+
+	req, err := http.NewRequest("DELETE", "http://localhost:8080/v1/projects/ARGO", nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := ""
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := push.Manager{}
+	router.HandleFunc("/v1/projects/{project}", WrapConfig(ProjectDelete, cfgKafka, &brk, str, &mgr))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
 func (suite *HandlerTestSuite) TestProjectUpdate() {
 
 	postJSON := `{
@@ -153,7 +175,9 @@ func (suite *HandlerTestSuite) TestProjectListAll() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
+
 	router.HandleFunc("/v1/projects", WrapConfig(ProjectListAll, cfgKafka, &brk, str, &mgr))
+
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())

--- a/projects/project.go
+++ b/projects/project.go
@@ -70,7 +70,6 @@ func Find(uuid string, name string, store stores.Store) (Projects, error) {
 	result := Projects{}
 	// if project string empty, returns all projects
 	projects, err := store.QueryProjects(uuid, name)
-
 	for _, item := range projects {
 		curProject := NewProject(item.UUID, item.Name, item.CreatedOn, item.ModifiedOn, item.CreatedBy, item.Description)
 		result.List = append(result.List, curProject)
@@ -130,7 +129,6 @@ func ExistsWithUUID(uuid string, store stores.Store) bool {
 func HasProject(name string, store stores.Store) bool {
 	projects, _ := store.QueryProjects("", name)
 	return len(projects) > 0
-
 }
 
 // CreateProject creates a new project
@@ -165,4 +163,31 @@ func UpdateProject(uuid string, name string, description string, modifiedOn time
 	// reflect stored object
 	stored, err := Find(uuid, name, store)
 	return stored.One(), err
+}
+
+// RemoveProject removes project
+func RemoveProject(uuid string, store stores.Store) error {
+	// Project with uuid should exist to be updated
+
+	// check if project with the same name exists
+	if ExistsWithUUID(uuid, store) == false {
+		return errors.New("not found")
+	}
+
+	// Remove project it self
+	if err := store.RemoveProject(uuid); err != nil {
+		return errors.New("backend error")
+	}
+
+	// Remove topics attached to this project
+	if err := store.RemoveProjectTopics(uuid); err != nil {
+		return errors.New("backend error")
+	}
+
+	// Remove subscriptions attached to this project
+	if err := store.RemoveProjectSubs(uuid); err != nil {
+		return errors.New("backend error")
+	}
+
+	return nil
 }

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -48,6 +48,7 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	pNew, err := Find("", "BRAND_NEW", store)
 
 	suite.Equal(expNew.List[0], reflect)
+
 	suite.Equal(expNew, pNew)
 	suite.Equal(nil, err)
 
@@ -55,6 +56,7 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	suite.Equal("BRAND_NEW", GetNameByUUID("uuid_new", store))
 
 	pAllNew, err := Find("", "", store)
+
 	suite.Equal(expAllNew, pAllNew)
 	suite.Equal(nil, err)
 
@@ -157,6 +159,18 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	outAllUpdJSON, _ := pAllUpdated.ExportJSON()
 
 	suite.Equal(expUpdJSON, outAllUpdJSON)
+
+	// Test removing project
+	RemoveProject("argo_uuid", store)
+	pRemoved, err := Find("argo_uuid", "", store)
+	suite.Equal(Projects{}, pRemoved)
+	suite.Equal(errors.New("not found"), err)
+	// Check to see that also projects topics and subscriptions have been removed from the store
+
+	resTop, _ := store.QueryTopics("argo_uuid", "")
+	suite.Equal([]stores.QTopic{}, resTop)
+	resSub, _ := store.QuerySubs("argo_uuid", "")
+	suite.Equal([]stores.QSub{}, resSub)
 
 }
 

--- a/push/push.go
+++ b/push/push.go
@@ -66,6 +66,30 @@ func (mgr *Manager) StopAll() error {
 	return nil
 }
 
+// RemoveProjectAll stops and removes all pushers related to a project
+func (mgr *Manager) RemoveProjectAll(projectUUID string) error {
+	// collect all subs to be removed here
+	subsToRemove := []string{}
+	// Iterate and stop all relevant subs
+	for k := range mgr.list {
+		project, sub, err := splitPSub(k)
+		if err != nil {
+			return err
+		}
+		if project == projectUUID {
+			mgr.Stop(projectUUID, sub)
+			subsToRemove = append(subsToRemove, sub)
+		}
+
+	}
+	// Now remove relevant subs from the list
+	for _, sub := range subsToRemove {
+		mgr.Remove(projectUUID, sub)
+	}
+
+	return nil
+}
+
 // Push method of pusher object to consume and push messages
 func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	log.Println("pid", p.id, "pushing")

--- a/routing.go
+++ b/routing.go
@@ -68,6 +68,7 @@ var defaultRoutes = []APIRoute{
 	{"projects:show", "GET", "/projects/{project}", ProjectListOne},
 	{"projects:create", "POST", "/projects/{project}", ProjectCreate},
 	{"projects:update", "PUT", "/projects/{project}", ProjectUpdate},
+	{"projects:delete", "DELETE", "/projects/{project}", ProjectDelete},
 	{"subscriptions:list", "GET", "/projects/{project}/subscriptions", SubListAll},
 	{"subscriptions:acl", "GET", "/projects/{project}/subscriptions/{subscription}:acl", SubACL},
 	{"subscriptions:show", "GET", "/projects/{project}/subscriptions/{subscription}", SubListOne},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -335,6 +335,19 @@ func (mk *MockStore) InsertProject(uuid string, name string, createdOn time.Time
 	return nil
 }
 
+// RemoveProject removes an existing project
+func (mk *MockStore) RemoveProject(uuid string) error {
+	for i, project := range mk.ProjectList {
+		if project.UUID == uuid {
+			// found item at i, remove it using index
+			mk.ProjectList = append(mk.ProjectList[:i], mk.ProjectList[i+1:]...)
+			return nil
+		}
+	}
+
+	return errors.New("not found")
+}
+
 // RemoveTopic removes an existing topic
 func (mk *MockStore) RemoveTopic(projectUUID string, name string) error {
 	for i, topic := range mk.TopicList {
@@ -345,6 +358,44 @@ func (mk *MockStore) RemoveTopic(projectUUID string, name string) error {
 		}
 	}
 
+	return errors.New("not found")
+}
+
+// RemoveProjectTopics removes all topics belonging to a specific project uuid
+func (mk *MockStore) RemoveProjectTopics(projectUUID string) error {
+	found := false
+	newList := []QTopic{}
+	for _, topic := range mk.TopicList {
+		if topic.ProjectUUID != projectUUID {
+			// found item at i, remove it using index
+			newList = append(newList, topic)
+		} else {
+			found = true
+		}
+	}
+	mk.TopicList = newList
+	if found {
+		return nil
+	}
+	return errors.New("not found")
+}
+
+// RemoveProjectSubs removes all existing subs belonging to a specific project uuid
+func (mk *MockStore) RemoveProjectSubs(projectUUID string) error {
+	found := false
+	newList := []QSub{}
+	for _, sub := range mk.SubList {
+		if sub.ProjectUUID != projectUUID {
+			// found item at i, remove it using index
+			newList = append(newList, sub)
+		} else {
+			found = true
+		}
+	}
+	mk.SubList = newList
+	if found {
+		return nil
+	}
 	return errors.New("not found")
 }
 

--- a/stores/store.go
+++ b/stores/store.go
@@ -11,6 +11,9 @@ type Store interface {
 	RemoveSub(projectUUID string, name string) error
 	QueryProjects(uuid string, name string) ([]QProject, error)
 	UpdateProject(projectUUID string, name string, description string, modifiedOn time.Time) error
+	RemoveProject(uuid string) error
+	RemoveProjectTopics(projectUUID string) error
+	RemoveProjectSubs(projectUUID string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertTopic(projectUUID string, name string) error
 	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -165,7 +165,6 @@ func (suite *StoreTestSuite) TestMockStore() {
 	projectOut5, err := store.QueryProjects("", "")
 	suite.Equal(expProj5, projectOut5)
 	suite.Equal(nil, err)
-
 	projectOut6, err := store.QueryProjects("argo_uuid2", "ARGO3")
 	suite.Equal(expProj6, projectOut6)
 	suite.Equal(nil, err)
@@ -191,6 +190,20 @@ func (suite *StoreTestSuite) TestMockStore() {
 	store.UpdateProject("argo_uuid3", "ARGO_3", "a newly modified description", modified)
 	prUp3, _ := store.QueryProjects("argo_uuid3", "")
 	suite.Equal(expPr3, prUp3[0])
+
+	// Test RemoveProjectTopics
+	store.RemoveProjectTopics("argo_uuid")
+	resTop, _ := store.QueryTopics("argo_uuid", "")
+	suite.Equal([]QTopic{}, resTop)
+	store.RemoveProjectSubs("argo_uuid")
+	resSub, _ := store.QuerySubs("argo_uuid", "")
+	suite.Equal([]QSub{}, resSub)
+
+	// Test RemoveProject
+	store.RemoveProject("argo_uuid")
+	resProj, err := store.QueryProjects("argo_uuid", "")
+	suite.Equal([]QProject{}, resProj)
+	suite.Equal(errors.New("not found"), err)
 
 }
 


### PR DESCRIPTION
### Goal
Implement an API Call to enable deleting an existing project. Also delete it's topics and subscriptions

_note_: to be merged following ARGO-511, ARGO-510

### Implementation
- [x] Add RemoveProject to store package
- [x] Add RemoveProjectTopics to remove all topics of a given project from the datastore
- [x] Add RemoveProjectSubscriptions to remove all topics of a given project from the datastore
- [x] Add ProjectRemove on project package. It handles removing the project entirely from the store and also removes it's subscriptions and topics
- [x] Add RemoveProjectSubs in push package. It stops and removes any given project's push workers that may currently run
- [x] Implement ProjectDelete handler to handle the request
- [x] Update unit tests
- [x] Update docs
