### PR TITLE
Subscription number

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -195,6 +195,36 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}:metrics:
+    get:
+      summary: Get metrics for a specific project
+      description: |
+        Shows a specific projects information
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+      tags:
+        - Projects
+      responses:
+        200:
+          description: A Metrics object
+          schema:
+            $ref: '#/definitions/Metrics'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
 
   /users:
     get:
@@ -1204,6 +1234,42 @@ responses:
       $ref: '#/definitions/ErrorMsg'
 
 definitions:
+
+  Metrics:
+   type: object
+   properties:
+     metrics:
+       type: array
+       items:
+         $ref: '#/definitions/Metric'
+
+  Metric:
+    type: object
+    properties:
+      metric:
+        type: string
+      metric_type:
+        type: string
+      resource_type:
+        type: string
+      resource_name:
+        type: string
+      value_type:
+        type: string
+      description:
+        type: string
+      timeseries:
+        type: array
+        items:
+          $ref: '#/definitions/Timepoint'
+
+  Timepoint:
+    type: object
+    properties:
+      timestamp:
+        type: string
+      value:
+        type: string
 
   SubMetrics:
     type: object

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -209,3 +209,51 @@ Code: `200 OK`, Empty response if successful.
 
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+## [GET] Project Metrics
+The following request returns related metrics for the specific project: eg. the number of topics
+
+### Request
+```
+GET "/v1/projects/{project_name}:metrics"
+```
+
+### Where
+- Project_name: name of the project
+- topic_name: name of the topic
+
+### Example request
+
+```json
+curl  -H "Content-Type: application/json"
+"https://{URL}/v1/projects/BRAND_NEW:metrics?key=S3CR3T"
+```
+
+### Responses  
+If successful it returns topic's related metrics (number of messages published and total bytes).
+
+Success Response
+`200 OK`
+```
+{
+   "metrics": [
+      {
+         "metric": "project.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project",
+         "resource_name": "ARGO",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-23T04:50:02Z",
+               "value": 3
+            }
+         ],
+         "description": "Counter that displays the number of topics belonging to the specific project"
+      }
+   ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -230,7 +230,7 @@ curl  -H "Content-Type: application/json"
 ```
 
 ### Responses  
-If successful it returns topic's related metrics (number of messages published and total bytes).
+If successful it returns projects related metrics (number of topics, number of subscriptions).
 
 Success Response
 `200 OK`
@@ -245,14 +245,29 @@ Success Response
          "resource_name": "ARGO",
          "timeseries": [
             {
-               "timestamp": "2017-06-23T04:50:02Z",
+               "timestamp": "2017-06-23T05:47:13Z",
                "value": 3
             }
          ],
          "description": "Counter that displays the number of topics belonging to the specific project"
+      },
+      {
+         "metric": "project.number_of_subscriptions",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project",
+         "resource_name": "ARGO",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-23T05:47:13Z",
+               "value": 4
+            }
+         ],
+         "description": "Counter that displays the number of subscriptions belonging to the specific project"
       }
    ]
 }
+
 ```
 
 ### Errors

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1122,11 +1122,25 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
          "resource_name": "ARGO",
          "timeseries": [
             {
-               "timestamp": "{{TIMESTAMP}}",
+               "timestamp": "{{TIMESTAMP1}}",
                "value": 3
             }
          ],
          "description": "Counter that displays the number of topics belonging to the specific project"
+      },
+      {
+         "metric": "project.number_of_subscriptions",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project",
+         "resource_name": "ARGO",
+         "timeseries": [
+            {
+               "timestamp": "{{TIMESTAMP2}}",
+               "value": 4
+            }
+         ],
+         "description": "Counter that displays the number of subscriptions belonging to the specific project"
       }
    ]
 }`
