### PR TITLE
ARGO-588 Add Users created_on, modified_on, created_by fields

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/ARGOeu/argo-messaging/config"
 	"github.com/ARGOeu/argo-messaging/stores"
@@ -133,7 +134,9 @@ func (suite *AuthTestSuite) TestAuth() {
          "name": "Test",
          "token": "S3CR3T",
          "email": "Test@test.com",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z"
       },
       {
          "projects": [
@@ -148,7 +151,9 @@ func (suite *AuthTestSuite) TestAuth() {
          "name": "UserA",
          "token": "S3CR3T1",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z"
       },
       {
          "projects": [
@@ -163,7 +168,10 @@ func (suite *AuthTestSuite) TestAuth() {
          "name": "UserB",
          "token": "S3CR3T2",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
       },
       {
          "projects": [
@@ -177,7 +185,10 @@ func (suite *AuthTestSuite) TestAuth() {
          "name": "UserX",
          "token": "S3CR3T3",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
       },
       {
          "projects": [
@@ -191,7 +202,10 @@ func (suite *AuthTestSuite) TestAuth() {
          "name": "UserZ",
          "token": "S3CR3T4",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
       }
    ]
 }`
@@ -240,11 +254,15 @@ func (suite *AuthTestSuite) TestAuth() {
    "email": "TOK3N",
    "service_roles": [
       "service_admin"
-   ]
+   ],
+   "created_on": "2009-11-10T23:00:00Z",
+   "modified_on": "2009-11-10T23:00:00Z"
 }`
 
+	tm := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
 	// Test Create
-	CreateUser("uuid12", "johndoe", []ProjectRoles{ProjectRoles{Project: "ARGO", Roles: []string{"consumer"}}}, "johndoe@fake.email.foo", "TOK3N", []string{"service_admin"}, store)
+	CreateUser("uuid12", "johndoe", []ProjectRoles{ProjectRoles{Project: "ARGO", Roles: []string{"consumer"}}}, "johndoe@fake.email.foo", "TOK3N", []string{"service_admin"}, tm, "", store)
 	usrs, _ := FindUsers("", "uuid12", "", store)
 	usrJSON, _ := usrs.List[0].ExportJSON()
 	suite.Equal(expUsrJSON, usrJSON)
@@ -265,9 +283,11 @@ func (suite *AuthTestSuite) TestAuth() {
    "service_roles": [
       "consumer",
       "producer"
-   ]
+   ],
+   "created_on": "2009-11-10T23:00:00Z",
+   "modified_on": "2009-11-10T23:00:00Z"
 }`
-	UpdateUser("uuid12", "johnny_doe", nil, "", []string{"consumer", "producer"}, store)
+	UpdateUser("uuid12", "johnny_doe", nil, "", []string{"consumer", "producer"}, tm, store)
 	usrUpd, _ := FindUsers("", "uuid12", "", store)
 	usrUpdJSON, _ := usrUpd.List[0].ExportJSON()
 	suite.Equal(expUpdate, usrUpdJSON)

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1228,6 +1228,12 @@ definitions:
         type: array
         items:
           type: string
+       created_on:
+        type: string
+       modified_on:
+        type: string
+       created_by:
+        type: string
 
   ProjectRoles:
       type: object

--- a/doc/v1/docs/api_users.md
+++ b/doc/v1/docs/api_users.md
@@ -28,49 +28,56 @@ Success Response
     {
        "projects": [
           {
-            "project": "ARGO",
+             "project": "ARGO",
              "roles": [
-                "project_admin"
+              "project_admin"
              ]
           }
        ],
        "name": "Test",
        "token": "S3CR3T",
        "email": "Test@test.com",
-       "service_roles":[]
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
     },
     {
        "projects": [
           {
-            "project": "ARGO",
+             "project": "ARGO",
              "roles": [
-                "project_admin"
+               "project_admin"
              ]
           }
        ],
        "name": "UserA",
        "token": "S3CR3T1",
        "email": "foo-email",
-       "service_roles":[]
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
     },
     {
        "projects": [
           {
-            "project": "ARGO",
+             "project": "ARGO",
              "roles": [
-                "project_admin"
+               "project_admin"
              ]
           }
        ],
        "name": "UserB",
        "token": "S3CR3T2",
        "email": "foo-email",
-       "service_roles":[]
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z",
+       "created_by": "UserA"
     },
     {
        "projects": [
           {
-            "project": "ARGO",
+             "project": "ARGO",
              "roles": [
                 "consumer"
              ]
@@ -79,7 +86,10 @@ Success Response
        "name": "UserX",
        "token": "S3CR3T3",
        "email": "foo-email",
-       "service_roles":[]
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z",
+       "created_by": "UserA"
     },
     {
        "projects": [
@@ -93,7 +103,10 @@ Success Response
        "name": "UserZ",
        "token": "S3CR3T4",
        "email": "foo-email",
-       "service_roles":[]
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z",
+       "created_by": "UserA"
     }
  ]
 }
@@ -139,7 +152,9 @@ Success Response
  "name": "UserA",
  "token": "S3CR3T1",
  "email": "foo-email",
- "service_roles":[]
+ "service_roles":[],
+ "created_on": "2009-11-10T23:00:00Z",
+ "modified_on": "2009-11-10T23:00:00Z"
 }
 ```
 
@@ -218,7 +233,10 @@ Success Response
  "name": "USERNEW",
  "token": "R4ND0MT0K3N",
  "email": "foo-email",
- "service_roles":[]
+ "service_roles":[],
+ "created_on": "2009-11-10T23:00:00Z",
+ "modified_on": "2009-11-10T23:00:00Z",
+ "created_by": "UserA"
 }
 ```
 
@@ -283,7 +301,10 @@ Success Response
  "name": "CHANGED_NAME",
  "token": "R4ND0MT0K3N",
  "email": "foo-email",
- "service_roles":[]
+ "service_roles":[],
+ "created_on": "2009-11-10T23:00:00Z",
+ "modified_on": "2009-11-11T10:00:00Z",
+ "created_by": "UserA"
 }
 ```
 
@@ -327,7 +348,10 @@ Success Response
  "name": "USER2",
  "token": "NEWRANDOMTOKEN",
  "email": "foo-email",
- "service_roles":[]
+ "service_roles":[],
+ "created_on": "2009-11-10T23:00:00Z",
+ "modified_on": "2009-11-11T12:00:00Z",
+ "created_by": "UserA"
 }
 ```
 

--- a/doc/v1/docs/projects_users.md
+++ b/doc/v1/docs/projects_users.md
@@ -11,8 +11,8 @@ After a fresh install of the ARGO Messaging Service, the steps you need to follo
  - Create a project: Project entities is used as a basis of organizing and isolating groups of users & resources
  - Create a project_admin user: Users that have the project_admin have, by default, all capabilities in their project. They can also manage resources such as topics and subscriptions (CRUD) and also manage ACLs (users) on those resources as well.
  - Create a topic: The main resource that is scoped in a project, and can hold messages.
- - Create a subscription: A subscription is the main resource from which users consume messages. 
- - Create users for the new resources: Usually a project has  publisher and consumer accounts for clients that either are authorized to publish or consume messages. 
+ - Create a subscription: A subscription is the main resource from which users consume messages.
+ - Create users for the new resources: Usually a project has  publisher and consumer accounts for clients that either are authorized to publish or consume messages.
 
 ## Configure `service_token`
 
@@ -36,7 +36,7 @@ First a service token must be defined in the config.json as such:
 The service token in this example has the value: `S3CR3T`
 This `service_token` is authorized for all available actions (projects,users,topics,subscriptions).
 
-In order to enable the use of this `service_token` you must restart the service. 
+In order to enable the use of this `service_token` you must restart the service.
 
 ```
 service argo-messaging restart
@@ -45,7 +45,7 @@ service argo-messaging restart
 ## Create a service_admin user
 
 The service_token is intended to be used for the first initialization of the API. The first thing the service needs is a user with all possible capabilities, which is a `service_admin`.
-Now even though no user has been initialized in the service, the administrator can use the ARGO Messaging API Call with service_token `S3CR3T` to create the user. 
+Now even though no user has been initialized in the service, the administrator can use the ARGO Messaging API Call with service_token `S3CR3T` to create the user.
 The service_admin will be able to further define projects and other users.
 
 Using the service_token an admin can create a new service_admin user with the username `demo_service_admin` by calling:
@@ -74,7 +74,9 @@ The response:
   "email": "sadmin@mail.example.foo",
   "service_roles": [
     "service_admin"
-  ]
+  ],
+  "created_on": "2016-10-13T11:19:07Z",
+  "modified_on": "2016-10-13T11:19:07Z"
 }
 ```
 
@@ -90,18 +92,18 @@ Using the `demo_service_admin` account, the user can create the first project (e
 POST https://{URL}/v1/projects/DEMO?key=904c56cc6e2b1955dbd98ace80a45be8238432fc
 ```
 with the following POST BODY:
-```
+```json
 {
    "description":"my first demo project"
 }
 ```
 
 and the response:
-```
+```json
 {
   "name": "DEMO",
-  "created_on": "2016-10-13T12:19:07.341+03:00",
-  "modified_on": "2016-10-13T12:19:07.341+03:00",
+  "created_on": "2016-10-13T12:19:07Z",
+  "modified_on": "2016-10-13T12:19:07Z",
   "created_by": "demo_service_admin",
   "description": "my first demo project"
 }
@@ -141,13 +143,16 @@ The response:
   "name": "admin_DEMO",
   "token": "6311196665befcc1523b8e013979347b8780254c",
   "email": "demoadmin@mail.example.foo",
-  "service_roles": []
+  "service_roles": [],
+  "created_on": "2016-10-13T12:29:07Z",
+  "modified_on": "2016-10-13T12:29:07Z",
+  "created_by": "demo_service_admin"
 }
 ```
 
 For more details visit the [API Users](api_users.md) to see all possible actions for users.
 
-## Create a topic 
+## Create a topic
 
 Service_admin users don't manage resources such as topics/subscriptions. Instead in each project the project_admin is eligible for creating (and managing) topics and subscriptions. To create a new topic (named `topic101`) as `admin_DEMO` user in project `DEMO` the user issues:
 
@@ -175,14 +180,14 @@ To create a new subscription (named `sub101`) to topic `topic101` of project `DE
 PUT https://{URL}/v1/projects/DEMO/subscriptions/subs101?key=6311196665befcc1523b8e013979347b8780254c
 ```
 with POST Body:
-```
+```json
 {
    "topic":"projects/DEMO/topic/topic101"
 }
 ```
 
 and response:
-```
+```json
 {
   "name": "/projects/DEMO/subscriptions/sub101",
   "topic": "/projects/DEMO/topics/topic101",
@@ -215,7 +220,7 @@ with POST Body:
 ```
 
 resulting in response:
-```
+```json
 {
   "projects": [
     {
@@ -228,11 +233,14 @@ resulting in response:
   "name": "publisher_DEMO",
   "token": "915dff62846dd1d790b4296c034c184fa3a859b6",
   "email": "demopublisher@mail.example.foo",
-  "service_roles": []
+  "service_roles": [],
+  "created_on": "2016-10-13T12:39:07Z",
+  "modified_on": "2016-10-13T12:39:07Z",
+  "created_by" : "demo_service_admin"
 }
 ```
 
-To create the `conumer_DEMO` user:
+To create the `consumer_DEMO` user:
 ```
 POST https://{URL}/v1/users/consumer_DEMO?key=904c56cc6e2b1955dbd98ace80a45be8238432fc
 ```
@@ -258,7 +266,10 @@ resulting in response:
   "name": "consumer_DEMO",
   "token": "dba38fd1a45337a617a59e7278c756f23642e9e7",
   "email": "democonsumer@mail.example.foo",
-  "service_roles": []
+  "service_roles": [],
+  "created_on": "2016-10-13T12:40:07Z",
+  "modified_on": "2016-10-13T12:40:07Z",
+  "created_by" : "demo_service_admin"
 }
 ```
 For more details visit the [API Users](api_users.md) to see all possible actions for users.

--- a/handlers.go
+++ b/handlers.go
@@ -503,7 +503,8 @@ func UserUpdate(w http.ResponseWriter, r *http.Request) {
 
 	// Get Result Object
 	userUUID := auth.GetUUIDByName(urlUser, refStr)
-	res, err := auth.UpdateUser(userUUID, postBody.Name, postBody.Projects, postBody.Email, postBody.ServiceRoles, refStr)
+	modified := time.Now()
+	res, err := auth.UpdateUser(userUUID, postBody.Name, postBody.Projects, postBody.Email, postBody.ServiceRoles, modified, refStr)
 
 	if err != nil {
 
@@ -553,6 +554,7 @@ func UserCreate(w http.ResponseWriter, r *http.Request) {
 
 	// Grab context references
 	refStr := context.Get(r, "str").(stores.Store)
+	refUserUUID := context.Get(r, "auth_user_uuid").(string)
 
 	// Read POST JSON body
 	body, err := ioutil.ReadAll(r.Body)
@@ -570,8 +572,9 @@ func UserCreate(w http.ResponseWriter, r *http.Request) {
 
 	uuid := uuid.NewV4().String() // generate a new uuid to attach to the new project
 	token, err := auth.GenToken() // generate a new user token
+	created := time.Now()
 	// Get Result Object
-	res, err := auth.CreateUser(uuid, urlUser, postBody.Projects, token, postBody.Email, postBody.ServiceRoles, refStr)
+	res, err := auth.CreateUser(uuid, urlUser, postBody.Projects, token, postBody.Email, postBody.ServiceRoles, created, refUserUUID, refStr)
 
 	if err != nil {
 		if err.Error() == "exists" {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -117,23 +117,6 @@ func (suite *HandlerTestSuite) TestRefreshToken() {
 
 func (suite *HandlerTestSuite) TestUserUpdate() {
 
-	expJSON := `{
-   "projects": [
-      {
-         "project": "ARGO",
-         "roles": [
-            "producer"
-         ]
-      }
-   ],
-   "name": "UPDATED_NAME",
-   "token": "S3CR3T4",
-   "email": "foo-email",
-   "service_roles": [
-      "service_admin"
-   ]
-}`
-
 	postJSON := `{
 	"name":"UPDATED_NAME",
 	"service_roles":["service_admin"]
@@ -154,7 +137,11 @@ func (suite *HandlerTestSuite) TestUserUpdate() {
 	router.HandleFunc("/v1/users/{user}", WrapMockAuthConfig(UserUpdate, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
-	suite.Equal(expJSON, w.Body.String())
+	userOut, _ := auth.GetUserFromJSON([]byte(w.Body.String()))
+	suite.Equal("UPDATED_NAME", userOut.Name)
+	suite.Equal([]string{"service_admin"}, userOut.ServiceRoles)
+	suite.Equal("UserA", userOut.CreatedBy)
+
 }
 
 func (suite *HandlerTestSuite) TestUserListOne() {
@@ -177,7 +164,9 @@ func (suite *HandlerTestSuite) TestUserListOne() {
    "name": "UserA",
    "token": "S3CR3T1",
    "email": "foo-email",
-   "service_roles": []
+   "service_roles": [],
+   "created_on": "2009-11-10T23:00:00Z",
+   "modified_on": "2009-11-10T23:00:00Z"
 }`
 
 	cfgKafka := config.NewAPICfg()
@@ -217,7 +206,9 @@ func (suite *HandlerTestSuite) TestUserListAll() {
          "name": "Test",
          "token": "S3CR3T",
          "email": "Test@test.com",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z"
       },
       {
          "projects": [
@@ -232,7 +223,9 @@ func (suite *HandlerTestSuite) TestUserListAll() {
          "name": "UserA",
          "token": "S3CR3T1",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z"
       },
       {
          "projects": [
@@ -247,7 +240,10 @@ func (suite *HandlerTestSuite) TestUserListAll() {
          "name": "UserB",
          "token": "S3CR3T2",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
       },
       {
          "projects": [
@@ -261,7 +257,10 @@ func (suite *HandlerTestSuite) TestUserListAll() {
          "name": "UserX",
          "token": "S3CR3T3",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
       },
       {
          "projects": [
@@ -275,7 +274,10 @@ func (suite *HandlerTestSuite) TestUserListAll() {
          "name": "UserZ",
          "token": "S3CR3T4",
          "email": "foo-email",
-         "service_roles": []
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
       }
    ]
 }`

--- a/projects/project.go
+++ b/projects/project.go
@@ -75,9 +75,11 @@ func Find(uuid string, name string, store stores.Store) (Projects, error) {
 	for _, item := range projects {
 		// Get Username from user uuid
 		username := ""
-		usr, err := store.QueryUsers("", item.CreatedBy, "")
-		if err == nil {
-			username = usr[0].Name
+		if item.CreatedBy != "" {
+			usr, err := store.QueryUsers("", item.CreatedBy, "")
+			if err == nil && len(usr) > 0 {
+				username = usr[0].Name
+			}
 		}
 		curProject := NewProject(item.UUID, item.Name, item.CreatedOn, item.ModifiedOn, username, item.Description)
 		result.List = append(result.List, curProject)

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -50,8 +50,8 @@ func (mk *MockStore) Close() {
 }
 
 // InsertUser inserts a new user to the store
-func (mk *MockStore) InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string) error {
-	user := QUser{UUID: uuid, Name: name, Email: email, Projects: projects, Token: token, ServiceRoles: serviceRoles}
+func (mk *MockStore) InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error {
+	user := QUser{UUID: uuid, Name: name, Email: email, Projects: projects, Token: token, ServiceRoles: serviceRoles, CreatedOn: createdOn, ModifiedOn: modifiedOn, CreatedBy: createdBy}
 	mk.UserList = append(mk.UserList, user)
 	return nil
 }
@@ -75,7 +75,7 @@ func (mk *MockStore) UpdateUserToken(uuid string, token string) error {
 }
 
 // UpdateUser updates user information
-func (mk *MockStore) UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string) error {
+func (mk *MockStore) UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error {
 
 	for i, item := range mk.UserList {
 		if item.UUID == uuid {
@@ -91,6 +91,8 @@ func (mk *MockStore) UpdateUser(uuid string, projects []QProjectRoles, name stri
 			if email != "" {
 				mk.UserList[i].Email = email
 			}
+
+			mk.UserList[i].ModifiedOn = modifiedOn
 
 			return nil
 		}
@@ -310,17 +312,17 @@ func (mk *MockStore) Initialize() {
 
 	// populate Users
 	qRole := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"admin", "member"}}}
-	qUsr := QUser{"uuid0", qRole, "Test", "S3CR3T", "Test@test.com", []string{}}
+	qUsr := QUser{"uuid0", qRole, "Test", "S3CR3T", "Test@test.com", []string{}, created, modified, ""}
 
 	mk.UserList = append(mk.UserList, qUsr)
 
 	qRoleConsumer := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"consumer"}}}
 	qRoleProducer := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"producer"}}}
 
-	mk.UserList = append(mk.UserList, QUser{"uuid1", qRole, "UserA", "S3CR3T1", "foo-email", []string{}})
-	mk.UserList = append(mk.UserList, QUser{"uuid2", qRole, "UserB", "S3CR3T2", "foo-email", []string{}})
-	mk.UserList = append(mk.UserList, QUser{"uuid3", qRoleConsumer, "UserX", "S3CR3T3", "foo-email", []string{}})
-	mk.UserList = append(mk.UserList, QUser{"uuid4", qRoleProducer, "UserZ", "S3CR3T4", "foo-email", []string{}})
+	mk.UserList = append(mk.UserList, QUser{"uuid1", qRole, "UserA", "S3CR3T1", "foo-email", []string{}, created, modified, ""})
+	mk.UserList = append(mk.UserList, QUser{"uuid2", qRole, "UserB", "S3CR3T2", "foo-email", []string{}, created, modified, "uuid1"})
+	mk.UserList = append(mk.UserList, QUser{"uuid3", qRoleConsumer, "UserX", "S3CR3T3", "foo-email", []string{}, created, modified, "uuid1"})
+	mk.UserList = append(mk.UserList, QUser{"uuid4", qRoleProducer, "UserZ", "S3CR3T4", "foo-email", []string{}, created, modified, "uuid1"})
 
 	qRole1 := QRole{"topics:list_all", []string{"admin", "reader", "publisher"}}
 	qRole2 := QRole{"topics:publish", []string{"admin", "publisher"}}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -132,7 +132,7 @@ func (mong *MongoStore) UpdateUserToken(uuid string, token string) error {
 }
 
 // UpdateUser updates user information
-func (mong *MongoStore) UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string) error {
+func (mong *MongoStore) UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error {
 	db := mong.Session.DB(mong.Database)
 	c := db.C("users")
 
@@ -165,6 +165,8 @@ func (mong *MongoStore) UpdateUser(uuid string, projects []QProjectRoles, name s
 	if serviceRoles != nil {
 		curUsr.ServiceRoles = serviceRoles
 	}
+
+	curUsr.ModifiedOn = modifiedOn
 
 	change := bson.M{"$set": curUsr}
 
@@ -458,8 +460,8 @@ func (mong *MongoStore) InsertTopic(projectUUID string, name string) error {
 }
 
 // InsertUser inserts a new user to the store
-func (mong *MongoStore) InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string) error {
-	user := QUser{UUID: uuid, Name: name, Email: email, Token: token, Projects: projects, ServiceRoles: serviceRoles}
+func (mong *MongoStore) InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error {
+	user := QUser{UUID: uuid, Name: name, Email: email, Token: token, Projects: projects, ServiceRoles: serviceRoles, CreatedOn: createdOn, ModifiedOn: modifiedOn, CreatedBy: createdBy}
 	return mong.InsertResource("users", user)
 }
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -39,6 +39,9 @@ type QUser struct {
 	Token        string          `bson:"token"`
 	Email        string          `bson:"email"`
 	ServiceRoles []string        `bson:"service_roles"`
+	CreatedOn    time.Time       `bson:"created_on"`
+	ModifiedOn   time.Time       `bson:"modified_on"`
+	CreatedBy    string          `bson:"created_by"`
 }
 
 //QProjectRoles include information about projects and roles that user has

--- a/stores/store.go
+++ b/stores/store.go
@@ -10,7 +10,7 @@ type Store interface {
 	RemoveTopic(projectUUID string, name string) error
 	RemoveSub(projectUUID string, name string) error
 	QueryUsers(projectUUID string, uuid string, name string) ([]QUser, error)
-	UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string) error
+	UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error
 	UpdateUserToken(uuid string, token string) error
 	RemoveUser(uuid string) error
 	QueryProjects(uuid string, name string) ([]QProject, error)
@@ -18,7 +18,7 @@ type Store interface {
 	RemoveProject(uuid string) error
 	RemoveProjectTopics(projectUUID string) error
 	RemoveProjectSubs(projectUUID string) error
-	InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string) error
+	InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertTopic(projectUUID string, name string) error
 	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -209,10 +209,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 	// Test Insert User
 	qRoleAdmin1 := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"admin"}}}
 	qRoles := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"admin"}}, QProjectRoles{"argo_uuid2", []string{"admin", "viewer"}}}
-	expUsr10 := QUser{"user_uuid10", qRoleAdmin1, "newUser1", "A3B94A94V3A", "fake@email.com", []string{}}
-	expUsr11 := QUser{"user_uuid11", qRoles, "newUser2", "BX312Z34NLQ", "fake@email.com", []string{}}
-	store.InsertUser("user_uuid10", qRoleAdmin1, "newUser1", "A3B94A94V3A", "fake@email.com", []string{})
-	store.InsertUser("user_uuid11", qRoles, "newUser2", "BX312Z34NLQ", "fake@email.com", []string{})
+	expUsr10 := QUser{"user_uuid10", qRoleAdmin1, "newUser1", "A3B94A94V3A", "fake@email.com", []string{}, created, modified, "uuid1"}
+	expUsr11 := QUser{"user_uuid11", qRoles, "newUser2", "BX312Z34NLQ", "fake@email.com", []string{}, created, modified, "uuid1"}
+	store.InsertUser("user_uuid10", qRoleAdmin1, "newUser1", "A3B94A94V3A", "fake@email.com", []string{}, created, modified, "uuid1")
+	store.InsertUser("user_uuid11", qRoles, "newUser2", "BX312Z34NLQ", "fake@email.com", []string{}, created, modified, "uuid1")
 	usr10, _ := store.QueryUsers("argo_uuid", "user_uuid10", "")
 	usr11, _ := store.QueryUsers("argo_uuid", "", "newUser2")
 
@@ -228,8 +228,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal([]string{"admin", "viewer"}, rolesB)
 
 	// Test Update User
-	usrUpdated := QUser{"user_uuid11", qRoles, "updated_name", "BX312Z34NLQ", "fake@email.com", []string{"service_admin"}}
-	store.UpdateUser("user_uuid11", nil, "updated_name", "", []string{"service_admin"})
+	usrUpdated := QUser{"user_uuid11", qRoles, "updated_name", "BX312Z34NLQ", "fake@email.com", []string{"service_admin"}, created, modified, "uuid1"}
+	store.UpdateUser("user_uuid11", nil, "updated_name", "", []string{"service_admin"}, modified)
 	usr11, _ = store.QueryUsers("", "user_uuid11", "")
 	suite.Equal(usrUpdated, usr11[0])
 


### PR DESCRIPTION
### Goal

Add the following extra fields to user information
- `created_on` : zulu timestamp
- `modified_on` : zulu timestamp
- `created_by` : username of the creator
### Implementation
- [x] Refactor User model in store package. Refactor Insert,Update and Query User methods
- [x] Refactor User model in auth package. Refactor CreateUser and UpdateUser methods
- [x] Update swagger
- [x] Update docs
### Additional Fixes
- [x] Fix api panic bug during listing projects / users when old schema data were leftover in the datastore
