### PR TITLE
Fix sub mod ACL issues

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -34,11 +34,13 @@ func GetACLFromJSON(input []byte) (ACL, error) {
 // ModACL is called to modify an acl
 func ModACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
 	// Transform user name to user uuid
+
 	userUUIDs := []string{}
 	for _, username := range acl {
 		userUUID := GetUUIDByName(username, store)
 		userUUIDs = append(userUUIDs, userUUID)
 	}
+
 	return store.ModACL(projectUUID, resourceType, resourceName, userUUIDs)
 }
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -50,24 +50,24 @@ func (suite *AuthTestSuite) TestAuth() {
 	// topic3: userC
 
 	// Check authorization per topic for userA
-	suite.Equal(true, PerResource("argo_uuid", "topic", "topic1", "UserA", store))
-	suite.Equal(true, PerResource("argo_uuid", "topic", "topic2", "UserA", store))
-	suite.Equal(false, PerResource("argo_uuid", "topic", "topic3", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "topics", "topic1", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "topics", "topic2", "UserA", store))
+	suite.Equal(false, PerResource("argo_uuid", "topics", "topic3", "UserA", store))
 
 	// Check authorization per topic for userB
-	suite.Equal(true, PerResource("argo_uuid", "topic", "topic1", "UserB", store))
-	suite.Equal(true, PerResource("argo_uuid", "topic", "topic2", "UserB", store))
-	suite.Equal(false, PerResource("argo_uuid", "topic", "topic3", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "topics", "topic1", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "topics", "topic2", "UserB", store))
+	suite.Equal(false, PerResource("argo_uuid", "topics", "topic3", "UserB", store))
 
 	// Check authorization per topic for userC
-	suite.Equal(false, PerResource("argo_uuid", "topic", "topic1", "UserX", store))
-	suite.Equal(false, PerResource("argo_uuid", "topic", "topic2", "UserX", store))
-	suite.Equal(true, PerResource("argo_uuid", "topic", "topic3", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "topics", "topic1", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "topics", "topic2", "UserX", store))
+	suite.Equal(true, PerResource("argo_uuid", "topics", "topic3", "UserX", store))
 
 	// Check authorization per topic for userD
-	suite.Equal(false, PerResource("argo_uuid", "topic", "topic1", "UserZ", store))
-	suite.Equal(true, PerResource("argo_uuid", "topic", "topic2", "UserZ", store))
-	suite.Equal(false, PerResource("argo_uuid", "topic", "topic3", "UserZ", store))
+	suite.Equal(false, PerResource("argo_uuid", "topics", "topic1", "UserZ", store))
+	suite.Equal(true, PerResource("argo_uuid", "topics", "topic2", "UserZ", store))
+	suite.Equal(false, PerResource("argo_uuid", "topics", "topic3", "UserZ", store))
 
 	// Check user authorization per subscription
 	//
@@ -77,26 +77,26 @@ func (suite *AuthTestSuite) TestAuth() {
 	// sub4: userB, userD
 
 	// Check authorization per subscription for userA
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub1", "UserA", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub2", "UserA", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub3", "UserA", store))
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub4", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub1", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub2", "UserA", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub3", "UserA", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub4", "UserA", store))
 
 	// Check authorization per subscription for userB
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub1", "UserB", store))
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub2", "UserB", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub3", "UserB", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub4", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub1", "UserB", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub2", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub3", "UserB", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub4", "UserB", store))
 	// Check authorization per subscription for userC
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub1", "UserX", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub2", "UserX", store))
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub3", "UserX", store))
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub4", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub1", "UserX", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub2", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub3", "UserX", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub4", "UserX", store))
 	// Check authorization per subscription for userD
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub1", "UserZ", store))
-	suite.Equal(false, PerResource("argo_uuid", "subscription", "sub2", "UserZ", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub3", "UserZ", store))
-	suite.Equal(true, PerResource("argo_uuid", "subscription", "sub4", "UserZ", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub1", "UserZ", store))
+	suite.Equal(false, PerResource("argo_uuid", "subscriptions", "sub2", "UserZ", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub3", "UserZ", store))
+	suite.Equal(true, PerResource("argo_uuid", "subscriptions", "sub4", "UserZ", store))
 
 	suite.Equal(true, IsConsumer([]string{"consumer"}))
 	suite.Equal(true, IsConsumer([]string{"consumer", "publisher"}))
@@ -305,19 +305,19 @@ func (suite *AuthTestSuite) TestSubACL() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	sACL, _ := GetACL("argo_uuid", "subscription", "sub1", store)
+	sACL, _ := GetACL("argo_uuid", "subscriptions", "sub1", store)
 	outJSON, _ := sACL.ExportJSON()
 	suite.Equal(expJSON01, outJSON)
 
-	sACL2, _ := GetACL("argo_uuid", "subscription", "sub2", store)
+	sACL2, _ := GetACL("argo_uuid", "subscriptions", "sub2", store)
 	outJSON2, _ := sACL2.ExportJSON()
 	suite.Equal(expJSON02, outJSON2)
 
-	sACL3, _ := GetACL("argo_uuid", "subscription", "sub3", store)
+	sACL3, _ := GetACL("argo_uuid", "subscriptions", "sub3", store)
 	outJSON3, _ := sACL3.ExportJSON()
 	suite.Equal(expJSON03, outJSON3)
 
-	sACL4, _ := GetACL("argo_uuid", "subscription", "sub4", store)
+	sACL4, _ := GetACL("argo_uuid", "subscriptions", "sub4", store)
 	outJSON4, _ := sACL4.ExportJSON()
 	suite.Equal(expJSON04, outJSON4)
 
@@ -358,15 +358,15 @@ func (suite *AuthTestSuite) TestTopicACL() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	tACL, _ := GetACL("argo_uuid", "topic", "topic1", store)
+	tACL, _ := GetACL("argo_uuid", "topics", "topic1", store)
 	outJSON, _ := tACL.ExportJSON()
 	suite.Equal(expJSON01, outJSON)
 
-	tACL2, _ := GetACL("argo_uuid", "topic", "topic2", store)
+	tACL2, _ := GetACL("argo_uuid", "topics", "topic2", store)
 	outJSON2, _ := tACL2.ExportJSON()
 	suite.Equal(expJSON02, outJSON2)
 
-	tACL3, _ := GetACL("argo_uuid", "topic", "topic3", store)
+	tACL3, _ := GetACL("argo_uuid", "topics", "topic3", store)
 	outJSON3, _ := tACL3.ExportJSON()
 	suite.Equal(expJSON03, outJSON3)
 

--- a/auth/users.go
+++ b/auth/users.go
@@ -302,7 +302,9 @@ func AreValidUsers(projectUUID string, users []string, store stores.Store) (bool
 
 // PerResource  (for topics and subscriptions)
 func PerResource(project string, resType string, resName string, user string, store stores.Store) bool {
-	if resType == "topic" || resType == "subscription" {
+
+	if resType == "topics" || resType == "subscriptions" {
+
 		acl, _ := GetACL(project, resType, resName, store)
 		for _, item := range acl.AuthUsers {
 			if item == user {

--- a/handlers.go
+++ b/handlers.go
@@ -916,7 +916,7 @@ func TopicModACL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = auth.ModACL(projectUUID, "topic", urlTopic, postBody.AuthUsers, refStr)
+	err = auth.ModACL(projectUUID, "topics", urlTopic, postBody.AuthUsers, refStr)
 
 	if err != nil {
 
@@ -975,7 +975,7 @@ func SubModACL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = auth.ModACL(projectUUID, "subscription", urlSub, postBody.AuthUsers, refStr)
+	err = auth.ModACL(projectUUID, "subscriptions", urlSub, postBody.AuthUsers, refStr)
 
 	if err != nil {
 
@@ -1298,7 +1298,7 @@ func TopicACL(w http.ResponseWriter, r *http.Request) {
 
 	// Get project UUID First to use as reference
 	projectUUID := context.Get(r, "auth_project_uuid").(string)
-	res, err := auth.GetACL(projectUUID, "topic", urlTopic, refStr)
+	res, err := auth.GetACL(projectUUID, "topics", urlTopic, refStr)
 
 	// If not found
 	if err != nil {
@@ -1339,7 +1339,7 @@ func SubACL(w http.ResponseWriter, r *http.Request) {
 
 	// Get project UUID First to use as reference
 	projectUUID := context.Get(r, "auth_project_uuid").(string)
-	res, err := auth.GetACL(projectUUID, "subscription", urlSub, refStr)
+	res, err := auth.GetACL(projectUUID, "subscriptions", urlSub, refStr)
 
 	// If not found
 	if err != nil {
@@ -1462,7 +1462,7 @@ func TopicPublish(w http.ResponseWriter, r *http.Request) {
 
 	if refAuthResource && auth.IsPublisher(refRoles) {
 
-		if auth.PerResource(projectUUID, "topic", urlTopic, refUser, refStr) == false {
+		if auth.PerResource(projectUUID, "topics", urlTopic, refUser, refStr) == false {
 			respondErr(w, 403, "Access to this resource is forbidden", "FORBIDDEN")
 			return
 		}
@@ -1557,7 +1557,7 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 	// - if enabled in config
 	// - if user has only consumer role
 	if refAuthResource && auth.IsConsumer(refRoles) {
-		if auth.PerResource(urlProject, "subscription", urlSub, refUser, refStr) == false {
+		if auth.PerResource(urlProject, "subscriptions", urlSub, refUser, refStr) == false {
 			respondErr(w, 403, "Access to this resource is forbidden", "FORBIDDEN")
 			return
 		}

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -21,11 +21,11 @@ type MockStore struct {
 
 // QueryACL Topic/Subscription ACL
 func (mk *MockStore) QueryACL(projectUUID string, resource string, name string) (QAcl, error) {
-	if resource == "topic" {
+	if resource == "topics" {
 		if _, exists := mk.TopicsACL[name]; exists {
 			return mk.TopicsACL[name], nil
 		}
-	} else if resource == "subscription" {
+	} else if resource == "subscriptions" {
 		if _, exists := mk.SubsACL[name]; exists {
 			return mk.SubsACL[name], nil
 		}
@@ -127,12 +127,12 @@ func (mk *MockStore) HasUsers(projectUUID string, users []string) (bool, []strin
 // ModACL changes the acl in a function
 func (mk *MockStore) ModACL(projectUUID string, resource string, name string, acl []string) error {
 	newAcl := QAcl{ACL: acl}
-	if resource == "topic" {
+	if resource == "topics" {
 		if _, exists := mk.TopicsACL[name]; exists {
 			mk.TopicsACL[name] = newAcl
 			return nil
 		}
-	} else if resource == "subscription" {
+	} else if resource == "subscriptions" {
 		if _, exists := mk.SubsACL[name]; exists {
 			mk.SubsACL[name] = newAcl
 			return nil

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -92,31 +92,31 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// Query ACLS
 	ExpectedACL01 := QAcl{[]string{"uuid1", "uuid2"}}
-	QAcl01, _ := store.QueryACL("argo_uuid", "topic", "topic1")
+	QAcl01, _ := store.QueryACL("argo_uuid", "topics", "topic1")
 	suite.Equal(ExpectedACL01, QAcl01)
 
 	ExpectedACL02 := QAcl{[]string{"uuid1", "uuid2", "uuid4"}}
-	QAcl02, _ := store.QueryACL("argo_uuid", "topic", "topic2")
+	QAcl02, _ := store.QueryACL("argo_uuid", "topics", "topic2")
 	suite.Equal(ExpectedACL02, QAcl02)
 
 	ExpectedACL03 := QAcl{[]string{"uuid3"}}
-	QAcl03, _ := store.QueryACL("argo_uuid", "topic", "topic3")
+	QAcl03, _ := store.QueryACL("argo_uuid", "topics", "topic3")
 	suite.Equal(ExpectedACL03, QAcl03)
 
 	ExpectedACL04 := QAcl{[]string{"uuid1", "uuid2"}}
-	QAcl04, _ := store.QueryACL("argo_uuid", "subscription", "sub1")
+	QAcl04, _ := store.QueryACL("argo_uuid", "subscriptions", "sub1")
 	suite.Equal(ExpectedACL04, QAcl04)
 
 	ExpectedACL05 := QAcl{[]string{"uuid1", "uuid3"}}
-	QAcl05, _ := store.QueryACL("argo_uuid", "subscription", "sub2")
+	QAcl05, _ := store.QueryACL("argo_uuid", "subscriptions", "sub2")
 	suite.Equal(ExpectedACL05, QAcl05)
 
 	ExpectedACL06 := QAcl{[]string{"uuid4", "uuid2", "uuid1"}}
-	QAcl06, _ := store.QueryACL("argo_uuid", "subscription", "sub3")
+	QAcl06, _ := store.QueryACL("argo_uuid", "subscriptions", "sub3")
 	suite.Equal(ExpectedACL06, QAcl06)
 
 	ExpectedACL07 := QAcl{[]string{"uuid2", "uuid4"}}
-	QAcl07, _ := store.QueryACL("argo_uuid", "subscription", "sub4")
+	QAcl07, _ := store.QueryACL("argo_uuid", "subscriptions", "sub4")
 	suite.Equal(ExpectedACL07, QAcl07)
 
 	QAcl08, err08 := store.QueryACL("argo_uuid", "subscr", "sub4ss")


### PR DESCRIPTION
### Issue
ModACL request resolved in resource not found errors (e.g. subscription not found etc)

### Fix
In ACL related methods use plural names as resource type ("topics", "subscriptions") and feed directly those type to the mongodb queries when selecting approprate collections (e.g. db.topics, db.subscriptions)

