### PR TITLE
ARGO-646 Sub pull update fix

### DIFF
--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -232,11 +232,12 @@ ConsumerLoop:
 
 			consumed++
 
-			log.Debug(consumed)
+			log.Debug("consumed:" + string(consumed))
+			log.Debug("max:" + string(max))
 			log.Debug(msg)
 			// if we pass over the available messages and still want more
 
-			if consumed > max {
+			if consumed >= max {
 				break ConsumerLoop
 			}
 

--- a/handlers.go
+++ b/handlers.go
@@ -1732,7 +1732,7 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 	zSec := "2006-01-02T15:04:05Z"
 	t := time.Now()
 	ts := t.Format(zSec)
-	refStr.UpdateSubPull(targSub.Name, int64(len(recList.RecMsgs))+targSub.Offset, ts)
+	refStr.UpdateSubPull(targSub.ProjectUUID, targSub.Name, int64(len(recList.RecMsgs))+targSub.Offset, ts)
 
 	output = []byte(resJSON)
 	respondOK(w, output)

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -277,7 +277,15 @@ func (mk *MockStore) QueryUsers(projectUUID string, uuid string, name string) ([
 }
 
 // UpdateSubPull updates next offset info after a pull
-func (mk *MockStore) UpdateSubPull(name string, offset int64, ts string) {
+func (mk *MockStore) UpdateSubPull(projectUUID string, name string, offset int64, ts string) error {
+	for i, item := range mk.SubList {
+		if item.ProjectUUID == projectUUID && item.Name == name {
+			mk.SubList[i].NextOffset = offset
+			mk.SubList[i].PendingAck = ts
+			return nil
+		}
+	}
+	return errors.New("not found")
 
 }
 

--- a/stores/store.go
+++ b/stores/store.go
@@ -29,7 +29,7 @@ type Store interface {
 	HasResourceRoles(resource string, roles []string) bool
 	GetUserRoles(projectUUID string, token string) ([]string, string)
 	UpdateSubOffset(projectUUID string, name string, offset int64)
-	UpdateSubPull(name string, offset int64, ts string)
+	UpdateSubPull(projectUUID string, name string, offset int64, ts string) error
 	UpdateSubOffsetAck(projectUUID string, name string, offset int64, ts string) error
 	ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error
 	QueryACL(projectUUID string, resource string, name string) (QAcl, error)

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -192,6 +192,12 @@ func (suite *StoreTestSuite) TestMockStore() {
 	prUp3, _ := store.QueryProjects("argo_uuid3", "")
 	suite.Equal(expPr3, prUp3[0])
 
+	// Test Sub Update Pull
+	err = store.UpdateSubPull("argo_uuid", "sub4", 4, "2016-10-11T12:00:35:15Z")
+	qSubUpd, err := store.QuerySubs("argo_uuid", "sub4")
+	var nxtOff int64 = 4
+	suite.Equal(qSubUpd[0].NextOffset, nxtOff)
+	suite.Equal("2016-10-11T12:00:35:15Z", qSubUpd[0].PendingAck)
 	// Test RemoveProjectTopics
 	store.RemoveProjectTopics("argo_uuid")
 	resTop, _ := store.QueryTopics("argo_uuid", "")


### PR DESCRIPTION
### Issue
Subscriptions with the same name but in different projects cause a wrong datastore update during pull requests.

### Fix
- Refactor UpdateSubPull method in stores package
- Update unit tests

### Extra fixes
- Minor fix in consume loop for returnImmediately if number of maxMessages is smaller than available ones
- Minor fix in request ack: If user acknowledged with ackId - 1 nothing happened and request returned 200. Now returns wrong ack id as expected
