### PR TITLE
ARGO-595 Fix users listing null details if user doesn't exist

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -101,6 +101,10 @@ func FindUsers(projectUUID string, uuid string, name string, store stores.Store)
 		result.List = append(result.List, curUser)
 	}
 
+	if len(result.List) == 0 {
+		err = errors.New("not found")
+	}
+
 	return result, err
 }
 


### PR DESCRIPTION
### Issue 
Users list specific user request displays a json with null fields when user doesn't exist. Instead it should display the appropriate json error msg
```json
{
  "error": {
    "code": 404,
    "message": "User does not exist",
    "status": "NOT_FOUND"
  }
}
```

### Fix
 - [x] Refactor FindUsers method in auth package to return a "not found" error if query is empty. Handler already looks for such an error to display the 404 error message