### PR TITLE
ARGO-779 Implement metric: data volume published to a topic

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -376,7 +376,7 @@ paths:
           $ref: "#/responses/500"
 
 
-  /users/{USER}/:refreshToken:
+  /users/{USER}:refreshToken:
     post:
       summary: Refreshes the token of an existing user
       description: |
@@ -551,7 +551,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:acl:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:acl:
     get:
       summary: List ACL of a given subscription
       description: |
@@ -586,7 +586,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:modifyAcl:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyAcl:
     post:
       summary: Modify ACL of a given subscription
       description: |
@@ -629,7 +629,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:modifyOffset:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyOffset:
     post:
       summary: Modify Offset of a given subscription
       description: |
@@ -672,7 +672,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:offsets:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:offsets:
     get:
       summary: Get min max and current offset of a subscription
       description: |
@@ -710,7 +710,7 @@ paths:
 
 
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:pull:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:pull:
     post:
       summary: Pull Messages from an existing subscription
       description: |
@@ -751,7 +751,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:acknowledge:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:acknowledge:
     post:
       summary: Acknowledge the succesfull delivery of pulled messages
       description: |
@@ -793,7 +793,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:modifyPushConfig:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyPushConfig:
     post:
       summary: Modify the push configuration options of the subscription
       description: |
@@ -836,7 +836,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}/:metrics:
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:metrics:
     get:
       summary: List of metrics related to the specific subscription
       description: |
@@ -1012,7 +1012,7 @@ paths:
 
 
 
-  /projects/{PROJECT}/topics/{TOPIC}/:publish:
+  /projects/{PROJECT}/topics/{TOPIC}:publish:
     post:
       summary: List topics in a project
       description: |
@@ -1053,7 +1053,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/topics/{TOPIC}/:acl:
+  /projects/{PROJECT}/topics/{TOPIC}:acl:
     get:
       summary: List ACL of a given topic
       description: |
@@ -1088,7 +1088,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/topics/{TOPIC}/:metrics:
+  /projects/{PROJECT}/topics/{TOPIC}:metrics:
     get:
       summary: List of metrics related to the specific topic
       description: |
@@ -1123,7 +1123,7 @@ paths:
         500:
           $ref: "#/responses/500"
 
-  /projects/{PROJECT}/topics/{TOPIC}/:modifyAcl:
+  /projects/{PROJECT}/topics/{TOPIC}:modifyAcl:
     post:
       summary: Modify ACL of a given topic
       description: |
@@ -1215,6 +1215,8 @@ definitions:
     type: object
     properties:
       mumber_of_messages:
+        type: string
+      total_bytes:
         type: string
 
   AuthUsers:

