### PR TITLE
ARGO-514 API Call to create user

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -1,6 +1,10 @@
 package auth
 
 import (
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 
 	"github.com/ARGOeu/argo-messaging/stores"
@@ -10,22 +14,166 @@ import (
 
 // User is the struct that holds user information
 type User struct {
-	Name    string
-	Email   string
-	Project string
-	Token   string
-	Roles   []string
+	UUID         string         `json:"-"`
+	Projects     []ProjectRoles `json:"projects,omitempty"`
+	Name         string         `json:"name"`
+	Token        string         `json:"token,omitempty"`
+	Email        string         `json:"email,omitempty"`
+	ServiceRoles []string       `json:"service_roles,omitempty"`
+}
+
+// ProjectRoles is the struct that hold project and role information of the user
+type ProjectRoles struct {
+	ProjectUUID string   `json:"project_uuid"`
+	Roles       []string `json:"roles"`
 }
 
 // Users holds a list of available users
 type Users struct {
-	List []Users
+	List []User `json:"users,omitempty"`
+}
+
+// ExportJSON exports Project to json format
+func (u *User) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(u, "", "   ")
+	return string(output[:]), err
+}
+
+// ExportJSON exports Projects list to json format
+func (us *Users) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(us, "", "   ")
+	return string(output[:]), err
+}
+
+// Empty returns true if users list is empty
+func (us *Users) Empty() bool {
+	if us.List == nil {
+		return true
+	}
+	return len(us.List) <= 0
+}
+
+// One returns the first user if a user list is not empty
+func (us *Users) One() User {
+	if us.Empty() == false {
+		return us.List[0]
+	}
+	return User{}
+}
+
+// GetUserFromJSON retrieves User info From JSON string
+func GetUserFromJSON(input []byte) (User, error) {
+	u := User{}
+	err := json.Unmarshal([]byte(input), &u)
+	return u, err
+}
+
+// NewUser accepts parameters and creates a new user
+func NewUser(uuid string, projects []ProjectRoles, name string, token string, email string, serviceRoles []string) User {
+	return User{UUID: uuid, Projects: projects, Name: name, Token: token, Email: email, ServiceRoles: serviceRoles}
+}
+
+// FindUsers returns a specific user or a list of all available users belonging to a  project in the datastore.
+func FindUsers(projectUUID string, uuid string, name string, store stores.Store) (Users, error) {
+	result := Users{}
+
+	users, err := store.QueryUsers(projectUUID, uuid, name)
+	for _, item := range users {
+		pRoles := []ProjectRoles{}
+		for _, pItem := range item.Projects {
+			pRoles = append(pRoles, ProjectRoles{ProjectUUID: pItem.ProjectUUID, Roles: pItem.Roles})
+		}
+		curUser := NewUser(item.UUID, pRoles, item.Name, item.Token, item.Email, item.ServiceRoles)
+		result.List = append(result.List, curUser)
+	}
+
+	return result, err
 }
 
 // Authenticate based on token
