### PR TITLE
Fixes ARGO-592

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "bind_ip":"",
   "port":8080,
   "zookeeper_hosts":["localhost"],
+  "kafka_znode":"",
   "store_host":"localhost",
   "store_db":"argo_msg",
   "certificate":"/etc/pki/tls/certs/localhost.crt",

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type APICfg struct {
 	BindIP       string
 	Port         int
 	ZooHosts     []string
+	KafkaZnode   string //The Zookeeper znode used by Kafka
 	StoreHost    string
 	StoreDB      string
 	Cert         string
@@ -52,7 +53,7 @@ func (cfg *APICfg) GetZooList() []string {
 	if err != nil {
 		panic(err)
 	}
-	brIDs, _, err := zConn.Children("/brokers/ids")
+	brIDs, _, err := zConn.Children(cfg.KafkaZnode + "/brokers/ids")
 	if err != nil {
 		panic(err)
 	}
@@ -60,7 +61,7 @@ func (cfg *APICfg) GetZooList() []string {
 	peerList := []string{}
 
 	for _, brID := range brIDs {
-		data, _, err := zConn.Get("/brokers/ids/" + brID)
+		data, _, err := zConn.Get(cfg.KafkaZnode + "/brokers/ids/" + brID)
 		if err != nil {
 			panic(err)
 		}
@@ -94,6 +95,8 @@ func (cfg *APICfg) Load() {
 	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
 	cfg.ZooHosts = viper.GetStringSlice("zookeeper_hosts")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - zookeeper_hosts", cfg.ZooHosts)
+	cfg.KafkaZnode = viper.GetString("kafka_znode")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.KafkaZnode)
 	cfg.StoreHost = viper.GetString("store_host")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")
@@ -120,6 +123,8 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
 	cfg.ZooHosts = viper.GetStringSlice("zookeeper_hosts")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - zookeeper_hosts", cfg.ZooHosts)
+	cfg.KafkaZnode = viper.GetString("kafka_znode")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.KafkaZnode)
 	cfg.StoreHost = viper.GetString("store_host")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ func (suite *ConfigTestSuite) SetupTest() {
 	  "bind_ip":"",
 	  "port":8080,
 		"zookeeper_hosts":["localhost"],
+		"kafka_znode":"/argo-messaging",
 		"store_host":"localhost",
 		"store_db":"argo_msg",
 		"certificate":"/etc/pki/tls/certs/localhost.crt",
@@ -34,6 +35,7 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	suite.Equal([]string(nil), APIcfg.ZooHosts)
 	APIcfg.Load()
 	suite.Equal([]string{"localhost"}, APIcfg.ZooHosts)
+	suite.Equal("", APIcfg.KafkaZnode)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
 	suite.Equal(8080, APIcfg.Port)
@@ -41,6 +43,7 @@ func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	// test "LOAD" param
 	APIcfg2 := NewAPICfg("LOAD")
 	suite.Equal([]string{"localhost"}, APIcfg2.ZooHosts)
+	suite.Equal("", APIcfg2.KafkaZnode)
 	suite.Equal("localhost", APIcfg2.StoreHost)
 	suite.Equal("argo_msg", APIcfg2.StoreDB)
 	suite.Equal(8080, APIcfg.Port)
@@ -55,6 +58,7 @@ func (suite *ConfigTestSuite) TestLoadStringJSON() {
 	APIcfg := NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)
 	suite.Equal([]string{"localhost"}, APIcfg.ZooHosts)
+	suite.Equal("/argo-messaging", APIcfg.KafkaZnode)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
 	suite.Equal(8080, APIcfg.Port)

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -17,7 +17,8 @@ The ARGO Messaging Service main configuration file is config.json. An example co
 {
   "bind_ip":"",
   "port":8080,
-  "zookeer_hosts":["localhost"],
+  "zookeeper_hosts":["localhost"],
+  "kafka_znode":"",
   "store_host":"localhost",
   "store_db":"argo_msg",
   "certificate":"/etc/pki/tls/certs/localhost.crt",
@@ -34,6 +35,7 @@ Parameter | Description
 bind_ip | the ip address to listen to.
 port | The port where the API will listen to
 zookeeper_hosts | List of zookeeper instances that are used to sync kafka
+kafka_znode | The znode under which Kafka writes its data on Zookeeper. Default is "" meaning the root node
 store_host | Address:port of the datastore server
 store_db | Database name used on the datastore server
 certificate | path to the node's TLS certificate file

--- a/doc/v1/docs/projects_users.md
+++ b/doc/v1/docs/projects_users.md
@@ -24,6 +24,7 @@ First a service token must be defined in the config.json as such:
   "bind_ip":"",
   "port":8080,
   "zookeeper_hosts":["localhost"],
+  "kafka_znode":"",
   "store_host":"localhost",
   "store_db":"argo_msg",
   "certificate":"/etc/pki/tls/certs/localhost.crt",

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -29,6 +29,7 @@ func (suite *HandlerTestSuite) SetupTest() {
 	"bind_ip":"",
 	"port":8080,
 	"zookeeper_hosts":["localhost"],
+	"kafka_znode":"",
 	"store_host":"localhost",
 	"store_db":"argo_msg",
 	"certificate":"/etc/pki/tls/certs/localhost.crt",


### PR DESCRIPTION
Adds an extra configuration parameter: ```kafka_znode```, which defines
the Zookeeper znode used by Kafka as the parent node for the Kafka data
in Zookeeper. The default value is an empty string, which means the root
Zookeeper node (/). A value of ```/argo-messaging``` would mean that the
messaging service should search for the brokers under the the node:
```
/argo-messaging/brokers/ids
```