### PR TITLE
ARGO-780 Implement Metric: data volume consumed by subscription

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: '2.0'
 info:
   title: argo-messaging-api
-  description: "NEW SWAGGER VERSION DOESNT SUPPORT THE :ACTION LIKE (/{SUBSCRIPTION}:acknowledge). IN ORDER TO RENDER THE DOCUMENTATION WE ADDED A TRAILING SLASH (/{SUBSCRIPTION}/:acknowledge).  PLEASE REMOVE THE TRAILING SLASH BEFORE TESTING. ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. This swagger UI interface provides access to the specification of the ARGO messaging api, which can be used to produce or consume messages."
+  description: "ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. This swagger UI interface provides access to the specification of the ARGO messaging api, which can be used to produce or consume messages."
   version: "0.9.2"
   contact:
     name: ARGO Developers
@@ -1209,15 +1209,17 @@ definitions:
     type: object
     properties:
       mumber_of_messages:
-        type: string
+        type: integer
+      total_bytes:
+        type: integer
 
   TopicMetrics:
     type: object
     properties:
       mumber_of_messages:
-        type: string
+        type: integer
       total_bytes:
-        type: string
+        type: integer
 
   AuthUsers:
     type: object

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: '2.0'
 info:
   title: argo-messaging-api
-  description: "ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. This swagger UI interface provides access to the specification of the ARGO messaging api, which can be used to produce or consume messages."
+  description: "NEW SWAGGER VERSION DOESNT SUPPORT THE :ACTION LIKE (/{SUBSCRIPTION}:acknowledge). IN ORDER TO RENDER THE DOCUMENTATION WE ADDED A TRAILING SLASH (/{SUBSCRIPTION}/:acknowledge).  PLEASE REMOVE THE TRAILING SLASH BEFORE TESTING. ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. This swagger UI interface provides access to the specification of the ARGO messaging api, which can be used to produce or consume messages."
   version: "0.9.2"
   contact:
     name: ARGO Developers

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -395,7 +395,8 @@ Success Response
 `200 OK`
 ```
 {
-  "number_of_messages":12
+  "number_of_messages":12,
+  "total_bytes":54
 }
 ```
 

--- a/handlers.go
+++ b/handlers.go
@@ -770,7 +770,6 @@ func SubAck(w http.ResponseWriter, r *http.Request) {
 		respondErr(w, 404, "Subscription doesn't exist", "NOT_FOUND")
 		return
 	}
-	old_off := cur_sub.List[0].Offset
 
 	// Get list of AckIDs
 	if postBody.IDs == nil {
@@ -815,9 +814,6 @@ func SubAck(w http.ResponseWriter, r *http.Request) {
 		respondErr(w, 400, err.Error(), "INTERNAL_SERVER_ERROR")
 		return
 	}
-
-	// increment subscrption number of message metric
-	refStr.IncrementSubMsgNum(projectUUID, subName, int64(off+1-old_off))
 
 	// Output result to JSON
 	resJSON := "{}"
@@ -1988,6 +1984,10 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 		curRec := messages.RecMsg{AckID: ackPrefix + curMsg.ID, Msg: curMsg}
 		recList.RecMsgs = append(recList.RecMsgs, curRec)
 	}
+
+	// increment subscrption number of message metric
+	refStr.IncrementSubMsgNum(projectUUID, urlSub, int64(len(msgs)))
+	refStr.IncrementSubBytes(projectUUID, urlSub, recList.TotalSize())
 
 	resJSON, err := recList.ExportJSON()
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1085,7 +1085,8 @@ func (suite *HandlerTestSuite) TestSubMetrics() {
 	}
 
 	expResp := `{
-   "number_of_messages": 0
+   "number_of_messages": 0,
+   "total_bytes": 0
 }`
 
 	cfgKafka := config.NewAPICfg()

