### PR TITLE
ARGO-866 Metric: number of subscriptions per topic

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1141,7 +1141,7 @@ paths:
         200:
           description: Topic metrics.
           schema:
-            $ref: '#/definitions/TopicMetrics'
+            $ref: '#/definitions/Metrics'
         400:
           $ref: "#/responses/400"
         401:

--- a/doc/v1/docs/api_topics.md
+++ b/doc/v1/docs/api_topics.md
@@ -304,9 +304,52 @@ Success Response
 `200 OK`
 ```
 {
-  "number_of_messages":4,
-  "total_bytes":54
+   "metrics": [
+      {
+         "metric": "topic.number_of_subscriptions",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "topic",
+         "resource_name": "topic1",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-27T10:20:18Z",
+               "value": 1
+            }
+         ],
+         "description": "Counter that displays the number of subscriptions belonging to a specific topic"
+      },
+      {
+         "metric": "topic.number_of_messages",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "topic",
+         "resource_name": "topic1",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-27T10:20:18Z",
+               "value": 0
+            }
+         ],
+         "description": "Counter that displays the number number of messages published to the specific topic"
+      },
+      {
+         "metric": "topic.number_of_bytes",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "topic",
+         "resource_name": "topic1",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-27T10:20:18Z",
+               "value": 0
+            }
+         ],
+         "description": "Counter that displays the total size of data (in bytes) published to the specific topic"
+      }
+   ]
 }
+
 ```
 
 ### Errors

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -11,6 +11,12 @@ const (
 	NameProjectTopics string = "project.number_of_topics"
 	DescProjectSubs   string = "Counter that displays the number of subscriptions belonging to the specific project"
 	NameProjectSubs   string = "project.number_of_subscriptions"
+	DescTopicSubs     string = "Counter that displays the number of subscriptions belonging to a specific topic"
+	NameTopicSubs     string = "topic.number_of_subscriptions"
+	DescTopicMsgs     string = "Counter that displays the number number of messages published to the specific topic"
+	NameTopicMsgs     string = "topic.number_of_messages"
+	DescTopicBytes    string = "Counter that displays the total size of data (in bytes) published to the specific topic"
+	NameTopicBytes    string = "topic.number_of_bytes"
 )
 
 type MetricList struct {
@@ -60,6 +66,27 @@ func NewProjectSubs(project string, value int64, tstamp string) Metric {
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
 	m := Metric{Metric: NameProjectSubs, MetricType: "counter", ValueType: "int64", ResourceType: "project", Resource: project, Timeseries: ts, Description: DescProjectSubs}
+	return m
+}
+
+func NewTopicSubs(topic string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameTopicSubs, MetricType: "counter", ValueType: "int64", ResourceType: "topic", Resource: topic, Timeseries: ts, Description: DescTopicSubs}
+	return m
+}
+
+func NewTopicMsgs(topic string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameTopicMsgs, MetricType: "counter", ValueType: "int64", ResourceType: "topic", Resource: topic, Timeseries: ts, Description: DescTopicMsgs}
+	return m
+}
+
+func NewTopicBytes(topic string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameTopicBytes, MetricType: "counter", ValueType: "int64", ResourceType: "topic", Resource: topic, Timeseries: ts, Description: DescTopicBytes}
 	return m
 }
 

--- a/metrics/models_test.go
+++ b/metrics/models_test.go
@@ -102,6 +102,7 @@ func (suite *MetricsTestSuite) TestGetSubs() {
 	suite.Equal(int64(4), n)
 
 }
+
 func (suite *MetricsTestSuite) TestGetSubsACL() {
 
 	APIcfg := config.NewAPICfg()
@@ -109,6 +110,16 @@ func (suite *MetricsTestSuite) TestGetSubsACL() {
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 	n, _ := GetProjectSubsACL("argo_uuid", "uuid1", store)
 	suite.Equal(int64(3), n)
+
+}
+
+func (suite *MetricsTestSuite) TestGetSubsByTopic() {
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	n, _ := GetProjectSubsByTopic("argo_uuid", "topic1", store)
+	suite.Equal(int64(1), n)
 
 }
 

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -7,6 +7,11 @@ func GetProjectTopics(projectUUID string, store stores.Store) (int64, error) {
 	return int64(len(topics)), err
 }
 
+func GetProjectSubsByTopic(projectUUID string, topic string, store stores.Store) (int64, error) {
+	subs, err := store.QuerySubsByTopic(projectUUID, topic)
+	return int64(len(subs)), err
+}
+
 func GetProjectTopicsACL(projectUUID string, username string, store stores.Store) (int64, error) {
 	topics, err := store.QueryTopicsByACL(projectUUID, username)
 	return int64(len(topics)), err

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -620,6 +620,16 @@ func (mk *MockStore) QuerySubs(projectUUID string, name string) ([]QSub, error) 
 	return result, nil
 }
 
+func (mk *MockStore) QuerySubsByTopic(projectUUID, topic string) ([]QSub, error) {
+	result := []QSub{}
+	for _, item := range mk.SubList {
+		if projectUUID == item.ProjectUUID && item.Topic == topic {
+			result = append(result, item)
+		}
+	}
+	return result, nil
+}
+
 func (mk *MockStore) QuerySubsByACL(projectUUID, user string) ([]QSub, error) {
 	result := []QSub{}
 	for _, item := range mk.SubList {

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -340,6 +340,27 @@ func (mong *MongoStore) QueryUsers(projectUUID string, uuid string, name string)
 	return results, err
 }
 
+//QuerySubsByTopic returns subscriptions of a specific topic
+func (mong *MongoStore) QuerySubsByTopic(projectUUID, topic string) ([]QSub, error) {
+	// By default return all subs of a given project
+	query := bson.M{"project_uuid": projectUUID}
+
+	// If topic is given return only the specific topic
+	if topic != "" {
+		query = bson.M{"project_uuid": projectUUID, "topic": topic}
+	}
+	db := mong.Session.DB(mong.Database)
+	c := db.C("subscriptions")
+	var results []QSub
+	err := c.Find(query).All(&results)
+
+	if err != nil {
+		log.Fatal("STORE", "\t", err.Error())
+	}
+
+	return results, err
+}
+
 //QuerySubsByACL returns subscriptions that a specific username has access to
 func (mong *MongoStore) QuerySubsByACL(projectUUID, user string) ([]QSub, error) {
 	// By default return all subs of a given project

--- a/stores/store.go
+++ b/stores/store.go
@@ -5,6 +5,7 @@ import "time"
 // Store encapsulates the generic store interface
 type Store interface {
 	Initialize()
+	QuerySubsByTopic(projectUUID, topic string) ([]QSub, error)
 	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
 	QuerySubsByACL(projectUUID, user string) ([]QSub, error)
 	QuerySubs(projectUUID string, name string) ([]QSub, error)


### PR DESCRIPTION
### Goal
Add metric: number of subscriptions per topic

### Implementation
-[x] Implement GetSubscriptionsPerTopic method in datastore
-[x] Implement Number of Subscriptions per topic metric in `metrics` package
-[x] Refactor topic.number of bytes  to the new metric model
-[x] Refactor topic.number of messages to the new metric model
-[x] Refactor handler topic:metrics to support the new metrics
-[x] Update unit tests
-[x] Update documentation