### PR TITLE
ARGO-586 Project created_by field uses user uuid as a reference

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -69,6 +69,7 @@ func WrapMockAuthConfig(hfn http.HandlerFunc, cfg *config.APICfg, brk brokers.Br
 		context.Set(r, "mgr", mgr)
 		context.Set(r, "auth_resource", cfg.ResAuth)
 		context.Set(r, "auth_user", "UserA")
+		context.Set(r, "auth_user_uuid", "uuid1")
 		context.Set(r, "auth_roles", []string{"publisher", "consumer"})
 		hfn.ServeHTTP(w, r)
 
@@ -290,7 +291,7 @@ func ProjectCreate(w http.ResponseWriter, r *http.Request) {
 
 	// Grab context references
 	refStr := context.Get(r, "str").(stores.Store)
-	refUser := context.Get(r, "auth_user").(string)
+	refUserUUID := context.Get(r, "auth_user_uuid").(string)
 
 	// Read POST JSON body
 	body, err := ioutil.ReadAll(r.Body)
@@ -307,10 +308,9 @@ func ProjectCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uuid := uuid.NewV4().String() // generate a new uuid to attach to the new project
-	user := refUser               // log current authenticated user as the creator
 	created := time.Now()
 	// Get Result Object
-	res, err := projects.CreateProject(uuid, urlProject, created, user, postBody.Description, refStr)
+	res, err := projects.CreateProject(uuid, urlProject, created, refUserUUID, postBody.Description, refStr)
 
 	if err != nil {
 		if err.Error() == "exists" {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -387,7 +387,7 @@ func (suite *HandlerTestSuite) TestProjectUpdate() {
 	projOut, _ := projects.GetFromJSON([]byte(w.Body.String()))
 	suite.Equal("NEWARGO", projOut.Name)
 	// Check if the mock authenticated userA has been marked as the creator
-	suite.Equal("userA", projOut.CreatedBy)
+	suite.Equal("UserA", projOut.CreatedBy)
 	suite.Equal("time to change the description mates and the name", projOut.Description)
 }
 
@@ -432,14 +432,14 @@ func (suite *HandlerTestSuite) TestProjectListAll() {
          "name": "ARGO",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "simple project"
       },
       {
          "name": "ARGO2",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "simple project"
       }
    ]
@@ -503,7 +503,7 @@ func (suite *HandlerTestSuite) TestProjectListOne() {
    "name": "ARGO",
    "created_on": "2009-11-10T23:00:00Z",
    "modified_on": "2009-11-10T23:00:00Z",
-   "created_by": "userA",
+   "created_by": "UserA",
    "description": "simple project"
 }`
 

--- a/projects/project.go
+++ b/projects/project.go
@@ -73,7 +73,13 @@ func Find(uuid string, name string, store stores.Store) (Projects, error) {
 	projects, err := store.QueryProjects(uuid, name)
 
 	for _, item := range projects {
-		curProject := NewProject(item.UUID, item.Name, item.CreatedOn, item.ModifiedOn, item.CreatedBy, item.Description)
+		// Get Username from user uuid
+		username := ""
+		usr, err := store.QueryUsers("", item.CreatedBy, "")
+		if err == nil {
+			username = usr[0].Name
+		}
+		curProject := NewProject(item.UUID, item.Name, item.CreatedOn, item.ModifiedOn, username, item.Description)
 		result.List = append(result.List, curProject)
 	}
 

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -17,8 +17,8 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	store := stores.NewMockStore("mockhost", "mockbase")
 	tm := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 
-	item1 := NewProject("argo_uuid", "ARGO", tm, tm, "userA", "simple project")
-	item2 := NewProject("argo_uuid2", "ARGO2", tm, tm, "userA", "simple project")
+	item1 := NewProject("argo_uuid", "ARGO", tm, tm, "UserA", "simple project")
+	item2 := NewProject("argo_uuid2", "ARGO2", tm, tm, "UserA", "simple project")
 	ep1 := Projects{List: []Project{item1}}
 	ep2 := Projects{List: []Project{item2}}
 	ep3 := Projects{List: []Project{item1, item2}}
@@ -39,9 +39,9 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	suite.Equal(errors.New("not found"), err)
 
 	// Create new project
-	itemNew := NewProject("uuid_new", "BRAND_NEW", tm, tm, "userA", "brand new project")
+	itemNew := NewProject("uuid_new", "BRAND_NEW", tm, tm, "UserA", "brand new project")
 
-	reflect, err := CreateProject("uuid_new", "BRAND_NEW", tm, "userA", "brand new project", store)
+	reflect, err := CreateProject("uuid_new", "BRAND_NEW", tm, "uuid1", "brand new project", store)
 
 	expNew := Projects{List: []Project{itemNew}}
 	expAllNew := Projects{List: []Project{item1, item2, itemNew}}
@@ -67,21 +67,21 @@ func (suite *ProjectsTestSuite) TestProjects() {
          "name": "ARGO",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "simple project"
       },
       {
          "name": "ARGO2",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "simple project"
       },
       {
          "name": "BRAND_NEW",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "brand new project"
       }
    ]
@@ -134,21 +134,21 @@ func (suite *ProjectsTestSuite) TestProjects() {
          "name": "NEW_ARGO",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "a new description and name for  project"
       },
       {
          "name": "ARGO2",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "this project has only description changed"
       },
       {
          "name": "ONLY_NAME_CHANGED",
          "created_on": "2009-11-10T23:00:00Z",
          "modified_on": "2009-11-10T23:00:00Z",
-         "created_by": "userA",
+         "created_by": "UserA",
          "description": "brand new project"
       }
    ]

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -303,8 +303,8 @@ func (mk *MockStore) Initialize() {
 	// populate Projects
 	created := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	modified := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	qPr := QProject{UUID: "argo_uuid", Name: "ARGO", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "simple project"}
-	qPr2 := QProject{UUID: "argo_uuid2", Name: "ARGO2", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "simple project"}
+	qPr := QProject{UUID: "argo_uuid", Name: "ARGO", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "simple project"}
+	qPr2 := QProject{UUID: "argo_uuid2", Name: "ARGO2", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "simple project"}
 	mk.ProjectList = append(mk.ProjectList, qPr)
 	mk.ProjectList = append(mk.ProjectList, qPr2)
 

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -136,8 +136,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 	modified := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 
 	// Test Projects
-	qPr := QProject{UUID: "argo_uuid", Name: "ARGO", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "simple project"}
-	qPr2 := QProject{UUID: "argo_uuid2", Name: "ARGO2", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "simple project"}
+	qPr := QProject{UUID: "argo_uuid", Name: "ARGO", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "simple project"}
+	qPr2 := QProject{UUID: "argo_uuid2", Name: "ARGO2", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "simple project"}
 	expProj1 := []QProject{qPr}
 	expProj2 := []QProject{qPr2}
 	expProj3 := []QProject{qPr, qPr2}
@@ -158,10 +158,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(expProj4, projectOut4)
 	suite.Equal(errors.New("not found"), err)
 	// Test insert project
-	qPr3 := QProject{UUID: "argo_uuid3", Name: "ARGO3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "simple project"}
+	qPr3 := QProject{UUID: "argo_uuid3", Name: "ARGO3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "simple project"}
 	expProj5 := []QProject{qPr, qPr2, qPr3}
 	expProj6 := []QProject{qPr3}
-	store.InsertProject("argo_uuid3", "ARGO3", created, modified, "userA", "simple project")
+	store.InsertProject("argo_uuid3", "ARGO3", created, modified, "uuid1", "simple project")
 	projectOut5, err := store.QueryProjects("", "")
 	suite.Equal(expProj5, projectOut5)
 	suite.Equal(nil, err)
@@ -179,15 +179,15 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// Test update project
 	modified = time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)
-	expPr1 := QProject{UUID: "argo_uuid3", Name: "ARGO3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "a modified description"}
+	expPr1 := QProject{UUID: "argo_uuid3", Name: "ARGO3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "a modified description"}
 	store.UpdateProject("argo_uuid3", "", "a modified description", modified)
 	prUp1, _ := store.QueryProjects("argo_uuid3", "")
 	suite.Equal(expPr1, prUp1[0])
-	expPr2 := QProject{UUID: "argo_uuid3", Name: "ARGO_updated3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "a modified description"}
+	expPr2 := QProject{UUID: "argo_uuid3", Name: "ARGO_updated3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "a modified description"}
 	store.UpdateProject("argo_uuid3", "ARGO_updated3", "", modified)
 	prUp2, _ := store.QueryProjects("argo_uuid3", "")
 	suite.Equal(expPr2, prUp2[0])
-	expPr3 := QProject{UUID: "argo_uuid3", Name: "ARGO_3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "userA", Description: "a newly modified description"}
+	expPr3 := QProject{UUID: "argo_uuid3", Name: "ARGO_3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "a newly modified description"}
 	store.UpdateProject("argo_uuid3", "ARGO_3", "a newly modified description", modified)
 	prUp3, _ := store.QueryProjects("argo_uuid3", "")
 	suite.Equal(expPr3, prUp3[0])


### PR DESCRIPTION
### Issue
In project information the field created_by lists the username of the project creator. The username is stored as a string in `created_by` field, so if username changes the project will reference an invalid creator name

### Implementation
- [x] Refactor project package so as to use user uuid in `created_by` field