### PR TITLE
Correct reference to sub/topic in api_subs.md

### DIFF
--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -107,7 +107,7 @@ Please refer to section [Errors](api_errors.md) to see all possible Errors
 
 
 ## [DELETE] Manage Subscriptions - Delete Subscriptions
-This request deletes a topic in a project with a DELETE request
+This request deletes a subscription in a project with a DELETE request
 
 ### Request
 `DELETE /v1/projects/{project_name}/subscriptions/{subscription_name}`


### PR DESCRIPTION
This seems to be a mistake in the docs, so change the reference to deleting a topic to deleting a sub in the section on deleting subs.