--- a/doc/v1/docs/api_topics.md
+++ b/doc/v1/docs/api_topics.md
@@ -298,13 +298,14 @@ curl  -H "Content-Type: application/json"
 ```
 
 ### Responses  
-If successful it returns the number of messages published in the specific topic.
+If successful it returns topic's related metrics (number of messages published and total bytes).
 
 Success Response
 `200 OK`
 ```
 {
-  "number_of_messages":4
+  "number_of_messages":4,
+  "total_bytes":54
 }
 ```
 

--- a/handlers.go
+++ b/handlers.go
@@ -1846,6 +1846,8 @@ func TopicPublish(w http.ResponseWriter, r *http.Request) {
 
 	// increment topic number of message metric
 	refStr.IncrementTopicMsgNum(projectUUID, urlTopic, int64(len(msgList.Msgs)))
+	// increment topic total bytes published
+	refStr.IncrementTopicBytes(projectUUID, urlTopic, msgList.TotalSize())
 
 	// Export the msgIDs
 	resJSON, err := msgIDs.ExportJSON()

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1110,7 +1110,8 @@ func (suite *HandlerTestSuite) TestTopicMetrics() {
 	}
 
 	expResp := `{
-   "number_of_messages": 0
+   "number_of_messages": 0,
+   "total_bytes": 0
 }`
 
 	cfgKafka := config.NewAPICfg()

--- a/messages/message.go
+++ b/messages/message.go
@@ -47,6 +47,38 @@ type MsgIDs struct {
 // Attributes representation as key/value
 type Attributes map[string]string
 
+//TotalSize returns the total bytesize of a message list
+func (msgL RecList) TotalSize() int64 {
+	sum := int64(0)
+	for _, msg := range msgL.RecMsgs {
+		// Convert data string to byte array
+		bt := []byte(msg.Msg.Data)
+		sum = sum + int64(len(bt))
+	}
+
+	return sum
+}
+
+//TotalSize returns the total bytesize of a message list
+func (msgL MsgList) TotalSize() int64 {
+	sum := int64(0)
+	for _, msg := range msgL.Msgs {
+		// Convert data string to byte array
+		bt := []byte(msg.Data)
+		sum = sum + int64(len(bt))
+	}
+
+	return sum
+}
+
+//Size returns the messages size in bytes
+func (msg Message) Size() int64 {
+	// Convert data string to byte array
+	bt := []byte(msg.Data)
+	size := int64(len(bt))
+	return size
+}
+
 // MarshalJSON generates json string for Attributes type
 func (attr Attributes) MarshalJSON() ([]byte, error) {
 	var buff bytes.Buffer

--- a/messages/message_test.go
+++ b/messages/message_test.go
@@ -51,6 +51,21 @@ func (suite *MsgTestSuite) TestAttributes() {
 	suite.Equal(errors.New("Attribute doesn't exist"), err1)
 }
 
+func (suite *MsgTestSuite) TestMsgListBytes() {
+
+	testMsg1 := New("this is a test")
+	testMsg2 := New("this is another test")
+	testMsg3 := New("this is another test")
+	sz1 := testMsg1.Size()
+	sz2 := testMsg2.Size()
+	sz3 := testMsg3.Size()
+	ml := MsgList{Msgs: []Message{}}
+	ml.Msgs = append(ml.Msgs, testMsg1)
+	ml.Msgs = append(ml.Msgs, testMsg2)
+	ml.Msgs = append(ml.Msgs, testMsg3)
+	suite.Equal(sz1+sz2+sz3, ml.TotalSize())
+}
+
 func (suite *MsgTestSuite) TestLoadMsgJson() {
 	txtJSON := `{
    "messageId": "35",

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -178,6 +178,18 @@ func (mk *MockStore) IncrementTopicMsgNum(projectUUID string, name string, num i
 	return errors.New("not found")
 }
 
+//IncrementTopicMsgNum increases the total number of bytes published in a topic
+func (mk *MockStore) IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error {
+	for i, item := range mk.TopicList {
+		if item.ProjectUUID == projectUUID && item.Name == name {
+			mk.TopicList[i].TotalBytes += totalBytes
+			return nil
+		}
+	}
+
+	return errors.New("not found")
+}
+
 //IncrementSubMsgNum increase number of messages pulled in a subscription
 func (mk *MockStore) IncrementSubMsgNum(projectUUID string, name string, num int64) error {
 
@@ -337,9 +349,9 @@ func (mk *MockStore) UpdateSubPull(projectUUID string, name string, offset int64
 func (mk *MockStore) Initialize() {
 
 	// populate topics
-	qtop1 := QTopic{"argo_uuid", "topic1", 0}
-	qtop2 := QTopic{"argo_uuid", "topic2", 0}
-	qtop3 := QTopic{"argo_uuid", "topic3", 0}
+	qtop1 := QTopic{"argo_uuid", "topic1", 0, 0}
+	qtop2 := QTopic{"argo_uuid", "topic2", 0, 0}
+	qtop3 := QTopic{"argo_uuid", "topic3", 0, 0}
 	mk.TopicList = append(mk.TopicList, qtop1)
 	mk.TopicList = append(mk.TopicList, qtop2)
 	mk.TopicList = append(mk.TopicList, qtop3)

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -377,6 +377,19 @@ func (mong *MongoStore) IncrementTopicMsgNum(projectUUID string, name string, nu
 
 }
 
+//IncrementTopicMsgNum increases the total number of bytes published in a topic
+func (mong *MongoStore) IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error {
+	db := mong.Session.DB(mong.Database)
+	c := db.C("topics")
+
+	doc := bson.M{"project_uuid": projectUUID, "name": name}
+	change := bson.M{"$inc": bson.M{"total_bytes": totalBytes}}
+
+	err := c.Update(doc, change)
+
+	return err
+}
+
 // IncrementTopicMsgNum increments the number of messages pulled in a subscription
 func (mong *MongoStore) IncrementSubMsgNum(projectUUID string, name string, num int64) error {
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -62,6 +62,7 @@ type QTopic struct {
 	ProjectUUID string `bson:"project_uuid"`
 	Name        string `bson:"name"`
 	MsgNum      int64  `bson:"msg_num"`
+	TotalBytes  int64  `bson:"total_bytes"`
 }
 
 func (qUsr *QUser) isInProject(projectUUID string) bool {

--- a/stores/store.go
+++ b/stores/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertTopic(projectUUID string, name string) error
 	IncrementTopicMsgNum(projectUUID string, name string, num int64) error
+	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubMsgNum(projectUUID string, name string, num int64) error
 	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
 	HasProject(name string) bool

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -18,9 +18,9 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("mockhost", store.Server)
 	suite.Equal("mockbase", store.Database)
 
-	eTopList := []QTopic{QTopic{"argo_uuid", "topic1", 0},
-		QTopic{"argo_uuid", "topic2", 0},
-		QTopic{"argo_uuid", "topic3", 0}}
+	eTopList := []QTopic{QTopic{"argo_uuid", "topic1", 0, 0},
+		QTopic{"argo_uuid", "topic2", 0, 0},
+		QTopic{"argo_uuid", "topic3", 0, 0}}
 
 	eSubList := []QSub{QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0},
 		QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0},
@@ -55,10 +55,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 	store.InsertTopic("argo_uuid", "topicFresh")
 	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, "", "linear", 300)
 
-	eTopList2 := []QTopic{QTopic{"argo_uuid", "topic1", 0},
-		QTopic{"argo_uuid", "topic2", 0},
-		QTopic{"argo_uuid", "topic3", 0},
-		QTopic{"argo_uuid", "topicFresh", 0}}
+	eTopList2 := []QTopic{QTopic{"argo_uuid", "topic1", 0, 0},
+		QTopic{"argo_uuid", "topic2", 0, 0},
+		QTopic{"argo_uuid", "topic3", 0, 0},
+		QTopic{"argo_uuid", "topicFresh", 0, 0}}
 
 	eSubList2 := []QSub{QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0},
 		QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0},

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -16,7 +16,8 @@ type Topic struct {
 }
 
 type TopicMetrics struct {
-	MsgNum int64 `json:"number_of_messages"`
+	MsgNum     int64 `json:"number_of_messages"`
+	TotalBytes int64 `json:"total_bytes"`
 }
 
 // Topics holds a list of Topic items
@@ -47,6 +48,7 @@ func FindMetric(projectUUID string, name string, store stores.Store) (TopicMetri
 		}
 
 		result.MsgNum = item.MsgNum
+		result.TotalBytes = item.TotalBytes
 	}
 	return result, err
 }


### PR DESCRIPTION
### Goal 
Implement metric: data volume (total bytes of messages) published to a topic 

### Implementation 
- [x] Refactor store topic model to support total_bytes field
- [x] Refactor topic metric model to support total_bytes field
- [x] Add Size() and TotalSize() methods to Message and MessageList structures to calculate sizes of messages in bytes
- [x] Add unit tests
- [x] Refactor handlers to increment topic's total_bytes in publish operations
- [x] Update Docs