### PR TITLE
ARGO-863 Add metric: Aggregation of topics per user at project. 

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -889,7 +889,7 @@ paths:
         200:
           description: Subscription metrics.
           schema:
-            $ref: '#/definitions/SubMetrics'
+            $ref: '#/definitions/Metrics'
         400:
           $ref: "#/responses/400"
         401:

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -395,8 +395,36 @@ Success Response
 `200 OK`
 ```
 {
-  "number_of_messages":12,
-  "total_bytes":54
+   "metrics": [
+      {
+         "metric": "subscription.number_of_messages",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "subscription",
+         "resource_name": "sub1",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-30T14:20:38Z",
+               "value": 0
+            }
+         ],
+         "description": "Counter that displays the number number of messages published to the specific topic"
+      },
+      {
+         "metric": "topic.number_of_bytes",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "topic",
+         "resource_name": "sub1",
+         "timeseries": [
+            {
+               "timestamp": "2017-06-30T14:20:38Z",
+               "value": 0
+            }
+         ],
+         "description": "Counter that displays the total size of data (in bytes) published to the specific topic"
+      }
+   ]
 }
 ```
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -1087,8 +1088,36 @@ func (suite *HandlerTestSuite) TestSubMetrics() {
 	}
 
 	expResp := `{
-   "number_of_messages": 0,
-   "total_bytes": 0
+   "metrics": [
+      {
+         "metric": "subscription.number_of_messages",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "subscription",
+         "resource_name": "sub1",
+         "timeseries": [
+            {
+               "timestamp": "{{TS1}}",
+               "value": 0
+            }
+         ],
+         "description": "Counter that displays the number number of messages consumed from the specific subscription"
+      },
+      {
+         "metric": "subscription.number_of_bytes",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "subscription",
+         "resource_name": "sub1",
+         "timeseries": [
+            {
+               "timestamp": "{{TS2}}",
+               "value": 0
+            }
+         ],
+         "description": "Counter that displays the total size of data (in bytes) consumed from the specific subscription"
+      }
+   ]
 }`
 
 	cfgKafka := config.NewAPICfg()
@@ -1101,7 +1130,15 @@ func (suite *HandlerTestSuite) TestSubMetrics() {
 	router.HandleFunc("/v1/projects/{project}/subscriptions/{subscription}:metrics", WrapMockAuthConfig(SubMetrics, cfgKafka, &brk, str, &mgr))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
+
+	metricOut, _ := metrics.GetMetricsFromJSON([]byte(w.Body.String()))
+	ts1 := metricOut.Metrics[0].Timeseries[0].Timestamp
+	ts2 := metricOut.Metrics[1].Timeseries[0].Timestamp
+	expResp = strings.Replace(expResp, "{{TS1}}", ts1, -1)
+	expResp = strings.Replace(expResp, "{{TS2}}", ts2, -1)
 	suite.Equal(expResp, w.Body.String())
+
+	fmt.Println(w.Body.String())
 
 }
 