-func Authenticate(project string, token string, store stores.Store) ([]string, string) {
-	roles, user := store.GetUserRoles(project, token)
+func Authenticate(projectUUID string, token string, store stores.Store) ([]string, string) {
+	roles, user := store.GetUserRoles(projectUUID, token)
+
 	return roles, user
+}
+
+// ExistsWithName returns true if a user with name exists
+func ExistsWithName(name string, store stores.Store) bool {
+	result := false
+
+	users, err := store.QueryUsers("", "", name)
+	if len(users) > 0 && err == nil {
+		result = true
+	}
+
+	return result
+}
+
+// ExistsWithUUID return true if a user with uuid exists
+func ExistsWithUUID(uuid string, store stores.Store) bool {
+	result := false
+
+	users, err := store.QueryUsers("", uuid, "")
+	if len(users) > 0 && err == nil {
+		result = true
+	}
+
+	return result
+}
+
+// GetNameByUUID queries user by UUID and returns the user's name. If not found, returns an empty string
+func GetNameByUUID(uuid string, store stores.Store) string {
+	result := ""
+	users, err := store.QueryUsers("", uuid, "")
+	if len(users) > 0 && err == nil {
+		result = users[0].Name
+	}
+
+	return result
+}
+
+// GetUUIDByName queries user by name and returns the corresponding UUID
+func GetUUIDByName(name string, store stores.Store) string {
+	result := ""
+	users, err := store.QueryUsers("", "", name)
+	if len(users) > 0 && err == nil {
+		result = users[0].UUID
+	}
+
+	return result
+}
+
+// CreateUser creates a new user
+func CreateUser(uuid string, name string, projects []ProjectRoles, token string, email string, serviceRoles []string, store stores.Store) (User, error) {
+	// check if project with the same name exists
+	if ExistsWithName(name, store) {
+		return User{}, errors.New("exists")
+	}
+
+	// Prep project roles for datastore insert
+	prList := []stores.QProjectRoles{}
+	for _, item := range projects {
+		prList = append(prList, stores.QProjectRoles{ProjectUUID: item.ProjectUUID, Roles: item.Roles})
+	}
+
+	if err := store.InsertUser(uuid, prList, name, token, email, serviceRoles); err != nil {
+		return User{}, errors.New("backend error")
+	}
+
+	// reflect stored object
+	stored, err := FindUsers("", "", name, store)
+	return stored.One(), err
+}
+
+// GenToken generates a new token
+func GenToken() (string, error) {
+	tokenLen := 32
+	tokenBytes := make([]byte, tokenLen)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return "", err
+	}
+	sha1Bytes := sha1.Sum(tokenBytes)
+	return hex.EncodeToString(sha1Bytes[:]), nil
 }
 
 // IsPublisher Checks if a user is publisher

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -101,6 +101,7 @@ paths:
            properties:
              description:
                type: string
+
       tags:
         - Projects
       responses:
@@ -194,6 +195,108 @@ paths:
         500:
           $ref: "#/responses/500"
 
+
+  /users:
+    get:
+      summary: List users in the service
+      description: |
+        List all available users in the service
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+      tags:
+        - Users
+      responses:
+        200:
+          description: An array of Users
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Users'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+  /users/{USER}:
+    get:
+      summary: Show a specific user
+      description: |
+        Shows a specific user's information
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: USER
+          in: path
+          description: Name of the user
+          required: true
+          type: string
+      tags:
+        - Users
+      responses:
+        200:
+          description: A User object
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+    post:
+      summary: Create a new user
+      description: |
+        Create a new user in a project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: USER
+          in: path
+          description: Name of the user
+          required: true
+          type: string
+        - name: User information
+          in: body
+          description: Extra user information such as roles and email
+          required: false
+          schema:
+           type: object
+           properties:
+             projects:
+               type: array
+               items:
+                 $ref: "#/definitions/ProjectRoles"
+             email:
+               type: string
+             service_admin:
+               type: boolean
+      tags:
+        - Users
+      responses:
+        200:
+          description: Returns the newly created user
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/subscriptions:
     get:
       summary: List subscriptions in a project
@@ -223,8 +326,6 @@ paths:
           $ref: "#/responses/404"
         500:
           $ref: "#/responses/500"
-
-
 
 
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:
@@ -993,6 +1094,39 @@ definitions:
        description:
         type: string
 
+  Users:
+    type: object
+    properties:
+      users:
+        type: array
+        items:
+          $ref: '#/definitions/User'
+
+  User:
+     type: object
+     properties:
+       name:
+        type: string
+       projects:
+        type: array
+        items:
+           $ref: '#/definitions/ProjectRoles'
+       token:
+        type: string
+       email:
+        type: string
+       service_admin:
+        type: string
+
+  ProjectRoles:
+      type: object
+      properties:
+        project_uuid:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
 
   MessageIDs:
      type: object

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -23,8 +23,7 @@ Success Response
 `200 OK`
 
 
