### PR TITLE
ARGO-630 Fix msg id mapping to broker offset issue

### DIFF
--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -14,7 +14,7 @@ type Broker interface {
 	Publish(topic string, payload messages.Message) (string, string, int, int64, error)
 	GetMinOffset(topic string) int64
 	GetMaxOffset(topic string) int64
-	Consume(topic string, offset int64, imm bool) ([]string, error)
+	Consume(topic string, offset int64, imm bool, max int64) ([]string, error)
 }
 
 var ErrOffsetOff = errors.New("Offset is off")

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -100,6 +100,6 @@ func (b *MockBroker) GetMinOffset(topic string) int64 {
 }
 
 // Consume function to consume a message from the broker
-func (b *MockBroker) Consume(topic string, offset int64, imm bool) ([]string, error) {
+func (b *MockBroker) Consume(topic string, offset int64, imm bool, max int64) ([]string, error) {
 	return b.MsgList, nil
 }

--- a/push/push.go
+++ b/push/push.go
@@ -107,13 +107,13 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	// Init Received Message List
 
 	fullTopic := p.sub.ProjectUUID + "." + p.sub.Topic
-	msgs, err := brk.Consume(fullTopic, p.sub.Offset, true)
+	msgs, err := brk.Consume(fullTopic, p.sub.Offset, true, 1)
 	if err != nil {
 		// If tracked offset is off, update it to the latest min offset
 		if err == brokers.ErrOffsetOff {
 			// Get Current Min Offset and advanced tracked one
 			p.sub.Offset = brk.GetMinOffset(fullTopic)
-			msgs, err = brk.Consume(fullTopic, p.sub.Offset, true)
+			msgs, err = brk.Consume(fullTopic, p.sub.Offset, true, 1)
 			if err != nil {
 				log.Error("Unable to consume after updating offset")
 				return


### PR DESCRIPTION
### Issue 
Msg.id generation is related to broker offset for each given message. Generated msg.id just before publishing caused an issue with small sets of duplicate ids (3-4 items) when published messages were in low time intervals (below 0.001 seconds). 

### Refactor
Msg.id is applied during consumption of messages. During subscription:pull handler, the read offset and the list of returned messages is reported and each message is assigned an appropriate msg.id according its position from read offset.
- Secondary fix: delay in broker.consume loop when returnImmediately is not set