### PR TITLE
ARGO-650 Push endpoint should be https

### DIFF
--- a/stores/mock.go
+++ b/stores/mock.go
@@ -172,7 +172,25 @@ func (mk *MockStore) UpdateSubOffset(projectUUID string, name string, offset int
 
 // ModSubPush modifies the subscription ack
 func (mk *MockStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error {
-	return nil
+	for i, item := range mk.SubList {
+		if item.ProjectUUID == projectUUID {
+			if push != "" {
+				mk.SubList[i].PushEndpoint = push
+				mk.SubList[i].RetPolicy = "linear"
+				mk.SubList[i].RetPeriod = 300
+			}
+			if rPolicy != "" {
+				mk.SubList[i].RetPolicy = rPolicy
+			}
+			if rPeriod != 0 {
+				mk.SubList[i].RetPeriod = rPeriod
+			}
+
+			return nil
+		}
+	}
+
+	return errors.New("not found")
 }
 
 // UpdateSubOffsetAck updates the offset of the current subscription


### PR DESCRIPTION
### Issue
Push configuration must accept only an https push endpoint. Until now there was no check for the validity of the user's push endpoint string (if its a valid https url)

### Fix
- Implement isValidHTTPS method that accepts a url string and checks if its a valid HTTPS url (uses net/url lib to check the validity and https scheme)
- Refactor handlers to call isValidHTTPS in push configuration related requests. 
- Return an appropriate error response if push endpoint url is not https
- Add unit tests, testing for invalid push configuration endpoints when handling Subscription Creation and Subscription Modify Push Configuration
 