### PR TITLE
Refactor project to projectUUID references

### DIFF
--- a/stores/mock.go
+++ b/stores/mock.go
@@ -50,7 +50,7 @@ func (mk *MockStore) Close() {
 }
 
 // HasUsers accepts a user array of usernames and returns the not found
-func (mk *MockStore) HasUsers(project string, users []string) (bool, []string) {
+func (mk *MockStore) HasUsers(projectUUID string, users []string) (bool, []string) {
 
 	var notFound []string
 
@@ -74,7 +74,7 @@ func (mk *MockStore) HasUsers(project string, users []string) (bool, []string) {
 }
 
 // ModACL changes the acl in a function
-func (mk *MockStore) ModACL(project string, resource string, name string, acl []string) error {
+func (mk *MockStore) ModACL(projectUUID string, resource string, name string, acl []string) error {
 	newAcl := QAcl{ACL: acl}
 	if resource == "topics" {
 		if _, exists := mk.TopicsACL[name]; exists {
@@ -252,9 +252,9 @@ func (mk *MockStore) Clone() Store {
 }
 
 // GetUserRoles returns the roles of a user in a project
-func (mk *MockStore) GetUserRoles(project string, token string) ([]string, string) {
+func (mk *MockStore) GetUserRoles(projectUUID string, token string) ([]string, string) {
 	for _, item := range mk.UserList {
-		if item.Project == project && item.Token == token {
+		if item.ProjectUUID == projectUUID && item.Token == token {
 			return item.Roles, "userA"
 		}
 	}
@@ -283,9 +283,9 @@ func (mk *MockStore) HasResourceRoles(resource string, roles []string) bool {
 }
 
 // HasProject returns true if project exists in store
-func (mk *MockStore) HasProject(project string) bool {
+func (mk *MockStore) HasProject(name string) bool {
 	for _, item := range mk.ProjectList {
-		if item.Name == project {
+		if item.Name == name {
 			return true
 		}
 	}
@@ -301,8 +301,8 @@ func (mk *MockStore) InsertTopic(projectUUID string, name string) error {
 }
 
 // InsertSub inserts a new sub object to the store
-func (mk *MockStore) InsertSub(project string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
-	sub := QSub{project, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod}
+func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
+	sub := QSub{projectUUID, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod}
 	mk.SubList = append(mk.SubList, sub)
 	return nil
 }

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -150,13 +150,13 @@ func (mong *MongoStore) UpdateSubOffset(projectUUID string, name string, offset 
 }
 
 // HasUsers accepts a user array of usernames and returns the not found
-func (mong *MongoStore) HasUsers(project string, users []string) (bool, []string) {
+func (mong *MongoStore) HasUsers(projectUUID string, users []string) (bool, []string) {
 	db := mong.Session.DB(mong.Database)
 	var results []QUser
 	var notFound []string
 	c := db.C("users")
 
-	err := c.Find(bson.M{"project": project, "name": bson.M{"$in": users}}).All(&results)
+	err := c.Find(bson.M{"project_uuid": projectUUID, "name": bson.M{"$in": users}}).All(&results)
 	if err != nil {
 		log.Fatalf("%s\t%s\t%s", "FATAL", "STORE", err.Error())
 	}
@@ -248,12 +248,12 @@ func (mong *MongoStore) HasResourceRoles(resource string, roles []string) bool {
 }
 
 //GetUserRoles returns the roles of a user in a project
-func (mong *MongoStore) GetUserRoles(project string, token string) ([]string, string) {
+func (mong *MongoStore) GetUserRoles(projectUUID string, token string) ([]string, string) {
 
 	db := mong.Session.DB(mong.Database)
 	c := db.C("users")
 	var results []QUser
-	err := c.Find(bson.M{"project_uuid": project, "token": token}).All(&results)
+	err := c.Find(bson.M{"project_uuid": projectUUID, "token": token}).All(&results)
 	if err != nil {
 		log.Fatalf("%s\t%s\t%s", "FATAL", "STORE", err.Error())
 	}
@@ -290,12 +290,12 @@ func (mong *MongoStore) QueryOneSub(projectUUID string, name string) (QSub, erro
 }
 
 // HasProject Returns true if project exists
-func (mong *MongoStore) HasProject(project string) bool {
+func (mong *MongoStore) HasProject(name string) bool {
 
 	db := mong.Session.DB(mong.Database)
 	c := db.C("projects")
 	var results []QProject
-	err := c.Find(bson.M{}).All(&results)
+	err := c.Find(bson.M{"name": name}).All(&results)
 	if err != nil {
 		log.Fatalf("%s\t%s\t%s", "FATAL", "STORE", err.Error())
 	}
@@ -319,28 +319,28 @@ func (mong *MongoStore) InsertProject(uuid string, name string, createdOn time.T
 }
 
 // InsertSub inserts a subscription to the store
-func (mong *MongoStore) InsertSub(project string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
-	sub := QSub{project, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod}
+func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
+	sub := QSub{projectUUID, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod}
 	return mong.InsertResource("subscriptions", sub)
 }
 
 // RemoveTopic removes a topic from the store
-func (mong *MongoStore) RemoveTopic(project string, name string) error {
-	topic := QTopic{project, name}
+func (mong *MongoStore) RemoveTopic(projectUUID string, name string) error {
+	topic := QTopic{projectUUID, name}
 	return mong.RemoveResource("topics", topic)
 }
 
 // RemoveSub removes a subscription from the store
-func (mong *MongoStore) RemoveSub(project string, name string) error {
-	sub := bson.M{"project": project, "name": name}
+func (mong *MongoStore) RemoveSub(projectUUID string, name string) error {
+	sub := bson.M{"project_uuid": projectUUID, "name": name}
 	return mong.RemoveResource("subscriptions", sub)
 }
 
 // ModACL modifies the push configuration
-func (mong *MongoStore) ModACL(project string, resource string, name string, acl []string) error {
+func (mong *MongoStore) ModACL(projectUUID string, resource string, name string, acl []string) error {
 	db := mong.Session.DB(mong.Database)
 	c := db.C(resource)
-	err := c.Update(bson.M{"project": project, "name": name}, bson.M{"$set": bson.M{"acl": acl}})
+	err := c.Update(bson.M{"project_uuid": projectUUID, "name": name}, bson.M{"$set": bson.M{"acl": acl}})
 	return err
 }
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -33,11 +33,11 @@ type QProject struct {
 
 // QUser are the results of the QUser query
 type QUser struct {
-	Name    string   `bson:"name"`
-	Email   string   `bson:"email"`
-	Project string   `bson:"project"`
-	Token   string   `bson:"token"`
-	Roles   []string `bson:"roles"`
+	Name        string   `bson:"name"`
+	Email       string   `bson:"email"`
+	ProjectUUID string   `bson:"project_uuid"`
+	Token       string   `bson:"token"`
+	Roles       []string `bson:"roles"`
 }
 
 // QRole holds roles resources relationships

--- a/stores/store.go
+++ b/stores/store.go
@@ -8,23 +8,23 @@ type Store interface {
 	QuerySubs(projectUUID string, name string) ([]QSub, error)
 	QueryTopics(projectUUID string, name string) ([]QTopic, error)
 	QueryProjects(name string, uuid string) ([]QProject, error)
-	RemoveTopic(project string, name string) error
-	RemoveSub(project string, name string) error
+	RemoveTopic(projectUUID string, name string) error
+	RemoveSub(projectUUID string, name string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertTopic(projectUUID string, name string) error
 	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
-	HasProject(project string) bool
-	HasUsers(project string, users []string) (bool, []string)
+	HasProject(name string) bool
+	HasUsers(projectUUID string, users []string) (bool, []string)
 	QueryOneSub(projectUUID string, name string) (QSub, error)
 	QueryPushSubs() []QSub
 	HasResourceRoles(resource string, roles []string) bool
-	GetUserRoles(project string, token string) ([]string, string)
+	GetUserRoles(projectUUID string, token string) ([]string, string)
 	UpdateSubOffset(projectUUID string, name string, offset int64)
 	UpdateSubPull(name string, offset int64, ts string)
 	UpdateSubOffsetAck(projectUUID string, name string, offset int64, ts string) error
-	ModSubPush(project string, name string, push string, rPolicy string, rPeriod int) error
-	QueryACL(project string, resource string, name string) (QAcl, error)
-	ModACL(project string, resource string, name string, acl []string) error
+	ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error
+	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
+	ModACL(projectUUID string, resource string, name string, acl []string) error
 	Clone() Store
 	Close()
 }


### PR DESCRIPTION
## Issue 
Subscription delete request was failing due to using old `project` field name instead of `project_uuid`

## Fix
- Refactored `project` to `project_uuid` in store methods
- Refactored `project` to `projectUUID` in store interface arguments for consistency and clarity