@@ -1142,8 +1156,10 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	metricOut, _ := metrics.GetMetricsFromJSON([]byte(w.Body.String()))
-	ts := metricOut.Metrics[0].Timeseries[0].Timestamp
-	expResp = strings.Replace(expResp, "{{TIMESTAMP}}", ts, -1)
+	ts1 := metricOut.Metrics[0].Timeseries[0].Timestamp
+	ts2 := metricOut.Metrics[1].Timeseries[0].Timestamp
+	expResp = strings.Replace(expResp, "{{TIMESTAMP1}}", ts1, -1)
+	expResp = strings.Replace(expResp, "{{TIMESTAMP2}}", ts2, -1)
 	suite.Equal(expResp, w.Body.String())
 
 }

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Metric names and descriptions
+const (
+	DescProjectTopics string = "Counter that displays the number of topics belonging to the specific project"
+	NameProjectTopics string = "project.number_of_topics"
+)
+
+type MetricList struct {
+	Metrics []Metric `json:"metrics"`
+}
+
+type Metric struct {
+	Metric       string      `json:"metric"`
+	MetricType   string      `json:"metric_type"`
+	ValueType    string      `json:"value_type"`
+	ResourceType string      `json:"resource_type"`
+	Resource     string      `json:"resource_name"`
+	Timeseries   []Timepoint `json:"timeseries"`
+	Description  string      `json:"description"`
+}
+
+type Timepoint struct {
+	Timestamp string      `json:"timestamp"`
+	Value     interface{} `json:"value"`
+}
+
+// ExportJSON exports whole ProjectTopic structure
+func (m *Metric) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(m, "", "   ")
+	return string(output[:]), err
+}
+
+// ExportJSON exports whole ProjectTopic structure
+func (ml *MetricList) ExportJSON() (string, error) {
+	output, err := json.MarshalIndent(ml, "", "   ")
+	return string(output[:]), err
+}
+
+func NewMetricList(m Metric) MetricList {
+	ml := MetricList{Metrics: []Metric{m}}
+	return ml
+}
+
+func NewProjectTopics(project string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameProjectTopics, MetricType: "counter", ValueType: "int64", ResourceType: "project", Resource: project, Timeseries: ts, Description: DescProjectTopics}
+	return m
+}
+
+// GetUserFromJSON retrieves User info From JSON string
+func GetMetricsFromJSON(input []byte) (MetricList, error) {
+	ml := MetricList{}
+	err := json.Unmarshal([]byte(input), &ml)
+	return ml, err
+}
+
+func GetTimeNowZulu() string {
+	zSec := "2006-01-02T15:04:05Z"
+	t := time.Now()
+	ts := t.Format(zSec)
+	return ts
+}

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -9,6 +9,8 @@ import (
 const (
 	DescProjectTopics string = "Counter that displays the number of topics belonging to the specific project"
 	NameProjectTopics string = "project.number_of_topics"
+	DescProjectSubs   string = "Counter that displays the number of subscriptions belonging to the specific project"
+	NameProjectSubs   string = "project.number_of_subscriptions"
 )
 
 type MetricList struct {
@@ -51,6 +53,13 @@ func NewProjectTopics(project string, value int64, tstamp string) Metric {
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
 	m := Metric{Metric: NameProjectTopics, MetricType: "counter", ValueType: "int64", ResourceType: "project", Resource: project, Timeseries: ts, Description: DescProjectTopics}
+	return m
+}
+
+func NewProjectSubs(project string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameProjectSubs, MetricType: "counter", ValueType: "int64", ResourceType: "project", Resource: project, Timeseries: ts, Description: DescProjectSubs}
 	return m
 }
 

--- a/metrics/models_test.go
+++ b/metrics/models_test.go
@@ -93,6 +93,25 @@ func (suite *MetricsTestSuite) TestGetTopicsACL() {
 
 }
 
+func (suite *MetricsTestSuite) TestGetSubs() {
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	n, _ := GetProjectSubs("argo_uuid", store)
+	suite.Equal(int64(4), n)
+
+}
+func (suite *MetricsTestSuite) TestGetSubsACL() {
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	n, _ := GetProjectSubsACL("argo_uuid", "uuid1", store)
+	suite.Equal(int64(3), n)
+
+}
+
 func TestMetricsTestSuite(t *testing.T) {
 	suite.Run(t, new(MetricsTestSuite))
 }

--- a/metrics/models_test.go
+++ b/metrics/models_test.go
@@ -1,0 +1,98 @@
+package metrics
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/ARGOeu/argo-messaging/config"
+	"github.com/ARGOeu/argo-messaging/stores"
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type MetricsTestSuite struct {
+	suite.Suite
+	cfgStr string
+}
+
+func (suite *MetricsTestSuite) SetupTest() {
+	suite.cfgStr = `{
+		"broker_host":"localhost:9092",
+		"store_host":"localhost",
+		"store_db":"argo_msg"
+	}`
+	log.SetOutput(ioutil.Discard)
+}
+
+func (suite *MetricsTestSuite) TestCreateMetric() {
+	expJson := `{
+   "metric": "project.number_of_topics",
+   "metric_type": "counter",
+   "value_type": "int64",
+   "resource_type": "project",
+   "resource_name": "test_project",
+   "timeseries": [
+      {
+         "timestamp": "2017-06-23T03:42:44Z",
+         "value": 32
+      }
+   ],
+   "description": "Counter that displays the number of topics belonging to the specific project"
+}`
+
+	ts := "2017-06-23T03:42:44Z"
+	myMetric := NewProjectTopics("test_project", 32, ts)
+	outputJSON, _ := myMetric.ExportJSON()
+	suite.Equal(expJson, outputJSON)
+}
+
+func (suite *MetricsTestSuite) TestCreateMetricList() {
+	expJson := `{
+   "metrics": [
+      {
+         "metric": "project.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project",
+         "resource_name": "test_project",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-23T03:42:44Z",
+               "value": 32
+            }
+         ],
+         "description": "Counter that displays the number of topics belonging to the specific project"
+      }
+   ]
+}`
+	ts := "2017-06-23T03:42:44Z"
+	myMetric := NewProjectTopics("test_project", 32, ts)
+	myList := NewMetricList(myMetric)
+	outputJSON, _ := myList.ExportJSON()
+
+	suite.Equal(expJson, outputJSON)
+}
+
+func (suite *MetricsTestSuite) TestGetTopics() {
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	n, _ := GetProjectTopics("argo_uuid", store)
+	suite.Equal(int64(3), n)
+
+}
+func (suite *MetricsTestSuite) TestGetTopicsACL() {
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	n, _ := GetProjectTopicsACL("argo_uuid", "uuid1", store)
+	suite.Equal(int64(2), n)
+
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -11,3 +11,13 @@ func GetProjectTopicsACL(projectUUID string, username string, store stores.Store
 	topics, err := store.QueryTopicsByACL(projectUUID, username)
 	return int64(len(topics)), err
 }
+
+func GetProjectSubs(projectUUID string, store stores.Store) (int64, error) {
+	subs, err := store.QuerySubs(projectUUID, "")
+	return int64(len(subs)), err
+}
+
+func GetProjectSubsACL(projectUUID string, username string, store stores.Store) (int64, error) {
+	subs, err := store.QuerySubsByACL(projectUUID, username)
+	return int64(len(subs)), err
+}

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -1,0 +1,13 @@
+package metrics
+
+import "github.com/ARGOeu/argo-messaging/stores"
+
+func GetProjectTopics(projectUUID string, store stores.Store) (int64, error) {
+	topics, err := store.QueryTopics(projectUUID, "")
+	return int64(len(topics)), err
+}
+
+func GetProjectTopicsACL(projectUUID string, username string, store stores.Store) (int64, error) {
+	topics, err := store.QueryTopicsByACL(projectUUID, username)
+	return int64(len(topics)), err
+}

--- a/routing.go
+++ b/routing.go
@@ -73,6 +73,7 @@ var defaultRoutes = []APIRoute{
 	{"users:delete", "DELETE", "/users/{user}", UserDelete},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:show", "GET", "/projects/{project}", ProjectListOne},
+	{"projects:metrics", "GET", "/projects/{project}:metrics", ProjectMetrics},
 	{"projects:create", "POST", "/projects/{project}", ProjectCreate},
 	{"projects:update", "PUT", "/projects/{project}", ProjectUpdate},
 	{"projects:delete", "DELETE", "/projects/{project}", ProjectDelete},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -620,6 +620,21 @@ func (mk *MockStore) QuerySubs(projectUUID string, name string) ([]QSub, error) 
 	return result, nil
 }
 
+func (mk *MockStore) QuerySubsByACL(projectUUID, user string) ([]QSub, error) {
+	result := []QSub{}
+	for _, item := range mk.SubList {
+		if projectUUID == item.ProjectUUID {
+			for _, usr := range mk.SubsACL[item.Name].ACL {
+				if usr == user {
+					result = append(result, item)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
 func (mk *MockStore) QueryTopicsByACL(projectUUID, user string) ([]QTopic, error) {
 	result := []QTopic{}
 	for _, item := range mk.TopicList {

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -620,6 +620,21 @@ func (mk *MockStore) QuerySubs(projectUUID string, name string) ([]QSub, error) 
 	return result, nil
 }
 
+func (mk *MockStore) QueryTopicsByACL(projectUUID, user string) ([]QTopic, error) {
+	result := []QTopic{}
+	for _, item := range mk.TopicList {
+		if projectUUID == item.ProjectUUID {
+			for _, usr := range mk.TopicsACL[item.Name].ACL {
+				if usr == user {
+					result = append(result, item)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
 // QueryTopics Query Subscription info from store
 func (mk *MockStore) QueryTopics(projectUUID string, name string) ([]QTopic, error) {
 	result := []QTopic{}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -340,7 +340,28 @@ func (mong *MongoStore) QueryUsers(projectUUID string, uuid string, name string)
 	return results, err
 }
 
-//QueryTopicsByACL returns topics of a specific username
+//QuerySubsByACL returns subscriptions that a specific username has access to
+func (mong *MongoStore) QuerySubsByACL(projectUUID, user string) ([]QSub, error) {
+	// By default return all subs of a given project
+	query := bson.M{"project_uuid": projectUUID}
+
+	// If name is given return only the specific topic
+	if user != "" {
+		query = bson.M{"project_uuid": projectUUID, "acl": user}
+	}
+	db := mong.Session.DB(mong.Database)
+	c := db.C("subscriptions")
+	var results []QSub
+	err := c.Find(query).All(&results)
+
+	if err != nil {
+		log.Fatal("STORE", "\t", err.Error())
+	}
+
+	return results, err
+}
+
+//QueryTopicsByACL returns topics that a specific username has access to
 func (mong *MongoStore) QueryTopicsByACL(projectUUID, user string) ([]QTopic, error) {
 	// By default return all topics of a given project
 	query := bson.M{"project_uuid": projectUUID}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -340,6 +340,27 @@ func (mong *MongoStore) QueryUsers(projectUUID string, uuid string, name string)
 	return results, err
 }
 
+//QueryTopicsByACL returns topics of a specific username
+func (mong *MongoStore) QueryTopicsByACL(projectUUID, user string) ([]QTopic, error) {
+	// By default return all topics of a given project
+	query := bson.M{"project_uuid": projectUUID}
+
+	// If name is given return only the specific topic
+	if user != "" {
+		query = bson.M{"project_uuid": projectUUID, "acl": user}
+	}
+	db := mong.Session.DB(mong.Database)
+	c := db.C("topics")
+	var results []QTopic
+	err := c.Find(query).All(&results)
+
+	if err != nil {
+		log.Fatal("STORE", "\t", err.Error())
+	}
+
+	return results, err
+}
+
 // QueryTopics Query Subscription info from store
 func (mong *MongoStore) QueryTopics(projectUUID string, name string) ([]QTopic, error) {
 

--- a/stores/store.go
+++ b/stores/store.go
@@ -5,6 +5,7 @@ import "time"
 // Store encapsulates the generic store interface
 type Store interface {
 	Initialize()
+	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
 	QuerySubs(projectUUID string, name string) ([]QSub, error)
 	QueryTopics(projectUUID string, name string) ([]QTopic, error)
 	RemoveTopic(projectUUID string, name string) error

--- a/stores/store.go
+++ b/stores/store.go
@@ -6,6 +6,7 @@ import "time"
 type Store interface {
 	Initialize()
 	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
+	QuerySubsByACL(projectUUID, user string) ([]QSub, error)
 	QuerySubs(projectUUID string, name string) ([]QSub, error)
 	QueryTopics(projectUUID string, name string) ([]QTopic, error)
 	RemoveTopic(projectUUID string, name string) error


### PR DESCRIPTION
## Goal
Add metric: number of subscriptions per project/user

## Implementation
- [x] Added a general model for metrics which has the following JSON representation:
 ```
{
   "metrics": [
      {
         "metric": "project.number_of_topics",
         "metric_type": "counter",
         "value_type": "int64",
         "resource_type": "project",
         "resource_name": "ARGO",
         "timeseries": [
            {
               "timestamp": "2017-06-23T05:47:13Z",
               "value": 3
            }
         ],
         "description": "Counter that displays the number of topics belonging to the specific project"
      },
      {
         "metric": "project.number_of_subscriptions",
         "metric_type": "counter",
         "value_type": "int64",
         "resource_type": "project",
         "resource_name": "ARGO",
         "timeseries": [
            {
               "timestamp": "2017-06-23T05:47:13Z",
               "value": 4
            }
         ],
         "description": "Counter that displays the number of subscriptions belonging to the specific project"
      }
   ]
}

```

- [x] Added QuerySubsByACL in the `store` package in order to retrieve the number of topics per acl user (publisher)
- [x] Added Methods  in the `metrics` package for quering the number of subs
- [x] Updated Project:Metrics GET handler
- [x] Added unit tests (models,handlers)
- [x] Updated mkdocs
