### PR TITLE
ARGO-628 Fix offset off bug

### DIFF
--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -1,6 +1,10 @@
 package brokers
 
-import "github.com/ARGOeu/argo-messaging/messages"
+import (
+	"errors"
+
+	"github.com/ARGOeu/argo-messaging/messages"
+)
 
 // Broker  Encapsulates the generic broker interface
 type Broker interface {
@@ -8,6 +12,9 @@ type Broker interface {
 	Initialize(peers []string)
 	CloseConnections()
 	Publish(topic string, payload messages.Message) (string, string, int, int64, error)
-	GetOffset(topic string) int64
-	Consume(topic string, offset int64, imm bool) []string
+	GetMinOffset(topic string) int64
+	GetMaxOffset(topic string) int64
+	Consume(topic string, offset int64, imm bool) ([]string, error)
 }
+
+var ErrOffsetOff = errors.New("Offset is off")

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -84,17 +84,22 @@ func (b *MockBroker) Initialize(peers []string) {
 func (b *MockBroker) Publish(topic string, msg messages.Message) (string, string, int, int64, error) {
 	payload, _ := msg.ExportJSON()
 	b.MsgList = append(b.MsgList, payload)
-	off := b.GetOffset(topic) - 1
+	off := b.GetMaxOffset(topic) - 1
 	msgID := strconv.FormatInt(off, 10)
 	return msgID, "argo_uuid.topic1", 0, int64(len(b.MsgList)), nil
 }
 
 // GetOffset returns a current topic's offset
-func (b *MockBroker) GetOffset(topic string) int64 {
+func (b *MockBroker) GetMaxOffset(topic string) int64 {
 	return int64(len(b.MsgList) + 1)
 }
 
+// GetOffset returns a current topic's offset
+func (b *MockBroker) GetMinOffset(topic string) int64 {
+	return int64(len(b.MsgList))
+}
+
 // Consume function to consume a message from the broker
-func (b *MockBroker) Consume(topic string, offset int64, imm bool) []string {
-	return b.MsgList
+func (b *MockBroker) Consume(topic string, offset int64, imm bool) ([]string, error) {
+	return b.MsgList, nil
 }

--- a/push/push.go
+++ b/push/push.go
@@ -107,7 +107,19 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	// Init Received Message List
 
 	fullTopic := p.sub.ProjectUUID + "." + p.sub.Topic
-	msgs := brk.Consume(fullTopic, p.sub.Offset, true)
+	msgs, err := brk.Consume(fullTopic, p.sub.Offset, true)
+	if err != nil {
+		// If tracked offset is off, update it to the latest min offset
+		if err == brokers.ErrOffsetOff {
+			// Get Current Min Offset and advanced tracked one
+			p.sub.Offset = brk.GetMinOffset(fullTopic)
+			msgs, err = brk.Consume(fullTopic, p.sub.Offset, true)
+			if err != nil {
+				log.Error("Unable to consume after updating offset")
+				return
+			}
+		}
+	}
 	if len(msgs) > 0 {
 		// Generate push message template
 		pMsg := messages.PushMsg{}


### PR DESCRIPTION
### Issue
If (during retention) tracked offset stays behind broker's min offset, api cannot consume new messages

### Fix
- Check if tracked offset is behind broker's min offset, increment it and retry