### PR TITLE
ARGO-587 Display project modified_on, created_on dates in zulu format

### DIFF
--- a/projects/project.go
+++ b/projects/project.go
@@ -11,12 +11,12 @@ import (
 
 // Project is the struct that holds Project information
 type Project struct {
-	UUID        string    `json:"-"`
-	Name        string    `json:"name,omitempty"`
-	CreatedOn   time.Time `json:"created_on,omitempty"`
-	ModifiedOn  time.Time `json:"modified_on,omitempty"`
-	CreatedBy   string    `json:"created_by,omitempty"`
-	Description string    `json:"description,omitempty"`
+	UUID        string `json:"-"`
+	Name        string `json:"name,omitempty"`
+	CreatedOn   string `json:"created_on,omitempty"`
+	ModifiedOn  string `json:"modified_on,omitempty"`
+	CreatedBy   string `json:"created_by,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // Projects holds a list of available projects
@@ -61,7 +61,8 @@ func GetFromJSON(input []byte) (Project, error) {
 
 // NewProject accepts parameters and creates a new project
 func NewProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) Project {
-	return Project{UUID: uuid, Name: name, CreatedOn: createdOn, ModifiedOn: modifiedOn, CreatedBy: createdBy, Description: description}
+	zuluForm := "2006-01-02T15:04:05Z"
+	return Project{UUID: uuid, Name: name, CreatedOn: createdOn.Format(zuluForm), ModifiedOn: modifiedOn.Format(zuluForm), CreatedBy: createdBy, Description: description}
 }
 
 // Find returns a specific project or a list of all available projects in the datastore.

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -106,7 +106,10 @@ func (suite *ProjectsTestSuite) TestProjects() {
   "modified_on": "2009-11-10T23:00:00Z",
   "description":"another description"
   }`
-	expGen02 := Project{CreatedOn: tm, ModifiedOn: tm, Description: "another description"}
+
+	zuluForm := "2006-01-02T15:04:05Z"
+
+	expGen02 := Project{CreatedOn: tm.Format(zuluForm), ModifiedOn: tm.Format(zuluForm), Description: "another description"}
 
 	prGen02, err := GetFromJSON([]byte(prJSON2))
 	suite.Equal(expGen02, prGen02)


### PR DESCRIPTION
- [x] Refactor Project createdOn and modifedOn fields to be displayed as strings containing dates formatted in zulu form.