### PR TITLE
ARGO-859 Add operational metric: memory usage for ams nodes

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -24,6 +24,34 @@ tags:
   - name: Projects
     description: Projects available in the service
 paths:
+
+  /metrics:
+    get:
+      summary: List operational metrics of the ams service
+      description: |
+        list operational metrics
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+      tags:
+        - Operational Metrics
+      responses:
+        200:
+          description: An array of Metrics
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Metrics'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
   /projects:
     get:
       summary: List subscriptions in a project

--- a/doc/v1/docs/api_metrics.md
+++ b/doc/v1/docs/api_metrics.md
@@ -31,15 +31,29 @@ Success Response
          "metric_type": "percentage",
          "value_type": "float64",
          "resource_type": "ams_node",
-         "resource_name": "host2.foo",
+         "resource_name": "host.foo",
          "timeseries": [
             {
-               "timestamp": "2017-07-04T09:36:03Z",
-               "value": 50
+               "timestamp": "2017-07-04T10:18:07Z",
+               "value": 0.2
             }
          ],
          "description": "Percentage value that displays the CPU usage of ams service in the specific node"
       },
+      {
+         "metric": "ams_node.memory_usage",
+         "metric_type": "percentage",
+         "value_type": "float64",
+         "resource_type": "ams_node",
+         "resource_name": "host.foo",
+         "timeseries": [
+            {
+               "timestamp": "2017-07-04T10:18:07Z",
+               "value": 0.1
+            }
+         ],
+         "description": "Percentage value that displays the Memory usage of ams service in the specific node"
+      }
    ]
 }
 

