### PR TITLE
Adds support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine
+ADD argo-messaging-linux-static /home/argo/argo-messaging
+ADD config.json /home/argo/config.json
+ADD host.crt /home/argo/host.crt
+ADD host.key /home/argo/host.key
+ENV HOME /home/argo
+EXPOSE 8080
+WORKDIR /home/argo
+# Kafka and Zookeper take some time to boot up.
+# We wait for 20'' and then start the service.
+CMD sleep 20 && /home/argo/argo-messaging

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ SPECFILE=${PKGNAME}.spec
 SHELL=bash
 PKGVERSION = $(shell grep -s '^Version:' $(SPECFILE) | sed -e 's/Version: *//')
 TMPDIR := $(shell mktemp -d /tmp/${PKGNAME}.XXXXXXXXXX)
+GOPATH := $(shell mktemp -d /tmp/go.XXXXXXXXXX)
+APPDIR := ${CURDIR}
+GOFILES_NOVENDOR = $(shell go list ./... | grep -v '/vendor/' | sed -e 's/_\/usr\/src\/myapp/./g')
 
 sources:
 	mkdir -p ${TMPDIR}/${PKGNAME}-${PKGVERSION}/src/github.com/ARGOeu/argo-messaging
@@ -10,3 +13,25 @@ sources:
 	cd ${TMPDIR} && tar czf ${PKGNAME}-${PKGVERSION}.tar.gz ${PKGNAME}-${PKGVERSION}
 	mv ${TMPDIR}/${PKGNAME}-${PKGVERSION}.tar.gz .
 	if [[ ${TMPDIR} == /tmp* ]]; then rm -rf ${TMPDIR} ;fi