--- a/push/push.go
+++ b/push/push.go
@@ -134,6 +134,7 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 			store.UpdateSubOffset(p.sub.ProjectUUID, p.sub.Name, 1+p.sub.Offset)
 			// Update subscription's metrics
 			store.IncrementSubMsgNum(p.sub.ProjectUUID, p.sub.Name, int64(1))
+			store.IncrementSubBytes(p.sub.ProjectUUID, p.sub.Name, pMsg.Msg.Size())
 			log.Debug("offset updated")
 		}
 	} else {

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -178,11 +178,23 @@ func (mk *MockStore) IncrementTopicMsgNum(projectUUID string, name string, num i
 	return errors.New("not found")
 }
 
-//IncrementTopicMsgNum increases the total number of bytes published in a topic
+//IncrementTopicBytes increases the total number of bytes published in a topic
 func (mk *MockStore) IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error {
 	for i, item := range mk.TopicList {
 		if item.ProjectUUID == projectUUID && item.Name == name {
 			mk.TopicList[i].TotalBytes += totalBytes
+			return nil
+		}
+	}
+
+	return errors.New("not found")
+}
+
+//IncrementSubBytes increases the total number of bytes published in a subscription
+func (mk *MockStore) IncrementSubBytes(projectUUID string, name string, totalBytes int64) error {
+	for i, item := range mk.SubList {
+		if item.ProjectUUID == projectUUID && item.Name == name {
+			mk.SubList[i].TotalBytes += totalBytes
 			return nil
 		}
 	}
@@ -357,10 +369,10 @@ func (mk *MockStore) Initialize() {
 	mk.TopicList = append(mk.TopicList, qtop3)
 
 	// populate Subscriptions
-	qsub1 := QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0}
-	qsub2 := QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0}
-	qsub3 := QSub{"argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300, 0}
-	qsub4 := QSub{"argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0}
+	qsub1 := QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0, 0}
+	qsub2 := QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0, 0}
+	qsub3 := QSub{"argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300, 0, 0}
+	qsub4 := QSub{"argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0}
 	mk.SubList = append(mk.SubList, qsub1)
 	mk.SubList = append(mk.SubList, qsub2)
 	mk.SubList = append(mk.SubList, qsub3)
@@ -478,14 +490,14 @@ func (mk *MockStore) HasProject(name string) bool {
 
 // InsertTopic inserts a new topic object to the store
 func (mk *MockStore) InsertTopic(projectUUID string, name string) error {
-	topic := QTopic{ProjectUUID: projectUUID, Name: name, MsgNum: 0}
+	topic := QTopic{ProjectUUID: projectUUID, Name: name, MsgNum: 0, TotalBytes: 0}
 	mk.TopicList = append(mk.TopicList, topic)
 	return nil
 }
 
 // InsertSub inserts a new sub object to the store
 func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
-	sub := QSub{projectUUID, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod, 0}
+	sub := QSub{projectUUID, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod, 0, 0}
 	mk.SubList = append(mk.SubList, sub)
 	return nil
 }

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -377,7 +377,7 @@ func (mong *MongoStore) IncrementTopicMsgNum(projectUUID string, name string, nu
 
 }
 
-//IncrementTopicMsgNum increases the total number of bytes published in a topic
+//IncrementTopicBytes increases the total number of bytes published in a topic
 func (mong *MongoStore) IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error {
 	db := mong.Session.DB(mong.Database)
 	c := db.C("topics")
@@ -403,6 +403,19 @@ func (mong *MongoStore) IncrementSubMsgNum(projectUUID string, name string, num 
 
 	return err
 
+}
+
+//IncrementSubMsgNum increases the total number of bytes consumed from a subscripion
+func (mong *MongoStore) IncrementSubBytes(projectUUID string, name string, totalBytes int64) error {
+	db := mong.Session.DB(mong.Database)
+	c := db.C("subscriptions")
+
+	doc := bson.M{"project_uuid": projectUUID, "name": name}
+	change := bson.M{"$inc": bson.M{"total_bytes": totalBytes}}
+
+	err := c.Update(doc, change)
+
+	return err
 }
 
 //HasResourceRoles returns the roles of a user in a project
@@ -501,7 +514,7 @@ func (mong *MongoStore) HasProject(name string) bool {
 
 // InsertTopic inserts a topic to the store
 func (mong *MongoStore) InsertTopic(projectUUID string, name string) error {
-	topic := QTopic{ProjectUUID: projectUUID, Name: name, MsgNum: 0}
+	topic := QTopic{ProjectUUID: projectUUID, Name: name, MsgNum: 0, TotalBytes: 0}
 	return mong.InsertResource("topics", topic)
 }
 
@@ -519,7 +532,7 @@ func (mong *MongoStore) InsertProject(uuid string, name string, createdOn time.T
 
 // InsertSub inserts a subscription to the store
 func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
-	sub := QSub{projectUUID, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod, 0}
+	sub := QSub{projectUUID, name, topic, offset, 0, "", push, ack, rPolicy, rPeriod, 0, 0}
 	return mong.InsertResource("subscriptions", sub)
 }
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -15,6 +15,7 @@ type QSub struct {
 	RetPolicy    string `bson:"retry_policy"`
 	RetPeriod    int    `bson:"retry_period"`
 	MsgNum       int64  `bson:"msg_num"`
+	TotalBytes   int64  `bson:"total_bytes"`
 }
 
 // QAcl holds a list of authorized users queried from topic or subscription collections

--- a/stores/store.go
+++ b/stores/store.go
@@ -23,6 +23,7 @@ type Store interface {
 	InsertTopic(projectUUID string, name string) error
 	IncrementTopicMsgNum(projectUUID string, name string, num int64) error
 	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
+	IncrementSubBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubMsgNum(projectUUID string, name string, num int64) error
 	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
 	HasProject(name string) bool

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -22,10 +22,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 		QTopic{"argo_uuid", "topic2", 0, 0},
 		QTopic{"argo_uuid", "topic3", 0, 0}}
 
-	eSubList := []QSub{QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0}}
+	eSubList := []QSub{QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0}}
 
 	tpList, _ := store.QueryTopics("argo_uuid", "")
 	suite.Equal(eTopList, tpList)
@@ -60,11 +60,11 @@ func (suite *StoreTestSuite) TestMockStore() {
 		QTopic{"argo_uuid", "topic3", 0, 0},
 		QTopic{"argo_uuid", "topicFresh", 0, 0}}
 
-	eSubList2 := []QSub{QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0},
-		QSub{"argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 10, "linear", 300, 0}}
+	eSubList2 := []QSub{QSub{"argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0},
+		QSub{"argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 10, "linear", 300, 0, 0}}
 
 	tpList, _ = store.QueryTopics("argo_uuid", "")
 	suite.Equal(eTopList2, tpList)

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -32,7 +32,8 @@ type PushConfig struct {
 
 // SubMetrics holds the subscription's metric details
 type SubMetrics struct {
-	MsgNum int64 `json:"number_of_messages"`
+	MsgNum     int64 `json:"number_of_messages"`
+	TotalBytes int64 `json:"total_bytes"`
 }
 
 // RetryPolicy holds information on retry policies
@@ -80,6 +81,7 @@ func FindMetric(projectUUID string, name string, store stores.Store) (SubMetrics
 		}
 
 		result.MsgNum = item.MsgNum
+		result.TotalBytes = item.TotalBytes
 	}
 	return result, err
 }


### PR DESCRIPTION
# Goal
Implement metric for data volume (total bytes of messages) consumed by a subscription

# Implementation
- [x] Refactor store subscription model
- [x] Refactor SubMetrics model 
- [x] Add IncrementSubBytes during consumption
- [x] Update docs

## Note: to be merged after: https://github.com/ARGOeu/argo-messaging/pull/122