--- a/doc/v1/docs/api_metrics.md
+++ b/doc/v1/docs/api_metrics.md
@@ -1,0 +1,49 @@
+#Operational Metrics API Calls
+
+Operational Metrics include metrics related to the CPU or memory usage of the ams nodes
+
+## [GET] Get Operational Metrics
+This request gets a list of operational metrics for the specific ams servcice
+
+### Request
+```json
+GET "/v1/metrics"
+```
+
+
+### Example request
+
+```json
+curl -H "Content-Type: application/json"
+ "https://{URL}/v1/metrics?key=S3CR3T"
+```
+
+### Responses
+If successful, the response returns a list of related operational metrics
+
+Success Response
+`200 OK`
+```json
+{
+   "metrics": [
+      {
+         "metric": "ams_node.cpu_usage",
+         "metric_type": "percentage",
+         "value_type": "float64",
+         "resource_type": "ams_node",
+         "resource_name": "host2.foo",
+         "timeseries": [
+            {
+               "timestamp": "2017-07-04T09:36:03Z",
+               "value": 50
+            }
+         ],
+         "description": "Percentage value that displays the CPU usage of ams service in the specific node"
+      },
+   ]
+}
+
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/doc/v1/mkdocs.yml
+++ b/doc/v1/mkdocs.yml
@@ -12,17 +12,18 @@ pages:
     - Messaging Backend - Apache Kafka: msg_backend.md
     - Messaging API flow: msg_flow.md
     - Authentication & Authorization: auth.md
-    - Project & User management guide: projects_users.md 
+    - Project & User management guide: projects_users.md
 - How to Guides:
     - Publisher Guide: publisher.md
     #  - Consumer Guide: consumer.md
-- API & References: 
+- API & References:
     - API Basic Information: api_basic.md
     - API Authentication: api_auth.md
     - API Users: api_users.md
     - API Projects: api_projects.md
     - API Topics: api_topics.md
     - API Subscriptions: api_subs.md
+    - API Operational Metrics: api_metrics.md
     - API Error Messages: api_errors.md
 - Q&A:
     - General : qa_general_questions.md

--- a/handlers.go
+++ b/handlers.go
@@ -622,6 +622,7 @@ func OpMetrics(w http.ResponseWriter, r *http.Request) {
 
 	// Get Results Object
 	res, err := metrics.GetUsageCPU(refStr)
+
 	if err != nil && err.Error() != "not found" {
 		respondErr(w, 500, "Internal error while querying datastore", "INTERNAL")
 		return
@@ -1832,7 +1833,7 @@ func SubMetrics(w http.ResponseWriter, r *http.Request) {
 
 	m1 := metrics.NewSubMsgs(urlSub, numMsg, metrics.GetTimeNowZulu())
 	res := metrics.NewMetricList(m1)
-	m2 := metrics.NewTopicBytes(urlSub, numBytes, metrics.GetTimeNowZulu())
+	m2 := metrics.NewSubBytes(urlSub, numBytes, metrics.GetTimeNowZulu())
 
 	res.Metrics = append(res.Metrics, m2)
 

--- a/handlers.go
+++ b/handlers.go
@@ -606,6 +606,42 @@ func UserCreate(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// OpMetrics (GET) all operational metrics
+func OpMetrics(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab context references
+	refStr := context.Get(r, "str").(stores.Store)
+
+	// Get Results Object
+	res, err := metrics.GetUsageCPU(refStr)
+	if err != nil && err.Error() != "not found" {
+		respondErr(w, 500, "Internal error while querying datastore", "INTERNAL")
+		return
+	}
+
+	// Output result to JSON
+	resJSON, err := res.ExportJSON()
+
+	if err != nil {
+
+		respondErr(w, 500, "Error exporting data", "INTERNAL_SERVER_ERROR")
+		return
+	}
+
+	// Write response
+	output = []byte(resJSON)
+	respondOK(w, output)
+
+}
+
 // UserListOne (GET) one user
 func UserListOne(w http.ResponseWriter, r *http.Request) {
 
@@ -1503,7 +1539,6 @@ func ProjectMetrics(w http.ResponseWriter, r *http.Request) {
 	res.Metrics = append(res.Metrics, m2)
 
 	// Project User topics aggregation
-	fmt.Println("aggregating topis/user...")
 	m3, err := metrics.AggrProjectUserTopics(projectUUID, refStr)
 	if err != nil {
 		respondErr(w, 500, "Error exporting data to JSON", "INTERNAL_SERVER_ERROR")
@@ -1515,7 +1550,6 @@ func ProjectMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Project User subscriptions aggregation
-	fmt.Println("aggregating subs/user...")
 	m4, err := metrics.AggrProjectUserSubs(projectUUID, refStr)
 	if err != nil {
 		respondErr(w, 500, "Error exporting data to JSON", "INTERNAL_SERVER_ERROR")
@@ -1798,7 +1832,7 @@ func SubMetrics(w http.ResponseWriter, r *http.Request) {
 
 	m1 := metrics.NewSubMsgs(urlSub, numMsg, metrics.GetTimeNowZulu())
 	res := metrics.NewMetricList(m1)
-	m2 := metrics.NewSubBytes(urlSub, numBytes, metrics.GetTimeNowZulu())
+	m2 := metrics.NewTopicBytes(urlSub, numBytes, metrics.GetTimeNowZulu())
 
 	res.Metrics = append(res.Metrics, m2)
 

--- a/handlers.go
+++ b/handlers.go
@@ -621,7 +621,7 @@ func OpMetrics(w http.ResponseWriter, r *http.Request) {
 	refStr := context.Get(r, "str").(stores.Store)
 
 	// Get Results Object
-	res, err := metrics.GetUsageCPU(refStr)
+	res, err := metrics.GetUsageCpuMem(refStr)
 
 	if err != nil && err.Error() != "not found" {
 		respondErr(w, 500, "Internal error while querying datastore", "INTERNAL")

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1344,10 +1345,24 @@ func (suite *HandlerTestSuite) TestOpMetrics() {
          "timeseries": [
             {
                "timestamp": "{{TS1}}",
-               "value": 0
+               "value": {{VAL1}}
             }
          ],
          "description": "Percentage value that displays the CPU usage of ams service in the specific node"
+      },
+      {
+         "metric": "ams_node.memory_usage",
+         "metric_type": "percentage",
+         "value_type": "float64",
+         "resource_type": "ams_node",
+         "resource_name": "{{HOST}}",
+         "timeseries": [
+            {
+               "timestamp": "{{TS1}}",
+               "value": {{VAL2}}
+            }
+         ],
+         "description": "Percentage value that displays the Memory usage of ams service in the specific node"
       }
    ]
 }`