+
+go-build-linux-static:
+	mkdir -p ${GOPATH}/src/github.com/ARGOeu/argo-messaging
+	cp -R . ${GOPATH}/src/github.com/ARGOeu/argo-messaging
+	cd ${GOPATH}/src/github.com/ARGOeu/argo-messaging && \
+	go get github.com/tools/godep && \
+	${GOPATH}/bin/godep restore && \
+	${GOPATH}/bin/godep update ... && \
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o ${APPDIR}/argo-messaging-linux-static . &&\
+	chown ${hostUID} ${APPDIR}/argo-messaging-linux-static
+
+go-test:
+	mkdir -p ${GOPATH}/src/github.com/ARGOeu/argo-messaging
+	cp -R . ${GOPATH}/src/github.com/ARGOeu/argo-messaging
+	cd ${GOPATH}/src/github.com/ARGOeu/argo-messaging && \
+	go get github.com/tools/godep && \
+	go get github.com/axw/gocov/... && \
+	go get github.com/AlekSi/gocov-xml && \
+	${GOPATH}/bin/godep restore && \
+	${GOPATH}/bin/godep update ... && \
+	${GOPATH}/bin/gocov test ${GOFILES_NOVENDOR} | ${GOPATH}/bin/gocov-xml > ${APPDIR}/coverage.xml &&\
+	chown ${hostUID} ${APPDIR}/coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,47 +1,122 @@
 [![Build Status](https://travis-ci.org/ARGOeu/argo-messaging.svg?branch=devel)](https://travis-ci.org/ARGOeu/argo-messaging)
 # ARGO Messaging
 
-## Development
+> ## :warning: Warning :warning: 
+> These installation instructions are meant for running the service for demo purposes. If you want to operate the service for anything else other than a simple demo, please implement a deployment model that meets your requirements.
 
-1. Install Golang and bzr library
-2. Create a new work space:
+In order to build, test and run the service, recent versions of the docker-engine (>=1.12) and the docker-compose (>= 1.8.0) are required. Step 1 refers to the docker installation on Ubuntu 16.04.1, please adopt accordingly your Linux distribution or OS.
 
-      `mkdir ~/go-workspace`
-      `export GOPATH=~/go-workspace`
-      `export PATH=$PATH:$GOPATH/bin`
+## Install docker from dockerproject.org (Ubuntu 16.04.1)
 
+```shell
+$ sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+$ echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" | sudo tee /etc/apt/sources.list.d/docker.list
+$ sudo apt-get update
+$ sudo apt-cache policy docker-engine
+$ sudo apt-get install linux-image-extra-$(uname -r) linux-image-extra-virtual
+$ sudo apt-get install docker-engine
+```
 
-  You may add the last `export` line into the `~/.bashrc` or the `~/.bash_profile` file to have `GOPATH` environment variable properly setup upon every login.
+We advise you to follow the steps described in docker manual. For Ubuntu:
 
-3. Get the latest version
+- Prerequisites : https://docs.docker.com/engine/installation/linux/ubuntulinux/#prerequisites
+- Install : https://docs.docker.com/engine/installation/linux/ubuntulinux/#install
+- Add a docker group [https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group] .
 
-      `go get github.com/ARGOeu/argo-messaging`
+**Note:** Don't forget to login logout before running the docker as a non root user. This ensures your user is running with the correct permissions.
 
-4. Get dependencies:
+## Install docker-compose
+ 
+We are using version of the Compose file format. To install the latest docker-compose, follow the guidelines here: https://github.com/docker/compose/releases
+   
+## Clone the argo-messaging repository
 
-   Argo-messaging uses godep tool for dependency handling.
-   To install godep tool issue:
+```shell
+$ git clone https://github.com/ARGOeu/argo-messaging
+```
 
-      `go get github.com/tools/godep`
-      `godep restore`
-      `godep update ...`
+## Get certificates (skip this step if you already have certificates)
 
-5. To build the service use the following command:
+The ARGO Messaging services requires certificates in order to operates. The easiest way is to get certificates from letsencrypt. You can follow the instructions from the letsencrypt website or use the docker letsencrypt docker image. One caveat of this approach is that the certificate files end up in the ```etc/live``` directory (see below) and will be owned by the root user.
 
-      `go build`
+```shell
+$ mkdir -p ${HOME}/letsencrypt/{etc,var}
+$ docker run -it --rm -p 443:443 -p 80:80 --name certbot \
+    -v "$HOME/letsencrypt/etc:/etc/letsencrypt" \
+    -v "$HOME/letsencrypt/var:/var/lib/letsencrypt" \
+    quay.io/letsencrypt/letsencrypt:latest certonly
+$ cd argo-messaging
+# Comment: Please change owneship of ${HOME}/letsencrypt to your user
+$ cp ${HOME}/letsencrypt/etc/live/*/fullchain.pem host.crt
+$ sudo cp ${HOME}/letsencrypt/etc/live/*/privkey.pem host.key
+```
+## Edit the default configuration file (config.json)
 
-6. To run the service use the following command:
+In the ```argo-messaging``` directory, edit ```config.json```:
 
-      `./argo-messaging`
+```diff
+{
+"bind_ip":"",
+"port":8080,
+-  "zookeeper_hosts":["localhost"],
+-  "store_host":"localhost",
++  "zookeeper_hosts":["zookeeper"],
++  "store_host":"mongo",
+"store_db":"argo_msg",
+-  "certificate":"/etc/pki/tls/certs/localhost.crt",
+-  "certificate_key":"/etc/pki/tls/private/localhost.key",
++  "certificate":"./host.crt",
++  "certificate_key":"./host.key",
+"service_token":"CHANGE-THIS-TO-A-LONG-STRING"
+}
+```
 
-7. To run the unit-tests:
+**Note:** Make sure that you change the service_token to a long string.
 
-      `go test ./...`
+## Edit docker-compose.yml
 
-8. To generate and serve godoc (@port 6060)
+In the ```argo-messaging``` directory, edit ```docker-compose.yml``` and add the public IP address of your host to the ```KAFKA_ADVERTISED_HOST_NAME``` key.
 
-      `godoc -http=:6060`
+## Run the tests
 
+```shell
+$ docker run --env hostUID=`id -u`:`id -g` --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.7 make go-test
+```
+
+## Build the service
+
+```shell
+$ docker run --env hostUID=`id -u`:`id -g` --rm -v "$PWD":/usr/src/myapp -w /usr/src/myapp golang:1.7 make go-build-linux-static
+```
+ 
+## Start the service
+
+```shell
+$ docker-compose build
+$ docker-compose up -d
+```
+
+##  Test that the service is running
+
+```shell
+$ curl https://<HOSTNAME>/v1/projects?key=<YOUR_SERVICE_TOKEN>
+```
+
+**Note:** Change ```<HOSTNAME>``` to the hostname of your host and ```<SERVICE_TOKEN>``` to the service token that you have added in ```config.json```. You should get an empty json response:
+
+```shell
+{}
+```
+
+## Stop the service
+
+```shell
+$ docker-compose stop
+```
+
+## Congratulations!
+
+Please visit http://argoeu.github.io/messaging/v1/ to learn how to use the service.
 
 ## Credits
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    links:
+      - zookeeper
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: ADD_PUBLIC_IP_ADDRESS
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: "10"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+  argo-messaging:
+    build: .
+    ports:
+      - "443:8080"
+    depends_on:
+        - mongo
+        - kafka
+    links:
+      - mongo
+      - zookeeper
+      - kafka
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Up to know we had only one deployment model for the ARGO Messaging
Service via the use of RPMs for CENTOS and RHEL environments. This
commit adds support for orchestrating the AMS deployment via docker.

It provides a way to deploy AMS on any Linux distribution that supports
a recent version of the docker-engine and docker-compose. It has been
tested on Ubuntu 16.04.1.

Dockerized features:

- Run unit tests
- Build linux static binary
- Get certificates via letsencrypt
- Deploy Zookeper, Kafka, MongoDB and AMS