### PR TITLE
ARGO-564 Fix subscription:pull response null

### DIFF
--- a/messages/message.go
+++ b/messages/message.go
@@ -190,6 +190,9 @@ func (msgIDs *MsgIDs) ExportJSON() (string, error) {
 
 // ExportJSON exports whole msgId  Structure as a json string
 func (recList *RecList) ExportJSON() (string, error) {
+	if recList.RecMsgs == nil {
+		recList.RecMsgs = []RecMsg{}
+	}
 	output, err := json.MarshalIndent(recList, "", "   ")
 	return string(output[:]), err
 }


### PR DESCRIPTION
### Issue
If no new messages are available during subscription pull the response returns null instead of an empty array
```
{
  "receivedMessages": null
}
```
Instead the prefered response is:
```
{
  "receivedMessages": []
}
```

### Implementation
-[x] Refactor ReceivedMessage List in messages package