### PR TITLE
ARGO-580 Add command line config parameters and help

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/samuel/go-zookeeper/zk"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -36,6 +37,9 @@ func NewAPICfg(params ...string) *APICfg {
 		if param == "LOAD" {
 			cfg.Load()
 			return &cfg
+		}
+		if param == "LOADTEST" {
+			cfg.LoadTest()
 		}
 	}
 
@@ -75,8 +79,8 @@ func (cfg *APICfg) GetZooList() []string {
 	return peerList
 }
 
-// Load the configuration
-func (cfg *APICfg) Load() {
+// LoadTest the configuration
+func (cfg *APICfg) LoadTest() {
 
 	viper.SetConfigName("config")
 	viper.AddConfigPath("/etc/argo-messaging")
@@ -96,7 +100,86 @@ func (cfg *APICfg) Load() {
 	cfg.ZooHosts = viper.GetStringSlice("zookeeper_hosts")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - zookeeper_hosts", cfg.ZooHosts)
 	cfg.KafkaZnode = viper.GetString("kafka_znode")
-	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.KafkaZnode)
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - kafka_znode", cfg.KafkaZnode)
+	cfg.StoreHost = viper.GetString("store_host")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
+	cfg.StoreDB = viper.GetString("store_db")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_db", cfg.StoreDB)
+	cfg.Cert = viper.GetString("certificate")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate", cfg.Cert)
+	cfg.CertKey = viper.GetString("certificate_key")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - certificate_key", cfg.CertKey)
+	cfg.ResAuth = viper.GetBool("per_resource_auth")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - per_resource_auth", cfg.CertKey)
+	cfg.ServiceToken = viper.GetString("service_token")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - service_token", cfg.ServiceToken)
+
+}
+
+// Load the configuration
+func (cfg *APICfg) Load() {
+	// Set Flags
+	var configPath *string
+
+	if pflag.Parsed() == false {
+		pflag.String("bind-ip", "localhost", "ip address to listen to")
+		viper.BindPFlag("bind_ip", pflag.Lookup("bind-ip"))
+
+		pflag.Int("port", 8080, "port number to listen to")
+		viper.BindPFlag("port", pflag.Lookup("port"))
+
+		pflag.StringSlice("zookeeper-hosts", []string{"localhost"}, "list of zookeeper hosts to connect to")
+		viper.BindPFlag("zookeeper_hosts", pflag.Lookup("zookeeper-hosts"))
+
+		pflag.String("kafka-znode", "", "kafka zookeeper node name")
+		viper.BindPFlag("kafka_znode", pflag.Lookup("kafka-znode"))
+
+		pflag.String("store-host", "localhost", "datastore (mongodb) host")
+		viper.BindPFlag("store_host", pflag.Lookup("store-host"))
+
+		pflag.String("store-db", "argo_msg", "datastore (mongodb) database name")
+		viper.BindPFlag("store_db", pflag.Lookup("store-db"))
+
+		pflag.String("certificate", "/etc/pki/tls/certs/localhost.crt", "certificate file *.crt")
+		viper.BindPFlag("certificate", pflag.Lookup("certificate"))
+
+		pflag.String("certificate-key", "/etc/pki/tls/private/localhost.key", "certificate key file *.key")
+		viper.BindPFlag("certificate_key", pflag.Lookup("certificate-key"))
+
+		pflag.Bool("per-resource-auth", true, "enable per resource authentication")
+		viper.BindPFlag("per_resource_auth", pflag.Lookup("per-resource-auth"))
+
+		pflag.String("service-key", "", "service token definition for immediate full api access")
+		viper.BindPFlag("service_key", pflag.Lookup("service-key"))
+
+		configPath = pflag.String("config-dir", "", "directory path to an alternative json config file")
+
+		pflag.Parse()
+
+	}
+
+	viper.SetConfigName("config")
+	if configPath != nil {
+		viper.AddConfigPath(*configPath)
+	}
+	viper.AddConfigPath("/etc/argo-messaging")
+	viper.AddConfigPath(".")
+
+	// Find and read the configuration file
+	err := viper.ReadInConfig()
+	if err != nil {
+		panic(fmt.Errorf("Errod trying to read the configuration file: %s \n", err))
+	}
+
+	// Load Kafka configuration
+	cfg.BindIP = viper.GetString("bind_ip")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - bind_ip", cfg.BindIP)
+	cfg.Port = viper.GetInt("port")
+	log.Printf("%s\t%s\t%s:%d", "INFO", "CONFIG", "Parameter Loaded - port", cfg.Port)
+	cfg.ZooHosts = viper.GetStringSlice("zookeeper_hosts")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - zookeeper_hosts", cfg.ZooHosts)
+	cfg.KafkaZnode = viper.GetString("kafka_znode")
+	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - kafka_znode", cfg.KafkaZnode)
 	cfg.StoreHost = viper.GetString("store_host")
 	log.Printf("%s\t%s\t%s:%s", "INFO", "CONFIG", "Parameter Loaded - store_host", cfg.StoreHost)
 	cfg.StoreDB = viper.GetString("store_db")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,15 +33,15 @@ func (suite *ConfigTestSuite) SetupTest() {
 func (suite *ConfigTestSuite) TestLoadConfiguration() {
 	APIcfg := NewAPICfg()
 	suite.Equal([]string(nil), APIcfg.ZooHosts)
-	APIcfg.Load()
+	APIcfg.LoadTest()
 	suite.Equal([]string{"localhost"}, APIcfg.ZooHosts)
 	suite.Equal("", APIcfg.KafkaZnode)
 	suite.Equal("localhost", APIcfg.StoreHost)
 	suite.Equal("argo_msg", APIcfg.StoreDB)
 	suite.Equal(8080, APIcfg.Port)
 
-	// test "LOAD" param
-	APIcfg2 := NewAPICfg("LOAD")
+	// test "LOADTEST" param
+	APIcfg2 := NewAPICfg("LOADTEST")
 	suite.Equal([]string{"localhost"}, APIcfg2.ZooHosts)
 	suite.Equal("", APIcfg2.KafkaZnode)
 	suite.Equal("localhost", APIcfg2.StoreHost)

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -44,3 +44,32 @@ per_resource_auth | enable authorization per resource (topic/subscription)
 service_token | (optional) If set, enables full service-wide access to the api to initialize projects,users and resources  
 
 **Location of config.json**: API will look first for config.json locally in the folder where the executable runs and then in the ` /etc/argo-messaging/`  location.
+
+
+## Command line parameters
+Apart from configuration file, argo-messaging service accepts configuration parameters in the command line. The list of the available command line parameters is displayed
+if the user issues
+```
+./argo-messaging-service --help
+```
+The available command line parameters are listed as follows:
+```
+--bind-ip string           ip address to listen to (default "localhost")
+--certificate string       certificate file *.crt (default "/etc/pki/tls/certs/localhost.crt")
+--certificate-key string   certificate key file *.key (default "/etc/pki/tls/private/localhost.key")
+--config-dir string        directory path to an alternative json config file
+--kafka-znode string       kafka zookeeper node name
+--per-resource-auth        enable per resource authentication (default true)
+--port int                 port number to listen to (default 8080)
+--service-key string       service token definition for immediate full api access
+--store-db string          datastore (mongodb) database name (default "argo_msg")
+--store-host string        datastore (mongodb) host (default "localhost")
+--zookeeper-hosts value    list of zookeeper hosts to connect to (default [localhost])
+```
+
+User can optionally specifiy an alternative configuration file directory with the use of the `--config-dir` parameter
+For example:
+```
+./argo-messaging-service --config-dir=/root/alternative/config/
+```
+The `/root/alternative/config/config.json` must exist


### PR DESCRIPTION
### Goal

Add the option to specify configuration parameters through command line. Add also `--help` message
### Implementation

The following parameters where added 

```
      --bind-ip string          
      --certificate string      
      --certificate-key string  
      --config-dir string        
      --kafka-znode string      
      --per-resource-auth        
      --port string             
      --service-key string       
      --store-db string         
      --store-host string        
      --zookeeper-hosts value    
```

Parameter `config-dir` allows user to specify an alternative config directory (which is expected to include a valid config.json file)
- [x] Refactor config package to use pflag and bind flags to existing configuration parameters
- [x] Update docs