@@ -1143,7 +1180,7 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
          "description": "Counter that displays the number of subscriptions belonging to the specific project"
       },
       {
-         "metric": "project.user.number_of_subscriptions",
+         "metric": "project.user.number_of_topics",
          "metric_type": "counter",
          "value_type": "int64",
          "resource_type": "project.user",
@@ -1151,6 +1188,62 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
          "timeseries": [
             {
                "timestamp": "{{TS3}}",
+               "value": 2
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserB",
+         "timeseries": [
+            {
+               "timestamp": "{{TS4}}",
+               "value": 2
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserX",
+         "timeseries": [
+            {
+               "timestamp": "{{TS5}}",
+               "value": 1
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserZ",
+         "timeseries": [
+            {
+               "timestamp": "{{TS6}}",
+               "value": 1
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_subscriptions",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserA",
+         "timeseries": [
+            {
+               "timestamp": "{{TS7}}",
                "value": 3
             }
          ],
@@ -1164,7 +1257,7 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
          "resource_name": "ARGO.UserB",
          "timeseries": [
             {
-               "timestamp": "{{TS4}}",
+               "timestamp": "{{TS8}}",
                "value": 3
             }
          ],
@@ -1178,7 +1271,7 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
          "resource_name": "ARGO.UserX",
          "timeseries": [
             {
-               "timestamp": "{{TS5}}",
+               "timestamp": "{{TS9}}",
                "value": 1
             }
          ],
@@ -1192,7 +1285,7 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
          "resource_name": "ARGO.UserZ",
          "timeseries": [
             {
-               "timestamp": "{{TS5}}",
+               "timestamp": "{{TS10}}",
                "value": 2
             }
          ],
@@ -1218,12 +1311,20 @@ func (suite *HandlerTestSuite) TestProjectcMetrics() {
 	ts4 := metricOut.Metrics[3].Timeseries[0].Timestamp
 	ts5 := metricOut.Metrics[4].Timeseries[0].Timestamp
 	ts6 := metricOut.Metrics[5].Timeseries[0].Timestamp
+	ts7 := metricOut.Metrics[6].Timeseries[0].Timestamp
+	ts8 := metricOut.Metrics[7].Timeseries[0].Timestamp
+	ts9 := metricOut.Metrics[8].Timeseries[0].Timestamp
+	ts10 := metricOut.Metrics[9].Timeseries[0].Timestamp
 	expResp = strings.Replace(expResp, "{{TS1}}", ts1, -1)
 	expResp = strings.Replace(expResp, "{{TS2}}", ts2, -1)
 	expResp = strings.Replace(expResp, "{{TS3}}", ts3, -1)
 	expResp = strings.Replace(expResp, "{{TS4}}", ts4, -1)
 	expResp = strings.Replace(expResp, "{{TS5}}", ts5, -1)
 	expResp = strings.Replace(expResp, "{{TS6}}", ts6, -1)
+	expResp = strings.Replace(expResp, "{{TS7}}", ts7, -1)
+	expResp = strings.Replace(expResp, "{{TS8}}", ts8, -1)
+	expResp = strings.Replace(expResp, "{{TS9}}", ts9, -1)
+	expResp = strings.Replace(expResp, "{{TS10}}", ts10, -1)
 	suite.Equal(expResp, w.Body.String())
 
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -123,7 +123,7 @@ func (suite *MetricsTestSuite) TestGetSubsByTopic() {
 
 }
 
-func (suite *MetricsTestSuite) TestAggrProjectUserTest() {
+func (suite *MetricsTestSuite) TestAggrProjectUserSubTest() {
 
 	expJSON := `{
    "metrics": [
@@ -190,6 +190,90 @@ func (suite *MetricsTestSuite) TestAggrProjectUserTest() {
 	APIcfg.LoadStrJSON(suite.cfgStr)
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 	ml, _ := AggrProjectUserSubs("argo_uuid", store)
+
+	ts1 := ml.Metrics[0].Timeseries[0].Timestamp
+	ts2 := ml.Metrics[0].Timeseries[0].Timestamp
+	ts3 := ml.Metrics[0].Timeseries[0].Timestamp
+	ts4 := ml.Metrics[0].Timeseries[0].Timestamp
+
+	expJSON = strings.Replace(expJSON, "{{TS1}}", ts1, -1)
+	expJSON = strings.Replace(expJSON, "{{TS2}}", ts2, -1)
+	expJSON = strings.Replace(expJSON, "{{TS3}}", ts3, -1)
+	expJSON = strings.Replace(expJSON, "{{TS4}}", ts4, -1)
+
+	outJSON, _ := ml.ExportJSON()
+
+	suite.Equal(expJSON, outJSON)
+
+}
+
+func (suite *MetricsTestSuite) TestAggrProjectUserTopicsTest() {
+
+	expJSON := `{
+   "metrics": [
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserA",
+         "timeseries": [
+            {
+               "timestamp": "{{TS1}}",
+               "value": 2
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserB",
+         "timeseries": [
+            {
+               "timestamp": "{{TS2}}",
+               "value": 2
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserX",
+         "timeseries": [
+            {
+               "timestamp": "{{TS3}}",
+               "value": 1
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      },
+      {
+         "metric": "project.user.number_of_topics",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "project.user",
+         "resource_name": "ARGO.UserZ",
+         "timeseries": [
+            {
+               "timestamp": "{{TS4}}",
+               "value": 1
+            }
+         ],
+         "description": "Counter that displays the number of topics that a user has access to the specific project"
+      }
+   ]
+}`
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	ml, _ := AggrProjectUserTopics("argo_uuid", store)
 
 	ts1 := ml.Metrics[0].Timeseries[0].Timestamp
 	ts2 := ml.Metrics[0].Timeseries[0].Timestamp

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -7,18 +7,24 @@ import (
 
 // Metric names and descriptions
 const (
-	DescProjectTopics   string = "Counter that displays the number of topics belonging to the specific project"
-	NameProjectTopics   string = "project.number_of_topics"
-	DescProjectSubs     string = "Counter that displays the number of subscriptions belonging to the specific project"
-	NameProjectSubs     string = "project.number_of_subscriptions"
-	DescTopicSubs       string = "Counter that displays the number of subscriptions belonging to a specific topic"
-	NameTopicSubs       string = "topic.number_of_subscriptions"
-	DescTopicMsgs       string = "Counter that displays the number number of messages published to the specific topic"
-	NameTopicMsgs       string = "topic.number_of_messages"
-	DescTopicBytes      string = "Counter that displays the total size of data (in bytes) published to the specific topic"
-	NameTopicBytes      string = "topic.number_of_bytes"
-	DescProjectUserSubs string = "Counter that displays the number of subscriptions that a user has access to the specific project"
-	NameProjectUserSubs string = "project.user.number_of_subscriptions"
+	DescProjectTopics     string = "Counter that displays the number of topics belonging to the specific project"
+	NameProjectTopics     string = "project.number_of_topics"
+	DescProjectSubs       string = "Counter that displays the number of subscriptions belonging to the specific project"
+	NameProjectSubs       string = "project.number_of_subscriptions"
+	DescTopicSubs         string = "Counter that displays the number of subscriptions belonging to a specific topic"
+	NameTopicSubs         string = "topic.number_of_subscriptions"
+	DescTopicMsgs         string = "Counter that displays the number number of messages published to the specific topic"
+	NameTopicMsgs         string = "topic.number_of_messages"
+	DescTopicBytes        string = "Counter that displays the total size of data (in bytes) published to the specific topic"
+	NameTopicBytes        string = "topic.number_of_bytes"
+	DescProjectUserSubs   string = "Counter that displays the number of subscriptions that a user has access to the specific project"
+	NameProjectUserSubs   string = "project.user.number_of_subscriptions"
+	DescProjectUserTopics string = "Counter that displays the number of topics that a user has access to the specific project"
+	NameProjectUserTopics string = "project.user.number_of_topics"
+	DescSubMsgs           string = "Counter that displays the number number of messages consumed from the specific subscription"
+	NameSubMsgs           string = "subscription.number_of_messages"
+	DescSubBytes          string = "Counter that displays the total size of data (in bytes) consumed from the specific subscription"
+	NameSubBytes          string = "subscription.number_of_bytes"
 )
 
 type MetricList struct {
@@ -78,6 +84,20 @@ func NewTopicSubs(topic string, value int64, tstamp string) Metric {
 	return m
 }
 
+func NewSubMsgs(topic string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameSubMsgs, MetricType: "counter", ValueType: "int64", ResourceType: "subscription", Resource: topic, Timeseries: ts, Description: DescSubMsgs}
+	return m
+}
+
+func NewSubBytes(topic string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameSubBytes, MetricType: "counter", ValueType: "int64", ResourceType: "subscription", Resource: topic, Timeseries: ts, Description: DescSubBytes}
+	return m
+}
+
 func NewTopicMsgs(topic string, value int64, tstamp string) Metric {
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
@@ -96,6 +116,14 @@ func NewProjectUserSubs(project string, user string, value int64, tstamp string)
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
 	m := Metric{Metric: NameProjectUserSubs, MetricType: "counter", ValueType: "int64", ResourceType: "project.user", Resource: project + "." + user, Timeseries: ts, Description: DescProjectUserSubs}
+
+	return m
+}
+
+func NewProjectUserTopics(project string, user string, value int64, tstamp string) Metric {
+	// Initialize single point timeseries with the latest timestamp and value
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameProjectUserTopics, MetricType: "counter", ValueType: "int64", ResourceType: "project.user", Resource: project + "." + user, Timeseries: ts, Description: DescProjectUserTopics}
 
 	return m
 }

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -47,3 +47,24 @@ func AggrProjectUserSubs(projectUUID string, store stores.Store) (MetricList, er
 	}
 	return ml, err
 }
+
+func AggrProjectUserTopics(projectUUID string, store stores.Store) (MetricList, error) {
+	pr, err := store.QueryProjects(projectUUID, "")
+	if err != nil {
+		return MetricList{}, err
+	}
+	prName := pr[0].Name
+	users, err := store.QueryUsers(projectUUID, "", "")
+	ml := MetricList{}
+	for _, item := range users {
+		username := item.Name
+		userUUID := item.UUID
+		numSubs, _ := GetProjectTopicsACL(projectUUID, userUUID, store)
+		if numSubs > 0 {
+			m := NewProjectUserTopics(prName, username, numSubs, GetTimeNowZulu())
+			ml.Metrics = append(ml.Metrics, m)
+		}
+
+	}
+	return ml, err
+}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -313,11 +313,11 @@ func (mong *MongoStore) QueryUsers(projectUUID string, uuid string, name string)
 	query := bson.M{}
 	// If project UUID is given return users that belong to the project
 	if projectUUID != "" {
-		query = bson.M{"project_uuid": projectUUID}
+		query = bson.M{"projects.project_uuid": projectUUID}
 		if uuid != "" {
-			query = bson.M{"project_uuid": projectUUID, "uuid": uuid}
+			query = bson.M{"projects.project_uuid": projectUUID, "uuid": uuid}
 		} else if name != "" {
-			query = bson.M{"project_uuid": projectUUID, "name": name}
+			query = bson.M{"projects.project_uuid": projectUUID, "name": name}
 		}
 	} else {
 		if uuid != "" {
@@ -331,6 +331,7 @@ func (mong *MongoStore) QueryUsers(projectUUID string, uuid string, name string)
 	db := mong.Session.DB(mong.Database)
 	c := db.C("users")
 	var results []QUser
+
 	err := c.Find(query).All(&results)
 
 	if err != nil {


### PR DESCRIPTION
# Goal
Add new metric: Aggreagation of topics per user for a specific project

# Implementation
- Add method for aggregating topics per user for a specific project (metrics package)
- Refactor project metrics request handler to use the new method
- Refactor subscription metrics to the new schema:
 - - Add const descriptions for subscription metrics in metrics package
 - - Add new subscription metric constructors
 - - Refactor subscription metrics request handler to use the new methods 
 - - Update swagger
- Update unit tests
- Update documentation 