@@ -1364,8 +1379,14 @@ func (suite *HandlerTestSuite) TestOpMetrics() {
 	suite.Equal(200, w.Code)
 	metricOut, _ := metrics.GetMetricsFromJSON([]byte(w.Body.String()))
 	ts1 := metricOut.Metrics[0].Timeseries[0].Timestamp
+	val1 := metricOut.Metrics[0].Timeseries[0].Value.(float64)
+	ts2 := metricOut.Metrics[1].Timeseries[0].Timestamp
+	val2 := metricOut.Metrics[1].Timeseries[0].Value.(float64)
 	host := metricOut.Metrics[0].Resource
 	expResp = strings.Replace(expResp, "{{TS1}}", ts1, -1)
+	expResp = strings.Replace(expResp, "{{TS2}}", ts2, -1)
+	expResp = strings.Replace(expResp, "{{VAL1}}", strconv.FormatFloat(val1, 'g', 1, 64), -1)
+	expResp = strings.Replace(expResp, "{{VAL2}}", strconv.FormatFloat(val2, 'g', 1, 64), -1)
 	expResp = strings.Replace(expResp, "{{HOST}}", host, -1)
 	suite.Equal(expResp, w.Body.String())
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1101,6 +1101,7 @@ func (suite *HandlerTestSuite) TestSubMetrics() {
                "value": 0
             }
          ],