-```
-json
+```json
 
 {
  "projects": [
@@ -71,7 +70,6 @@ GET "/v1/projects/{project_name}"
 
 ### Example request
 ```
-
 curl -X GET -H "Content-Type: application/json"
   "https://{URL}/v1/projects/BRAND_NEW?key=S3CR3T"
 ```
@@ -82,9 +80,7 @@ If successful, the response contains information about the specific project
 Success Response
 `200 OK`
 
-```
-json
->>>>>>> ARGO-510 Implement API Call to create projects
+```json
 {
    "name": "BRAND_NEW",
    "created_on": "2009-11-10T23:00:00Z",
@@ -133,7 +129,7 @@ Success Response
 
 ```json
 {
- "name": "projects/PROJET_NEW",
+ "name": "PROJET_NEW"
  "created_on": "2009-11-10T23:00:00Z",
  "modified_on": "2009-11-10T23:00:00Z",
  "created_by": "userA",
@@ -170,13 +166,13 @@ curl -X PUT -H "Content-Type: application/json"
 ```
 
 ### Responses  
-If successful, the response contains the newly created project
+If successful, the response contains the newly updated
 
 Success Response
 `200 OK`
 ```json
 {
- "name": "projects/PROJET_NEW_UPDATED",
+ "name": "PROJET_NEW_UPDATED",
  "created_on": "2009-11-10T23:00:00Z",
  "modified_on": "2009-11-13T23:00:00Z",
  "created_by": "userA",

--- a/doc/v1/docs/api_users.md
+++ b/doc/v1/docs/api_users.md
@@ -1,0 +1,218 @@
+#User Api Calls
+
+ARGO Messaging Service supports calls for creating and modifing users
+
+## [GET] Manage Users - List all users
+This request lists all available users in the service
+
+### Request
+```json
+GET "/v1/users"
+```
+
+
+
+
+
+### Example request
+```
+curl -X GET -H "Content-Type: application/json"
+  "https://{URL}/v1/users?key=S3CR3T"
+```
+
+### Responses  
+If successful, the response contains a list of all available users in the service
+
+Success Response
+`200 OK`
+```json
+{
+ "users": [
+    {
+       "projects": [
+          {
+             "project_uuid": "argo_uuid",
+             "roles": [
+                "admin",
+                "member"
+             ]
+          }
+       ],
+       "name": "Test",
+       "token": "S3CR3T",
+       "email": "Test@test.com",
+       "service_roles":[]
+    },
+    {
+       "projects": [
+          {
+             "project_uuid": "argo_uuid",
+             "roles": [
+                "admin",
+                "member"
+             ]
+          }
+       ],
+       "name": "UserA",
+       "token": "S3CR3T1",
+       "email": "foo-email",
+       "service_roles":[]
+    },
+    {
+       "projects": [
+          {
+             "project_uuid": "argo_uuid",
+             "roles": [
+                "admin",
+                "member"
+             ]
+          }
+       ],
+       "name": "UserB",
+       "token": "S3CR3T2",
+       "email": "foo-email",
+       "service_roles":[]
+    },
+    {
+       "projects": [
+          {
+             "project_uuid": "argo_uuid",
+             "roles": [
+                "consumer"
+             ]
+          }
+       ],
+       "name": "UserX",
+       "token": "S3CR3T3",
+       "email": "foo-email",
+       "service_roles":[]
+    },
+    {
+       "projects": [
+          {
+             "project_uuid": "argo_uuid",
+             "roles": [
+                "producer"
+             ]
+          }
+       ],
+       "name": "UserZ",
+       "token": "S3CR3T4",
+       "email": "foo-email",
+       "service_admin":false
+    }
+ ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+
+## [GET] Manage Users - List a specific user
+This request lists information about a specific user in the service
+### Request
+```
+POST "/v1/users/{user_name}"
+```
+
+### Where
+- user_name: Name of the user
+
+
+### Example request
+```
+curl -X POST -H "Content-Type: application/json"
+  "https://{URL}/v1/users/UserA?key=S3CR3T"
+```
+
+### Responses  
+If successful, the response contains information about the specific user
+
+Success Response
+`200 OK`
+```json
+{
+ "projects": [
+    {
+       "project_uuid": "argo_uuid",
+       "roles": [
+          "admin",
+          "member"
+       ]
+    }
+ ],
+ "name": "UserA",
+ "token": "S3CR3T1",
+ "email": "foo-email",
+ "service_roles":[]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+
+## [POST] Manage Users - Create new user
+This request creates a new user in a project
+
+### Request
+```json
+POST "/v1/users/{user_name}"
+```
+
+### Post body:
+```json
+{
+ "projects": [
+    {
+       "project_uuid": "argo_uuid",
+       "roles": [
+          "admin",
+          "member"
+       ]
+    }
+ ],
+ "email": "foo-email",
+ "service_roles":[]
+}
+```
+
+### Where
+- user_name: Name of the user
+- projects: A list of Projects & associated roles that the user has on those projects
+- email: User's email
+- service_roles: A list of service-wide roles. An example of service-wide role is `service_admin` which can manage projects or other users
+
+### Example request
+```
+json
+curl -X POST -H "Content-Type: application/json"
+ -d POSTDATA "https://{URL}/v1/projects/ARGO/users/USERNEW?key=S3CR3T"
+```
+
+### Responses  
+If successful, the response contains the newly created project
+
+Success Response
+`200 OK`
+```json
+{
+ "projects": [
+    {
+       "project_uuid": "argo_uuid",
+       "roles": [
+          "admin",
+          "member"
+       ]
+    }
+ ],
+ "name": "USERNEW",
+ "token": "R4ND0MT0K3N",
+ "email": "foo-email",
+ "service_admin":false
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -40,6 +40,7 @@ func (suite *ProjectsTestSuite) TestProjects() {
 
 	// Create new project
 	itemNew := NewProject("uuid_new", "BRAND_NEW", tm, tm, "userA", "brand new project")
+
 	reflect, err := CreateProject("uuid_new", "BRAND_NEW", tm, "userA", "brand new project", store)
 
 	expNew := Projects{List: []Project{itemNew}}
@@ -48,7 +49,6 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	pNew, err := Find("", "BRAND_NEW", store)
 
 	suite.Equal(expNew.List[0], reflect)
-
 	suite.Equal(expNew, pNew)
 	suite.Equal(nil, err)
 

--- a/routing.go
+++ b/routing.go
@@ -64,6 +64,9 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *p
 
 // Global list populated with default routes
 var defaultRoutes = []APIRoute{
+	{"users:list", "GET", "/users", UserListAll},
+	{"users:show", "GET", "/users/{user}", UserListOne},
+	{"users:create", "POST", "/users/{user}", UserCreate},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:show", "GET", "/projects/{project}", ProjectListOne},
 	{"projects:create", "POST", "/projects/{project}", ProjectCreate},

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -33,10 +33,17 @@ type QProject struct {
 
 // QUser are the results of the QUser query
 type QUser struct {
-	Name        string   `bson:"name"`
-	Email       string   `bson:"email"`
+	UUID         string          `bson:"uuid"`
+	Projects     []QProjectRoles `bson:"projects"`
+	Name         string          `bson:"name"`
+	Token        string          `bson:"token"`
+	Email        string          `bson:"email"`
+	ServiceRoles []string        `bson:"service_roles"`
+}
+
+//QProjectRoles include information about projects and roles that user has
+type QProjectRoles struct {
 	ProjectUUID string   `bson:"project_uuid"`
-	Token       string   `bson:"token"`
 	Roles       []string `bson:"roles"`
 }
 
@@ -50,4 +57,32 @@ type QRole struct {
 type QTopic struct {
 	ProjectUUID string `bson:"project_uuid"`
 	Name        string `bson:"name"`
+}
+
+func (qUsr *QUser) isInProject(projectUUID string) bool {
+	for _, item := range qUsr.Projects {
+		if item.ProjectUUID == projectUUID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (qUsr *QUser) getProjectRoles(projectUUID string) []string {
+
+	result := []string{}
+
+	for _, item := range qUsr.Projects {
+		if item.ProjectUUID == projectUUID {
+			result = item.Roles
+		}
+	}
+
+	// if Service admin add this also to the roles regardless of the project
+	if len(qUsr.ServiceRoles) > 0 {
+		result = append(result, qUsr.ServiceRoles...)
+	}
+
+	return result
 }

--- a/stores/store.go
+++ b/stores/store.go
@@ -9,11 +9,13 @@ type Store interface {
 	QueryTopics(projectUUID string, name string) ([]QTopic, error)
 	RemoveTopic(projectUUID string, name string) error
 	RemoveSub(projectUUID string, name string) error
+	QueryUsers(projectUUID string, uuid string, name string) ([]QUser, error)
 	QueryProjects(uuid string, name string) ([]QProject, error)
 	UpdateProject(projectUUID string, name string, description string, modifiedOn time.Time) error
 	RemoveProject(uuid string) error
 	RemoveProjectTopics(projectUUID string) error
 	RemoveProjectSubs(projectUUID string) error
+	InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertTopic(projectUUID string, name string) error
 	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -37,8 +37,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(false, store.HasProject("FOO"))
 
 	// Test user
-	roles01, _ := store.GetUserRoles("ARGO", "S3CR3T")
-	roles02, _ := store.GetUserRoles("ARGO", "SecretKey")
+	roles01, _ := store.GetUserRoles("argo_uuid", "S3CR3T")
+	roles02, _ := store.GetUserRoles("argo_uuid", "SecretKey")
 	suite.Equal([]string{"admin", "member"}, roles01)
 	suite.Equal([]string{}, roles02)
 
@@ -147,7 +147,6 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(expProj1, projectOut1)
 	suite.Equal(nil, err)
 	projectOut2, err := store.QueryProjects("", "ARGO2")
-
 	suite.Equal(expProj2, projectOut2)
 	suite.Equal(nil, err)
 	projectOut3, err := store.QueryProjects("", "")
@@ -155,6 +154,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(nil, err)
 
 	projectOut4, err := store.QueryProjects("", "FOO")
+
 	suite.Equal(expProj4, projectOut4)
 	suite.Equal(errors.New("not found"), err)
 	// Test insert project
@@ -165,6 +165,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	projectOut5, err := store.QueryProjects("", "")
 	suite.Equal(expProj5, projectOut5)
 	suite.Equal(nil, err)
+
 	projectOut6, err := store.QueryProjects("argo_uuid2", "ARGO3")
 	suite.Equal(expProj6, projectOut6)
 	suite.Equal(nil, err)
@@ -204,6 +205,27 @@ func (suite *StoreTestSuite) TestMockStore() {
 	resProj, err := store.QueryProjects("argo_uuid", "")
 	suite.Equal([]QProject{}, resProj)
 	suite.Equal(errors.New("not found"), err)
+
+	// Test Insert User
+	qRoleAdmin1 := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"adming"}}}
+	qRoles := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"admin"}}, QProjectRoles{"argo_uuid2", []string{"admin", "viewer"}}}
+	expUsr10 := QUser{"user_uuid10", qRoleAdmin1, "newUser1", "A3B94A94V3A", "fake@email.com", []string{}}
+	expUsr11 := QUser{"user_uuid11", qRoles, "newUser2", "BX312Z34NLQ", "fake@email.com", []string{}}
+	store.InsertUser("user_uuid10", qRoleAdmin1, "newUser1", "A3B94A94V3A", "fake@email.com", []string{})
+	store.InsertUser("user_uuid11", qRoles, "newUser2", "BX312Z34NLQ", "fake@email.com", []string{})
+	usr10, _ := store.QueryUsers("argo_uuid", "user_uuid10", "")
+	usr11, _ := store.QueryUsers("argo_uuid", "", "newUser2")
+
+	suite.Equal(expUsr10, usr10[0])
+	suite.Equal(expUsr11, usr11[0])
+
+	rolesA, usernameA := store.GetUserRoles("argo_uuid", "BX312Z34NLQ")
+	rolesB, usernameB := store.GetUserRoles("argo_uuid2", "BX312Z34NLQ")
+	suite.Equal("newUser2", usernameA)
+	suite.Equal("newUser2", usernameB)
+
+	suite.Equal([]string{"admin"}, rolesA)
+	suite.Equal([]string{"admin", "viewer"}, rolesB)
 
 }
 


### PR DESCRIPTION
## Goal
Implement API Call to enable creating new users

## Implemetation
- [x] Update User Model with the new requested fields (uuid etc)
- [x] Add InsertUser method on store package
- [x] Add  UserCreate method on auth package
- [x] Add UserCreate handler for the request
- [x] Update docs

-----------------------------------------
## Refactoring
- [x] Refactor users to exist outside of projects (service wide)
- [x] Refactor user models and methods to support multiple projects and roles:
Each user definition now supports a list of projects in which a user participates accompanied with a list of roles for each project. For example:
```json
{
  "name": "UserX",
  "token": "S3CR3T",
  "email": "foo@email-foo.coml",
  "projects": [
    {
      "project_uuid": "uuid0",
      "roles": [
        "admin"
      ]
    },
    {
      "project_uuid": "uuid2",
      "roles": [
        "viewer",
        "consumer"
      ]
    }
  ],
  "service_roles":["service_admin"]
}
```

Each user has a seperate field to hold a list of service-wide roles named `service_roles`. An example of a service wide role is `service_admin` which allows users to manage projects and other users. 

## Fixes
- [x] Fixed project update method