### PR TITLE
Fix ACL issues. Transfer Topic/Sub ACL logic to auth package

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/ARGOeu/argo-messaging/stores"
+)
+
+// ACL holds the authorized users for a resource (topic/subscription)
+type ACL struct {
+	AuthUsers []string `json:"authorized_users"`
+}
+
+// ExportJSON export topic acl body to json for use in http response
+func (acl *ACL) ExportJSON() (string, error) {
+	if acl.AuthUsers == nil {
+		acl.AuthUsers = make([]string, 0)
+	}
+	output, err := json.MarshalIndent(acl, "", "   ")
+	return string(output[:]), err
+}
+
+// GetACLFromJSON retrieves ACL info from JSON
+func GetACLFromJSON(input []byte) (ACL, error) {
+	acl := ACL{}
+	err := json.Unmarshal([]byte(input), &acl)
+	if acl.AuthUsers == nil {
+		return acl, errors.New("wrong argument")
+	}
+	return acl, err
+}
+
+// ModACL is called to modify an acl
+func ModACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
+	// Transform user name to user uuid
+	userUUIDs := []string{}
+	for _, username := range acl {
+		userUUID := GetUUIDByName(username, store)
+		userUUIDs = append(userUUIDs, userUUID)
+	}
+	return store.ModACL(projectUUID, resourceType, resourceName, userUUIDs)
+}
+
+// GetACL returns an authorized list of user for the resource (topic or subscription)
+func GetACL(projectUUID string, resourceType string, resourceName string, store stores.Store) (ACL, error) {
+	result := ACL{}
+	acl, err := store.QueryACL(projectUUID, resourceType, resourceName)
+	if err != nil {
+		return result, err
+	}
+	for _, item := range acl.ACL {
+		// Get Username from user uuid
+		username := GetNameByUUID(item, store)
+		result.AuthUsers = append(result.AuthUsers, username)
+	}
+	return result, err
+}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,14 +1,27 @@
 package auth
 
 import (
+	"io/ioutil"
+	"log"
 	"testing"
 
+	"github.com/ARGOeu/argo-messaging/config"
 	"github.com/ARGOeu/argo-messaging/stores"
 	"github.com/stretchr/testify/suite"
 )
 
 type AuthTestSuite struct {
 	suite.Suite
+	cfgStr string
+}
+
+func (suite *AuthTestSuite) SetupTest() {
+	suite.cfgStr = `{
+		"broker_host":"localhost:9092",
+		"store_host":"localhost",
+		"store_db":"argo_msg"
+	}`
+	log.SetOutput(ioutil.Discard)
 }
 
 func (suite *AuthTestSuite) TestAuth() {
@@ -37,24 +50,24 @@ func (suite *AuthTestSuite) TestAuth() {
 	// topic3: userC
 
 	// Check authorization per topic for userA
-	suite.Equal(true, PerResource("ARGO", "topic", "topic1", "userA", store))
-	suite.Equal(true, PerResource("ARGO", "topic", "topic2", "userA", store))
-	suite.Equal(false, PerResource("ARGO", "topic", "topic3", "userA", store))
+	suite.Equal(true, PerResource("argo_uuid", "topic", "topic1", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "topic", "topic2", "UserA", store))
+	suite.Equal(false, PerResource("argo_uuid", "topic", "topic3", "UserA", store))
 
 	// Check authorization per topic for userB
-	suite.Equal(true, PerResource("ARGO", "topic", "topic1", "userB", store))
-	suite.Equal(true, PerResource("ARGO", "topic", "topic2", "userB", store))
-	suite.Equal(false, PerResource("ARGO", "topic", "topic3", "userB", store))
+	suite.Equal(true, PerResource("argo_uuid", "topic", "topic1", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "topic", "topic2", "UserB", store))
+	suite.Equal(false, PerResource("argo_uuid", "topic", "topic3", "UserB", store))
 
 	// Check authorization per topic for userC
-	suite.Equal(false, PerResource("ARGO", "topic", "topic1", "userC", store))
-	suite.Equal(false, PerResource("ARGO", "topic", "topic2", "userC", store))
-	suite.Equal(true, PerResource("ARGO", "topic", "topic3", "userC", store))
+	suite.Equal(false, PerResource("argo_uuid", "topic", "topic1", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "topic", "topic2", "UserX", store))
+	suite.Equal(true, PerResource("argo_uuid", "topic", "topic3", "UserX", store))
 
 	// Check authorization per topic for userD
-	suite.Equal(false, PerResource("ARGO", "topic", "topic1", "userD", store))
-	suite.Equal(true, PerResource("ARGO", "topic", "topic2", "userD", store))
-	suite.Equal(false, PerResource("ARGO", "topic", "topic3", "userD", store))
+	suite.Equal(false, PerResource("argo_uuid", "topic", "topic1", "UserZ", store))
+	suite.Equal(true, PerResource("argo_uuid", "topic", "topic2", "UserZ", store))
+	suite.Equal(false, PerResource("argo_uuid", "topic", "topic3", "UserZ", store))
 
 	// Check user authorization per subscription
 	//
@@ -64,26 +77,26 @@ func (suite *AuthTestSuite) TestAuth() {
 	// sub4: userB, userD
 
 	// Check authorization per subscription for userA
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub1", "userA", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub2", "userA", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub3", "userA", store))
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub4", "userA", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub1", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub2", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub3", "UserA", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub4", "UserA", store))
 
 	// Check authorization per subscription for userB
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub1", "userB", store))
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub2", "userB", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub3", "userB", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub4", "userB", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub1", "UserB", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub2", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub3", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub4", "UserB", store))
 	// Check authorization per subscription for userC
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub1", "userC", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub2", "userC", store))
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub3", "userC", store))
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub4", "userC", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub1", "UserX", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub2", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub3", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub4", "UserX", store))
 	// Check authorization per subscription for userD
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub1", "userD", store))
-	suite.Equal(false, PerResource("ARGO", "subscription", "sub2", "userD", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub3", "userD", store))
-	suite.Equal(true, PerResource("ARGO", "subscription", "sub4", "userD", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub1", "UserZ", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub2", "UserZ", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub3", "UserZ", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub4", "UserZ", store))
 
 	suite.Equal(true, IsConsumer([]string{"consumer"}))
 	suite.Equal(true, IsConsumer([]string{"consumer", "publisher"}))
@@ -251,6 +264,116 @@ func (suite *AuthTestSuite) TestAuth() {
 	usrUpd, _ := FindUsers("", "uuid12", "", store)
 	usrUpdJSON, _ := usrUpd.List[0].ExportJSON()
 	suite.Equal(expUpdate, usrUpdJSON)
+}
+
+func (suite *AuthTestSuite) TestSubACL() {
+	expJSON01 := `{
+   "authorized_users": [
+      "UserA",
+      "UserB"
+   ]
+}`
+
+	expJSON02 := `{
+   "authorized_users": [
+      "UserA",
+      "UserX"
+   ]
+}`
+
+	expJSON03 := `{
+   "authorized_users": [
+      "UserZ",
+      "UserB",
+      "UserA"
+   ]
+}`
+
+	expJSON04 := `{
+   "authorized_users": [
+      "UserB",
+      "UserZ"
+   ]
+}`
+
+	expJSON05 := `{
+   "authorized_users": []
+}`
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+
+	sACL, _ := GetACL("argo_uuid", "subscription", "sub1", store)
+	outJSON, _ := sACL.ExportJSON()
+	suite.Equal(expJSON01, outJSON)
+
+	sACL2, _ := GetACL("argo_uuid", "subscription", "sub2", store)
+	outJSON2, _ := sACL2.ExportJSON()
+	suite.Equal(expJSON02, outJSON2)
+
+	sACL3, _ := GetACL("argo_uuid", "subscription", "sub3", store)
+	outJSON3, _ := sACL3.ExportJSON()
+	suite.Equal(expJSON03, outJSON3)
+
+	sACL4, _ := GetACL("argo_uuid", "subscription", "sub4", store)
+	outJSON4, _ := sACL4.ExportJSON()
+	suite.Equal(expJSON04, outJSON4)
+
+	sACL5 := ACL{}
+	outJSON5, _ := sACL5.ExportJSON()
+	suite.Equal(expJSON05, outJSON5)
+
+}
+
+func (suite *AuthTestSuite) TestTopicACL() {
+	expJSON01 := `{
+   "authorized_users": [
+      "UserA",
+      "UserB"
+   ]
+}`
+
+	expJSON02 := `{
+   "authorized_users": [
+      "UserA",
+      "UserB",
+      "UserZ"
+   ]
+}`
+
+	expJSON03 := `{
+   "authorized_users": [
+      "UserX"
+   ]
+}`
+
+	expJSON04 := `{
+   "authorized_users": []
+}`
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+
+	tACL, _ := GetACL("argo_uuid", "topic", "topic1", store)
+	outJSON, _ := tACL.ExportJSON()
+	suite.Equal(expJSON01, outJSON)
+
+	tACL2, _ := GetACL("argo_uuid", "topic", "topic2", store)
+	outJSON2, _ := tACL2.ExportJSON()
+	suite.Equal(expJSON02, outJSON2)
+
+	tACL3, _ := GetACL("argo_uuid", "topic", "topic3", store)
+	outJSON3, _ := tACL3.ExportJSON()
+	suite.Equal(expJSON03, outJSON3)
+
+	tACL4 := ACL{}
+	outJSON4, _ := tACL4.ExportJSON()
+	suite.Equal(expJSON04, outJSON4)
+
 }
 
 func TestAuthTestSuite(t *testing.T) {

--- a/auth/users.go
+++ b/auth/users.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/ARGOeu/argo-messaging/projects"
 	"github.com/ARGOeu/argo-messaging/stores"
-	"github.com/ARGOeu/argo-messaging/subscriptions"
-	"github.com/ARGOeu/argo-messaging/topics"
 )
 
 // User is the struct that holds user information
@@ -139,6 +137,7 @@ func GetNameByUUID(uuid string, store stores.Store) string {
 func GetUUIDByName(name string, store stores.Store) string {
 	result := ""
 	users, err := store.QueryUsers("", "", name)
+
 	if len(users) > 0 && err == nil {
 		result = users[0].UUID
 	}
@@ -281,8 +280,8 @@ func IsRoleValid(role string, validRoles []string) bool {
 }
 
 // AreValidUsers accepts a user array of usernames and checks if users exist in the store
-func AreValidUsers(project string, users []string, store stores.Store) (bool, error) {
-	found, notFound := store.HasUsers(project, users)
+func AreValidUsers(projectUUID string, users []string, store stores.Store) (bool, error) {
+	found, notFound := store.HasUsers(projectUUID, users)
 	if found {
 		return true, nil
 	}
@@ -303,16 +302,9 @@ func AreValidUsers(project string, users []string, store stores.Store) (bool, er
 
 // PerResource  (for topics and subscriptions)
 func PerResource(project string, resType string, resName string, user string, store stores.Store) bool {
-	if resType == "topic" {
-		tACL, _ := topics.GetTopicACL(project, resName, store)
-		for _, item := range tACL.AuthUsers {
-			if item == user {
-				return true
-			}
-		}
-	} else if resType == "subscription" {
-		sACL, _ := subscriptions.GetSubACL(project, resName, store)
-		for _, item := range sACL.AuthUsers {
+	if resType == "topic" || resType == "subscription" {
+		acl, _ := GetACL(project, resType, resName, store)
+		for _, item := range acl.AuthUsers {
 			if item == user {
 				return true
 			}

--- a/doc/v1/docs/api_users.md
+++ b/doc/v1/docs/api_users.md
@@ -182,6 +182,16 @@ POST "/v1/users/{user_name}"
 - email: User's email
 - service_roles: A list of service-wide roles. An example of service-wide role is `service_admin` which can manage projects or other users
 
+##### Available Roles
+ARGO Messaging Service has the following predefined project roles:
+- project_admin
+- admin
+- viewer
+- consumer
+- producer
+and the following service-wide role:
+- service_admin
+
 ### Example request
 ```
 json
@@ -246,6 +256,16 @@ PUT "/v1/users/{user_name}"
 - projects: A list of Projects & associated roles that the user has on those projects
 - email: User's email
 - service_roles: A list of service-wide roles. An example of service-wide role is `service_admin` which can manage projects or other users
+
+##### Available Roles
+ARGO Messaging Service has the following predefined project roles:
+- project_admin
+- admin
+- viewer
+- consumer
+- producer
+and the following service-wide role:
+- service_admin
 
 ### Example request
 ```

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -186,7 +186,7 @@ func (suite *HandlerTestSuite) TestUserListOne() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/users/{user}", WrapConfig(UserListOne, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/users/{user}", WrapMockAuthConfig(UserListOne, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -281,7 +281,7 @@ func (suite *HandlerTestSuite) TestUserListAll() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/users", WrapConfig(UserListAll, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/users", WrapMockAuthConfig(UserListAll, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -304,7 +304,7 @@ func (suite *HandlerTestSuite) TestProjectDelete() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}", WrapConfig(ProjectDelete, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}", WrapMockAuthConfig(ProjectDelete, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -363,7 +363,7 @@ func (suite *HandlerTestSuite) TestProjectCreate() {
 	projOut, _ := projects.GetFromJSON([]byte(w.Body.String()))
 	suite.Equal("ARGONEW", projOut.Name)
 	// Check if the mock authenticated userA has been marked as the creator
-	suite.Equal("userA", projOut.CreatedBy)
+	suite.Equal("UserA", projOut.CreatedBy)
 	suite.Equal("This is a newly created project", projOut.Description)
 }
 
@@ -402,7 +402,7 @@ func (suite *HandlerTestSuite) TestProjectListAll() {
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
 
-	router.HandleFunc("/v1/projects", WrapConfig(ProjectListAll, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects", WrapMockAuthConfig(ProjectListAll, cfgKafka, &brk, str, &mgr))
 
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
@@ -433,7 +433,7 @@ func (suite *HandlerTestSuite) TestProjectListOneNotFound() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}", WrapConfig(ProjectListOne, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}", WrapMockAuthConfig(ProjectListOne, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -463,7 +463,7 @@ func (suite *HandlerTestSuite) TestProjectListOne() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}", WrapConfig(ProjectListOne, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}", WrapMockAuthConfig(ProjectListOne, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -498,7 +498,7 @@ func (suite *HandlerTestSuite) TestSubCreate() {
 	router := mux.NewRouter().StrictSlash(true)
 	mgr := push.Manager{}
 	w := httptest.NewRecorder()
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapConfig(SubCreate, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapMockAuthConfig(SubCreate, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -531,7 +531,7 @@ func (suite *HandlerTestSuite) TestSubCreateExists() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapConfig(SubCreate, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapMockAuthConfig(SubCreate, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(409, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -563,7 +563,7 @@ func (suite *HandlerTestSuite) TestSubCreateErrorTopic() {
 	mgr := push.Manager{}
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapConfig(SubCreate, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapMockAuthConfig(SubCreate, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -584,7 +584,7 @@ func (suite *HandlerTestSuite) TestSubDelete() {
 	mgr := push.Manager{}
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapConfig(SubDelete, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapMockAuthConfig(SubDelete, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -615,7 +615,7 @@ func (suite *HandlerTestSuite) TestSubListOne() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapConfig(SubListOne, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapMockAuthConfig(SubListOne, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -680,7 +680,7 @@ func (suite *HandlerTestSuite) TestSubListAll() {
 	router := mux.NewRouter().StrictSlash(true)
 	mgr := push.Manager{}
 	w := httptest.NewRecorder()
-	router.HandleFunc("/v1/projects/{project}/subscriptions", WrapConfig(SubListAll, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions", WrapMockAuthConfig(SubListAll, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -703,7 +703,7 @@ func (suite *HandlerTestSuite) TestTopicDelete() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapConfig(TopicDelete, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapMockAuthConfig(TopicDelete, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -730,7 +730,7 @@ func (suite *HandlerTestSuite) TestSubDeleteNotfound() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapConfig(SubDelete, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapMockAuthConfig(SubDelete, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -759,7 +759,7 @@ func (suite *HandlerTestSuite) TestTopicDeleteNotfound() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapConfig(TopicDelete, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapMockAuthConfig(TopicDelete, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -785,7 +785,7 @@ func (suite *HandlerTestSuite) TestTopicCreate() {
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
 
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapConfig(TopicCreate, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapMockAuthConfig(TopicCreate, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -813,7 +813,7 @@ func (suite *HandlerTestSuite) TestTopicCreateExists() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapConfig(TopicCreate, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapMockAuthConfig(TopicCreate, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(409, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -837,7 +837,7 @@ func (suite *HandlerTestSuite) TestTopicListOne() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapConfig(TopicListOne, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapMockAuthConfig(TopicListOne, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -852,8 +852,8 @@ func (suite *HandlerTestSuite) TestTopicACL01() {
 
 	expResp := `{
    "authorized_users": [
-      "userA",
-      "userB"
+      "UserA",
+      "UserB"
    ]
 }`
 
@@ -864,7 +864,7 @@ func (suite *HandlerTestSuite) TestTopicACL01() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:acl", WrapConfig(TopicACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:acl", WrapMockAuthConfig(TopicACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -880,7 +880,7 @@ func (suite *HandlerTestSuite) TestTopicACL02() {
 
 	expResp := `{
    "authorized_users": [
-      "userC"
+      "UserX"
    ]
 }`
 
@@ -891,7 +891,7 @@ func (suite *HandlerTestSuite) TestTopicACL02() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:acl", WrapConfig(TopicACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:acl", WrapMockAuthConfig(TopicACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -922,7 +922,7 @@ func (suite *HandlerTestSuite) TestModTopicACLWrong() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:modAcl", WrapConfig(TopicModACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:modAcl", WrapMockAuthConfig(TopicModACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expRes, w.Body.String())
@@ -953,7 +953,7 @@ func (suite *HandlerTestSuite) TestModSubACLWrong() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:modAcl", WrapConfig(SubModACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:modAcl", WrapMockAuthConfig(SubModACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expRes, w.Body.String())
@@ -976,7 +976,7 @@ func (suite *HandlerTestSuite) TestModTopicACL01() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:modAcl", WrapConfig(TopicModACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:modAcl", WrapMockAuthConfig(TopicModACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal("", w.Body.String())
@@ -985,7 +985,7 @@ func (suite *HandlerTestSuite) TestModTopicACL01() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	router.HandleFunc("/v1/projects/{project}/topics/{topic}:acl", WrapConfig(TopicACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}:acl", WrapMockAuthConfig(TopicACL, cfgKafka, &brk, str, &mgr))
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, req2)
 	suite.Equal(200, w2.Code)
@@ -1017,7 +1017,7 @@ func (suite *HandlerTestSuite) TestModSubACL01() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscription/{subscription}:modAcl", WrapConfig(SubModACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscription/{subscription}:modAcl", WrapMockAuthConfig(SubModACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal("", w.Body.String())
@@ -1026,7 +1026,7 @@ func (suite *HandlerTestSuite) TestModSubACL01() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	router.HandleFunc("/v1/projects/{project}/subscription/{subscription}:acl", WrapConfig(SubACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscription/{subscription}:acl", WrapMockAuthConfig(SubACL, cfgKafka, &brk, str, &mgr))
 	w2 := httptest.NewRecorder()
 	router.ServeHTTP(w2, req2)
 	suite.Equal(200, w2.Code)
@@ -1051,8 +1051,8 @@ func (suite *HandlerTestSuite) TestSubACL01() {
 
 	expResp := `{
    "authorized_users": [
-      "userA",
-      "userB"
+      "UserA",
+      "UserB"
    ]
 }`
 
@@ -1063,7 +1063,7 @@ func (suite *HandlerTestSuite) TestSubACL01() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscription/{subscription}:acl", WrapConfig(SubACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscription/{subscription}:acl", WrapMockAuthConfig(SubACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -1079,9 +1079,9 @@ func (suite *HandlerTestSuite) TestSubACL02() {
 
 	expResp := `{
    "authorized_users": [
-      "userD",
-      "userB",
-      "userA"
+      "UserZ",
+      "UserB",
+      "UserA"
    ]
 }`
 
@@ -1092,7 +1092,7 @@ func (suite *HandlerTestSuite) TestSubACL02() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:acl", WrapConfig(SubACL, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:acl", WrapMockAuthConfig(SubACL, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -1127,7 +1127,7 @@ func (suite *HandlerTestSuite) TestTopicListAll() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := push.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics", WrapConfig(TopicListAll, cfgKafka, &brk, str, &mgr))
+	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -1438,7 +1438,7 @@ func (suite *HandlerTestSuite) TestSubAck() {
 	router2 := mux.NewRouter().StrictSlash(true)
 	w2 := httptest.NewRecorder()
 	mgr = push.Manager{}
-	router2.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:acknowledge", WrapConfig(SubAck, cfgKafka, &brk, str, &mgr))
+	router2.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:acknowledge", WrapMockAuthConfig(SubAck, cfgKafka, &brk, str, &mgr))
 	router2.ServeHTTP(w2, req2)
 	suite.Equal(200, w2.Code)
 	suite.Equal("{}", w2.Body.String())
@@ -1453,7 +1453,7 @@ func (suite *HandlerTestSuite) TestSubAck() {
 	router3 := mux.NewRouter().StrictSlash(true)
 	w3 := httptest.NewRecorder()
 	mgr = push.Manager{}
-	router3.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:acknowledge", WrapConfig(SubAck, cfgKafka, &brk, str, &mgr))
+	router3.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:acknowledge", WrapMockAuthConfig(SubAck, cfgKafka, &brk, str, &mgr))
 	router3.ServeHTTP(w3, req3)
 	suite.Equal(408, w3.Code)
 	suite.Equal(expJSON2, w3.Body.String())
@@ -1610,7 +1610,7 @@ func (suite *HandlerTestSuite) TestValidationInSubs() {
 		req, err := http.NewRequest("GET", url, bytes.NewBuffer([]byte("")))
 		router := mux.NewRouter().StrictSlash(true)
 		mgr := push.Manager{}
-		router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapValidate(WrapConfig(SubListOne, cfgKafka, &brk, str, &mgr)))
+		router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}", WrapValidate(WrapMockAuthConfig(SubListOne, cfgKafka, &brk, str, &mgr)))
 
 		if err != nil {
 			log.Fatal(err)
@@ -1683,7 +1683,7 @@ func (suite *HandlerTestSuite) TestValidationInTopics() {
 		req, err := http.NewRequest("GET", url, bytes.NewBuffer([]byte("")))
 		router := mux.NewRouter().StrictSlash(true)
 		mgr := push.Manager{}
-		router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapValidate(WrapConfig(TopicListOne, cfgKafka, &brk, str, &mgr)))
+		router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapValidate(WrapMockAuthConfig(TopicListOne, cfgKafka, &brk, str, &mgr)))
 
 		if err != nil {
 			log.Fatal(err)

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -127,12 +127,12 @@ func (mk *MockStore) HasUsers(projectUUID string, users []string) (bool, []strin
 // ModACL changes the acl in a function
 func (mk *MockStore) ModACL(projectUUID string, resource string, name string, acl []string) error {
 	newAcl := QAcl{ACL: acl}
-	if resource == "topics" {
+	if resource == "topic" {
 		if _, exists := mk.TopicsACL[name]; exists {
 			mk.TopicsACL[name] = newAcl
 			return nil
 		}
-	} else if resource == "subscriptions" {
+	} else if resource == "subscription" {
 		if _, exists := mk.SubsACL[name]; exists {
 			mk.SubsACL[name] = newAcl
 			return nil
@@ -327,14 +327,14 @@ func (mk *MockStore) Initialize() {
 	mk.RoleList = append(mk.RoleList, qRole1)
 	mk.RoleList = append(mk.RoleList, qRole2)
 
-	qTopicACL01 := QAcl{[]string{"userA", "userB"}}
-	qTopicACL02 := QAcl{[]string{"userA", "userB", "userD"}}
-	qTopicACL03 := QAcl{[]string{"userC"}}
+	qTopicACL01 := QAcl{[]string{"uuid1", "uuid2"}}
+	qTopicACL02 := QAcl{[]string{"uuid1", "uuid2", "uuid4"}}
+	qTopicACL03 := QAcl{[]string{"uuid3"}}
 
-	qSubACL01 := QAcl{[]string{"userA", "userB"}}
-	qSubACL02 := QAcl{[]string{"userA", "userC"}}
-	qSubACL03 := QAcl{[]string{"userD", "userB", "userA"}}
-	qSubACL04 := QAcl{[]string{"userB", "userD"}}
+	qSubACL01 := QAcl{[]string{"uuid1", "uuid2"}}
+	qSubACL02 := QAcl{[]string{"uuid1", "uuid3"}}
+	qSubACL03 := QAcl{[]string{"uuid4", "uuid2", "uuid1"}}
+	qSubACL04 := QAcl{[]string{"uuid2", "uuid4"}}
 
 	mk.TopicsACL = make(map[string]QAcl)
 	mk.SubsACL = make(map[string]QAcl)

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -91,44 +91,44 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(sb, eSubList[0])
 
 	// Query ACLS
-	ExpectedACL01 := QAcl{[]string{"userA", "userB"}}
-	QAcl01, _ := store.QueryACL("ARGO", "topic", "topic1")
+	ExpectedACL01 := QAcl{[]string{"uuid1", "uuid2"}}
+	QAcl01, _ := store.QueryACL("argo_uuid", "topic", "topic1")
 	suite.Equal(ExpectedACL01, QAcl01)
 
-	ExpectedACL02 := QAcl{[]string{"userA", "userB", "userD"}}
-	QAcl02, _ := store.QueryACL("ARGO", "topic", "topic2")
+	ExpectedACL02 := QAcl{[]string{"uuid1", "uuid2", "uuid4"}}
+	QAcl02, _ := store.QueryACL("argo_uuid", "topic", "topic2")
 	suite.Equal(ExpectedACL02, QAcl02)
 
-	ExpectedACL03 := QAcl{[]string{"userC"}}
-	QAcl03, _ := store.QueryACL("ARGO", "topic", "topic3")
+	ExpectedACL03 := QAcl{[]string{"uuid3"}}
+	QAcl03, _ := store.QueryACL("argo_uuid", "topic", "topic3")
 	suite.Equal(ExpectedACL03, QAcl03)
 
-	ExpectedACL04 := QAcl{[]string{"userA", "userB"}}
-	QAcl04, _ := store.QueryACL("ARGO", "subscription", "sub1")
+	ExpectedACL04 := QAcl{[]string{"uuid1", "uuid2"}}
+	QAcl04, _ := store.QueryACL("argo_uuid", "subscription", "sub1")
 	suite.Equal(ExpectedACL04, QAcl04)
 
-	ExpectedACL05 := QAcl{[]string{"userA", "userC"}}
-	QAcl05, _ := store.QueryACL("ARGO", "subscription", "sub2")
+	ExpectedACL05 := QAcl{[]string{"uuid1", "uuid3"}}
+	QAcl05, _ := store.QueryACL("argo_uuid", "subscription", "sub2")
 	suite.Equal(ExpectedACL05, QAcl05)
 
-	ExpectedACL06 := QAcl{[]string{"userD", "userB", "userA"}}
-	QAcl06, _ := store.QueryACL("ARGO", "subscription", "sub3")
+	ExpectedACL06 := QAcl{[]string{"uuid4", "uuid2", "uuid1"}}
+	QAcl06, _ := store.QueryACL("argo_uuid", "subscription", "sub3")
 	suite.Equal(ExpectedACL06, QAcl06)
 
-	ExpectedACL07 := QAcl{[]string{"userB", "userD"}}
-	QAcl07, _ := store.QueryACL("ARGO", "subscription", "sub4")
+	ExpectedACL07 := QAcl{[]string{"uuid2", "uuid4"}}
+	QAcl07, _ := store.QueryACL("argo_uuid", "subscription", "sub4")
 	suite.Equal(ExpectedACL07, QAcl07)
 
-	QAcl08, err08 := store.QueryACL("ARGO", "subscr", "sub4ss")
+	QAcl08, err08 := store.QueryACL("argo_uuid", "subscr", "sub4ss")
 	suite.Equal(QAcl{}, QAcl08)
 	suite.Equal(errors.New("not found"), err08)
 
 	//Check has users
-	allFound, notFound := store.HasUsers("ARGO", []string{"UserA", "UserB", "FooUser"})
+	allFound, notFound := store.HasUsers("argo_uuid", []string{"UserA", "UserB", "FooUser"})
 	suite.Equal(false, allFound)
 	suite.Equal([]string{"FooUser"}, notFound)
 
-	allFound, notFound = store.HasUsers("ARGO", []string{"UserA", "UserB"})
+	allFound, notFound = store.HasUsers("argo_uuid", []string{"UserA", "UserB"})
 	suite.Equal(true, allFound)
 	suite.Equal([]string(nil), notFound)
 

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -52,51 +52,9 @@ type AckIDs struct {
 	IDs []string `json:"AckIds"`
 }
 
-// SubACL holds the authorized users for a topic
-type SubACL struct {
-	AuthUsers []string `json:"authorized_users"`
-}
-
-// Empty returns true if Topics has no items
+// Empty returns true if Subscriptions list has no items
 func (sl *Subscriptions) Empty() bool {
 	return len(sl.List) <= 0
-}
-
-// GetSubACL returns an authorized list of users for the topic
-func GetSubACL(project string, sub string, store stores.Store) (SubACL, error) {
-	result := SubACL{}
-	subACL, err := store.QueryACL(project, "subscription", sub)
-	if err != nil {
-		return result, err
-	}
-	for _, item := range subACL.ACL {
-		result.AuthUsers = append(result.AuthUsers, item)
-	}
-	return result, nil
-}
-
-// GetACLFromJSON retrieves SubACL info from JSON
-func GetACLFromJSON(input []byte) (SubACL, error) {
-	s := SubACL{}
-	err := json.Unmarshal([]byte(input), &s)
-	if s.AuthUsers == nil {
-		return s, errors.New("wrong argument")
-	}
-	return s, err
-}
-
-// ModACL is called to modify a sub's acl
-func ModACL(project string, name string, acl []string, store stores.Store) error {
-	return store.ModACL(project, "subscriptions", name, acl)
-}
-
-// ExportJSON export subscription acl body to json for use in http response
-func (sAcl *SubACL) ExportJSON() (string, error) {
-	if sAcl.AuthUsers == nil {
-		sAcl.AuthUsers = make([]string, 0)
-	}
-	output, err := json.MarshalIndent(sAcl, "", "   ")
-	return string(output[:]), err
 }
 
 // GetAckFromJSON retrieves ack ids from json

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -259,67 +259,6 @@ func (suite *SubTestSuite) TestExportJson() {
 
 }
 
-func (suite *SubTestSuite) TestSubACL() {
-	expJSON01 := `{
-   "authorized_users": [
-      "userA",
-      "userB"
-   ]
-}`
-
-	expJSON02 := `{
-   "authorized_users": [
-      "userA",
-      "userC"
-   ]
-}`
-
-	expJSON03 := `{
-   "authorized_users": [
-      "userD",
-      "userB",
-      "userA"
-   ]
-}`
-
-	expJSON04 := `{
-   "authorized_users": [
-      "userB",
-      "userD"
-   ]
-}`
-
-	expJSON05 := `{
-   "authorized_users": []
-}`
-
-	APIcfg := config.NewAPICfg()
-	APIcfg.LoadStrJSON(suite.cfgStr)
-
-	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
-
-	sACL, _ := GetSubACL("ARGO", "sub1", store)
-	outJSON, _ := sACL.ExportJSON()
-	suite.Equal(expJSON01, outJSON)
-
-	sACL2, _ := GetSubACL("ARGO", "sub2", store)
-	outJSON2, _ := sACL2.ExportJSON()
-	suite.Equal(expJSON02, outJSON2)
-
-	sACL3, _ := GetSubACL("ARGO", "sub3", store)
-	outJSON3, _ := sACL3.ExportJSON()
-	suite.Equal(expJSON03, outJSON3)
-
-	sACL4, _ := GetSubACL("ARGO", "sub4", store)
-	outJSON4, _ := sACL4.ExportJSON()
-	suite.Equal(expJSON04, outJSON4)
-
-	sACL5 := SubACL{}
-	outJSON5, _ := sACL5.ExportJSON()
-	suite.Equal(expJSON05, outJSON5)
-
-}
-
 func (suite *SubTestSuite) TestGetMaxAckID() {
 	ackIDs := []string{"projects/ARGO/subscriptions/sub1:2",
 		"projects/ARGO/subscriptions/sub1:4",

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -15,11 +15,6 @@ type Topic struct {
 	FullName    string `json:"name"`
 }
 
-// TopicACL holds the authorized users for a topic
-type TopicACL struct {
-	AuthUsers []string `json:"authorized_users"`
-}
-
 // Topics holds a list of Topic items
 type Topics struct {
 	List []Topic `json:"topics,omitempty"`
@@ -56,44 +51,6 @@ func Find(projectUUID string, name string, store stores.Store) (Topics, error) {
 func (tp *Topic) ExportJSON() (string, error) {
 
 	output, err := json.MarshalIndent(tp, "", "   ")
-	return string(output[:]), err
-}
-
-// GetTopicACL returns an authorized list of users for the topic
-func GetTopicACL(projectUUID string, topic string, store stores.Store) (TopicACL, error) {
-	result := TopicACL{}
-	topicACL, err := store.QueryACL(projectUUID, "topic", topic)
-	if err != nil {
-		return result, err
-	}
-	for _, item := range topicACL.ACL {
-		result.AuthUsers = append(result.AuthUsers, item)
-	}
-	return result, err
-}
-
-// GetACLFromJSON retrieves TopicACL info from JSON
-func GetACLFromJSON(input []byte) (TopicACL, error) {
-	s := TopicACL{}
-	err := json.Unmarshal([]byte(input), &s)
-	if s.AuthUsers == nil {
-		return s, errors.New("wrong argument")
-	}
-	return s, err
-}
-
-// ModACL is called to modify a topic's acl
-func ModACL(projectUUID string, name string, acl []string, store stores.Store) error {
-
-	return store.ModACL(projectUUID, "topics", name, acl)
-}
-
-// ExportJSON export topic acl body to json for use in http response
-func (tAcl *TopicACL) ExportJSON() (string, error) {
-	if tAcl.AuthUsers == nil {
-		tAcl.AuthUsers = make([]string, 0)
-	}
-	output, err := json.MarshalIndent(tAcl, "", "   ")
 	return string(output[:]), err
 }
 

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -111,62 +111,6 @@ func (suite *TopicTestSuite) TestExportJson() {
 
 }
 
-func (suite *TopicTestSuite) TestTopicACL() {
-	expJSON01 := `{
-   "authorized_users": [
-      "userA",
-      "userB"
-   ]
-}`
-
-	expJSON02 := `{
-   "authorized_users": [
-      "userA",
-      "userB",
-      "userD"
-   ]
-}`
-
-	expJSON03 := `{
-   "authorized_users": [
-      "userC"
-   ]
-}`
-
-	expJSON04 := `{
-   "authorized_users": []
-}`
-
-	APIcfg := config.NewAPICfg()
-	APIcfg.LoadStrJSON(suite.cfgStr)
-
-	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
-
-	tACL, _ := GetTopicACL("ARGO", "topic1", store)
-	outJSON, _ := tACL.ExportJSON()
-	suite.Equal(expJSON01, outJSON)
-
-	tACL2, _ := GetTopicACL("ARGO", "topic2", store)
-	outJSON2, _ := tACL2.ExportJSON()
-	suite.Equal(expJSON02, outJSON2)
-
-	tACL3, _ := GetTopicACL("ARGO", "topic3", store)
-	outJSON3, _ := tACL3.ExportJSON()
-	suite.Equal(expJSON03, outJSON3)
-
-	tACL4 := TopicACL{}
-	outJSON4, _ := tACL4.ExportJSON()
-	suite.Equal(expJSON04, outJSON4)
-
-	// Test topics empty method
-	tpc1, _ := Find("argo_uuid", "FooTopic", store)
-	suite.Equal(true, tpc1.Empty())
-
-	tpc2, _ := Find("argo_uuid", "", store)
-	suite.Equal(false, tpc2.Empty())
-
-}
-
 func TestTopicsTestSuite(t *testing.T) {
 	suite.Run(t, new(TopicTestSuite))
 }


### PR DESCRIPTION
- [x] Fix ACL query issues regarding using `project_uuid` reference instead of old `project` ref. 
- [x] Transfer ACL components to auth package to avoid cyclic dependencies as more features were added
- [x] Make ACLs reference users by their uuid's instead of usernames in the datastore.
- [x] Transform user uuids to usernames when acls are rendered in json responses
- [x] Optimize projectUUID retrieval in handlers (retrieved once during auth step and shared to handlers via context variable) 
- [x] Add check to assert that if Update Project/User methods change a resource name, that name remains unique
- [x] Fix some invalid argument errors to have correct status (400) 
- [x] Update docs with list of predefined roles