### PR TITLE
ARGO-640 Add latest topic offset when creating a new subscription

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1209,8 +1209,8 @@ func SubCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get current topic offset
-
-	fullTopic := tProject + "." + tName
+	tProjectUUID := projects.GetUUIDByName(tProject, refStr)
+	fullTopic := tProjectUUID + "." + tName
 	curOff := refBrk.GetMaxOffset(fullTopic)
 
 	pushEnd := ""


### PR DESCRIPTION
### Issue
When a new subscription is created it must receive the latest topic's offset. Instead it begins with offset=0. This is due to a bug with not using project_uuid correctly when asking for topic offset

### Fix
Refactor method to use project_uuid when asking for a topic's max offset