### PR TITLE
ARGO-615 Add secondary logging of messages that exceed size threshold

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,5 +8,7 @@
   "certificate":"/etc/pki/tls/certs/localhost.crt",
   "certificate_key":"/etc/pki/tls/private/localhost.key",
   "service_token":"b328c3861f061f87cbd34cf34f36ba2ae20883a5",
-  "log_level":"INFO"
+  "log_level":"INFO",
+  "big_msg_size_threshold":1048576,
+  "big_msg_log_file":"big_msg.log.json"
 }

--- a/messages/message.go
+++ b/messages/message.go
@@ -5,6 +5,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"errors"
+	"os"
 	"sort"
 	"strings"
 )
@@ -180,6 +181,39 @@ func (pMsg *PushMsg) ExportJSON() (string, error) {
 func (msg *Message) ExportJSON() (string, error) {
 	output, err := json.MarshalIndent(msg, "", "   ")
 	return string(output[:]), err
+}
+
+// BigMsgWriteFile writes the whole message structure as json to file if the message
+// is bigger than a defined threshold in bytes
+func (msg *Message) BigMsgWriteFile(threshold int, filename string) error {
+
+	// if threshold is < 0 abort
+	if threshold < 0 {
+		return nil
+	}
+
+	outJSON, err := msg.ExportJSON()
+	if err != nil {
+		return err
+	}
+
+	// Check first if msg is bigger than threshold
+	bytes := []byte(outJSON)
+	// If byte length not bigger than threshold just return
+	if len(bytes) <= threshold {
+		return nil
+	}
+
+	// Open filename for appending the message in json
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(outJSON)
+	return err
+
 }
 
 // ExportJSON exports whole msgId  Structure as a json string


### PR DESCRIPTION
### Goal
Log Big messages that exceed (1Mb) size in secondary log for debugging

### Implementation
Add the following configuration options:
- `big_msg_log` = (true/false) specifiy if big message logging will be enabled. _DEFAULT = false_
- `big_msg_size_threshold` = specify desired threshold in bytes for large messages
- `big_msg_log_file` = specify a local filename for the large messages to be written to (for debugging)
** the above can be used also as cli parameters (`--big-msg-size-threshold` & `--big-msg-log-file`)

By default the big message logging is **disabled**
 