### PR TITLE
Updated example to api_subs documentation

### DIFF
--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -246,7 +246,7 @@ Messages retrieved from a pull subscription can be acknowledged by sending messa
 {
   "ackIds": [
   "dQNNHlAbEGEIBE..."
- ],
+ ]
 
 }
 ```

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -270,8 +270,7 @@ curl -X POST -H "Content-Type: application/json"
 {
  "ackIds": [
   "dQNNHlAbEGEIBE..."
- ],
-
+ ]
 }
 ```
 


### PR DESCRIPTION
Updated example to api_subs documentation that lead to error to messaging. There was a comma in the post body after the ackIds. This lead to wrong parameter fot the user and 408 ack timeout to the messsaging service.