+<<<<<<< 3e2f1e10881b5407acda63d64cb11c9956608b3a
          "description": "Counter that displays the number number of messages consumed from the specific subscription"
       },
       {
@@ -1108,6 +1109,15 @@ func (suite *HandlerTestSuite) TestSubMetrics() {
          "metric_type": "counter",
          "value_type": "int64",
          "resource_type": "subscription",
+=======
+         "description": "Counter that displays the number number of messages published to the specific topic"
+      },
+      {
+         "metric": "topic.number_of_bytes",
+         "metric_type": "counter",
+         "value_type": "int64",
+         "resource_type": "topic",
+>>>>>>> ARGO-863 Add metric: Aggregation of topics per user at project. Refactor subscription metrics to new schema
          "resource_name": "sub1",
          "timeseries": [
             {
@@ -1115,7 +1125,11 @@ func (suite *HandlerTestSuite) TestSubMetrics() {
                "value": 0
             }
          ],
+<<<<<<< 3e2f1e10881b5407acda63d64cb11c9956608b3a
          "description": "Counter that displays the total size of data (in bytes) consumed from the specific subscription"
+=======
+         "description": "Counter that displays the total size of data (in bytes) published to the specific topic"
+>>>>>>> ARGO-863 Add metric: Aggregation of topics per user at project. Refactor subscription metrics to new schema
       }
    ]
 }`

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -75,6 +75,44 @@ func (suite *MetricsTestSuite) TestCreateMetricList() {
 	suite.Equal(expJson, outputJSON)
 }
 
+func (suite *MetricsTestSuite) TestOperational() {
+
+	expJSON := `{
+   "metrics": [
+      {
+         "metric": "ams_node.cpu_usage",
+         "metric_type": "percentage",
+         "value_type": "float64",
+         "resource_type": "ams_node",
+         "resource_name": "{{HOST}}",
+         "timeseries": [
+            {
+               "timestamp": "{{TS1}}",
+               "value": 0
+            }
+         ],
+         "description": "Percentage value that displays the CPU usage of ams service in the specific node"
+      }
+   ]
+}`
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+	ml, _ := GetUsageCPU(store)
+	outJSON, _ := ml.ExportJSON()
+
+	ts1 := ml.Metrics[0].Timeseries[0].Timestamp
+	host := ml.Metrics[0].Resource
+
+	expJSON = strings.Replace(expJSON, "{{TS1}}", ts1, -1)
+
+	expJSON = strings.Replace(expJSON, "{{HOST}}", host, -1)
+
+	suite.Equal(expJSON, outJSON)
+
+}
+
 func (suite *MetricsTestSuite) TestGetTopics() {
 
 	APIcfg := config.NewAPICfg()
@@ -192,9 +230,9 @@ func (suite *MetricsTestSuite) TestAggrProjectUserSubTest() {
 	ml, _ := AggrProjectUserSubs("argo_uuid", store)
 
 	ts1 := ml.Metrics[0].Timeseries[0].Timestamp
-	ts2 := ml.Metrics[0].Timeseries[0].Timestamp
-	ts3 := ml.Metrics[0].Timeseries[0].Timestamp
-	ts4 := ml.Metrics[0].Timeseries[0].Timestamp
+	ts2 := ml.Metrics[1].Timeseries[0].Timestamp
+	ts3 := ml.Metrics[2].Timeseries[0].Timestamp
+	ts4 := ml.Metrics[3].Timeseries[0].Timestamp
 
 	expJSON = strings.Replace(expJSON, "{{TS1}}", ts1, -1)
 	expJSON = strings.Replace(expJSON, "{{TS2}}", ts2, -1)

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -27,6 +27,8 @@ const (
 	NameSubBytes          string = "subscription.number_of_bytes"
 	DescOpNodeCPU         string = "Percentage value that displays the CPU usage of ams service in the specific node"
 	NameOpNodeCPU         string = "ams_node.cpu_usage"
+	DescOpNodeMEM         string = "Percentage value that displays the Memory usage of ams service in the specific node"
+	NameOpNodeMEM         string = "ams_node.memory_usage"
 )
 
 type MetricList struct {
@@ -137,6 +139,13 @@ func NewProjectUserTopics(project string, user string, value int64, tstamp strin
 func NewOpNodeCPU(hostname string, value float64, tstamp string) Metric {
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
 	m := Metric{Metric: NameOpNodeCPU, MetricType: "percentage", ValueType: "float64", ResourceType: "ams_node", Resource: hostname, Timeseries: ts, Description: DescOpNodeCPU}
+
+	return m
+}
+
+func NewOpNodeMEM(hostname string, value float64, tstamp string) Metric {
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameOpNodeMEM, MetricType: "percentage", ValueType: "float64", ResourceType: "ams_node", Resource: hostname, Timeseries: ts, Description: DescOpNodeMEM}
 
 	return m
 }

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -87,7 +87,9 @@ func NewTopicSubs(topic string, value int64, tstamp string) Metric {
 func NewSubMsgs(topic string, value int64, tstamp string) Metric {
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+
 	m := Metric{Metric: NameSubMsgs, MetricType: "counter", ValueType: "int64", ResourceType: "subscription", Resource: topic, Timeseries: ts, Description: DescSubMsgs}
+
 	return m
 }
 
@@ -95,6 +97,7 @@ func NewSubBytes(topic string, value int64, tstamp string) Metric {
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
 	m := Metric{Metric: NameSubBytes, MetricType: "counter", ValueType: "int64", ResourceType: "subscription", Resource: topic, Timeseries: ts, Description: DescSubBytes}
+
 	return m
 }
 

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -25,6 +25,8 @@ const (
 	NameSubMsgs           string = "subscription.number_of_messages"
 	DescSubBytes          string = "Counter that displays the total size of data (in bytes) consumed from the specific subscription"
 	NameSubBytes          string = "subscription.number_of_bytes"
+	DescOpNodeCPU         string = "Percentage value that displays the CPU usage of ams service in the specific node"
+	NameOpNodeCPU         string = "ams_node.cpu_usage"
 )
 
 type MetricList struct {
@@ -127,6 +129,14 @@ func NewProjectUserTopics(project string, user string, value int64, tstamp strin
 	// Initialize single point timeseries with the latest timestamp and value
 	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
 	m := Metric{Metric: NameProjectUserTopics, MetricType: "counter", ValueType: "int64", ResourceType: "project.user", Resource: project + "." + user, Timeseries: ts, Description: DescProjectUserTopics}
+
+	return m
+}
+
+// Initialize single point timeseries with the latest timestamp and value
+func NewOpNodeCPU(hostname string, value float64, tstamp string) Metric {
+	ts := []Timepoint{Timepoint{Timestamp: tstamp, Value: value}}
+	m := Metric{Metric: NameOpNodeCPU, MetricType: "percentage", ValueType: "float64", ResourceType: "ams_node", Resource: hostname, Timeseries: ts, Description: DescOpNodeCPU}
 
 	return m
 }

--- a/metrics/operational.go
+++ b/metrics/operational.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/ARGOeu/argo-messaging/stores"
+	log "github.com/Sirupsen/logrus"
+)
+
+func GetUsageCPU(store stores.Store) (MetricList, error) {
+	pid := os.Getpid()
+	pidstr := strconv.FormatInt(int64(pid), 10)
+	out, err := exec.Command("ps", "-p", pidstr, "-o", "%cpu").Output()
+	if err != nil {
+		log.Error(err)
+	}
+
+	cpuVal, err := strconv.ParseFloat(string(out[:len(out)]), 64)
+	if err != nil {
+		log.Error(err)
+	}
+
+	host, err := os.Hostname()
+	if err != nil {
+		log.Error(err)
+	}
+
+	store.InsertOpMetric(host, cpuVal, 0.0)
+	result := store.GetOpMetrics()
+	ml := MetricList{Metrics: []Metric{}}
+	for _, v := range result {
+		m := NewOpNodeCPU(v.Hostname, v.CPU, GetTimeNowZulu())
+		ml.Metrics = append(ml.Metrics, m)
+	}
+
+	return ml, err
+}

--- a/metrics/operational.go
+++ b/metrics/operational.go
@@ -4,20 +4,38 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/ARGOeu/argo-messaging/stores"
 	log "github.com/Sirupsen/logrus"
 )
 
-func GetUsageCPU(store stores.Store) (MetricList, error) {
+func GetUsageCpuMem(store stores.Store) (MetricList, error) {
 	pid := os.Getpid()
 	pidstr := strconv.FormatInt(int64(pid), 10)
 	out, err := exec.Command("ps", "-p", pidstr, "-o", "%cpu").Output()
 	if err != nil {
 		log.Error(err)
+
 	}
 
-	cpuVal, err := strconv.ParseFloat(string(out[:len(out)]), 64)
+	// Take cli output and split it by new line chars
+	cpuOut := strings.Split(string(out[:len(out)]), "\n")
+	log.Info("CPU extracted value:", cpuOut[1])
+	cpuVal, err := strconv.ParseFloat(strings.TrimSpace(cpuOut[1]), 64)
+	if err != nil {
+		log.Error(err)
+	}
+
+	out2, err := exec.Command("ps", "-p", pidstr, "-o", "%mem").Output()
+	if err != nil {
+		log.Error(err)
+	}
+
+	// Take cli output and split it by new line chars
+	memOut := strings.Split(string(out2[:len(out2)]), "\n")
+	log.Info("MEM extracted value:", memOut[1])
+	memVal, err := strconv.ParseFloat(strings.TrimSpace(memOut[1]), 64)
 	if err != nil {
 		log.Error(err)
 	}
@@ -27,12 +45,14 @@ func GetUsageCPU(store stores.Store) (MetricList, error) {
 		log.Error(err)
 	}
 
-	store.InsertOpMetric(host, cpuVal, 0.0)
+	store.InsertOpMetric(host, cpuVal, memVal)
 	result := store.GetOpMetrics()
 	ml := MetricList{Metrics: []Metric{}}
 	for _, v := range result {
 		m := NewOpNodeCPU(v.Hostname, v.CPU, GetTimeNowZulu())
+		m2 := NewOpNodeMEM(v.Hostname, v.MEM, GetTimeNowZulu())
 		ml.Metrics = append(ml.Metrics, m)
+		ml.Metrics = append(ml.Metrics, m2)
 	}
 
 	return ml, err

--- a/routing.go
+++ b/routing.go
@@ -65,6 +65,7 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *p
 
 // Global list populated with default routes
 var defaultRoutes = []APIRoute{
+	{"ams:metrics", "GET", "/metrics", OpMetrics},
 	{"users:list", "GET", "/users", UserListAll},
 	{"users:show", "GET", "/users/{user}", UserListOne},
 	{"users:refreshToken", "POST", "/users/{user}:refreshToken", RefreshToken},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -17,6 +17,7 @@ type MockStore struct {
 	Session     bool
 	TopicsACL   map[string]QAcl
 	SubsACL     map[string]QAcl
+	OpMetrics   map[string]QopMetric
 }
 
 // QueryACL Topic/Subscription ACL
@@ -42,6 +43,12 @@ func NewMockStore(server string, database string) *MockStore {
 	mk.Session = true
 	mk.Initialize()
 	return &mk
+}
+
+func (mk *MockStore) InsertOpMetric(hostname string, cpu float64, mem float64) error {
+	qOp := QopMetric{hostname, cpu, mem}
+	mk.OpMetrics[hostname] = qOp
+	return nil
 }
 
 // Close is used to close session
@@ -72,6 +79,14 @@ func (mk *MockStore) UpdateUserToken(uuid string, token string) error {
 
 	return errors.New("not found")
 
+}
+
+func (mk *MockStore) GetOpMetrics() []QopMetric {
+	results := []QopMetric{}
+	for _, v := range mk.OpMetrics {
+		results = append(results, v)
+	}
+	return results
 }
 
 // UpdateUser updates user information
@@ -359,6 +374,7 @@ func (mk *MockStore) UpdateSubPull(projectUUID string, name string, offset int64
 
 // Initialize is used to initalize the mock
 func (mk *MockStore) Initialize() {
+	mk.OpMetrics = make(map[string]QopMetric)
 
 	// populate topics
 	qtop1 := QTopic{"argo_uuid", "topic1", 0, 0}

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -23,6 +23,13 @@ type QAcl struct {
 	ACL []string `bson:"acl"`
 }
 
+// QopMetric are the results of the QopMetric query
+type QopMetric struct {
+	Hostname string  `bson:"hostname"`
+	CPU      float64 `bson:"cpu"`
+	MEM      float64 `bson:"mem"`
+}
+
 // QProject are the results of the QProject query
 type QProject struct {
 	UUID        string    `bson:"uuid"`

--- a/stores/store.go
+++ b/stores/store.go
@@ -23,6 +23,7 @@ type Store interface {
 	RemoveProjectSubs(projectUUID string) error
 	InsertUser(uuid string, projects []QProjectRoles, name string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
+	InsertOpMetric(hostname string, cpu float64, mem float64) error
 	InsertTopic(projectUUID string, name string) error
 	IncrementTopicMsgNum(projectUUID string, name string, num int64) error
 	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
@@ -34,6 +35,7 @@ type Store interface {
 	QueryOneSub(projectUUID string, name string) (QSub, error)
 	QueryPushSubs() []QSub
 	HasResourceRoles(resource string, roles []string) bool
+	GetOpMetrics() []QopMetric
 	GetUserRoles(projectUUID string, token string) ([]string, string)
 	UpdateSubOffset(projectUUID string, name string, offset int64)
 	UpdateSubPull(projectUUID string, name string, offset int64, ts string) error


### PR DESCRIPTION
# Goal 
Add operational metric: memory usage for ams nodes

# Implementation 
- [x] Add get memory usage logic in metrics package
- [x] Refactor operational metric request to display also memory usage metrics
- [x] Add unit tests
- [x] Update docs