### PR TITLE
ARGO-925 Fix returnImmediately functionality in pull operation

### DIFF
--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -1,6 +1,7 @@
 package brokers
 
 import (
+	"context"
 	"errors"
 
 	"github.com/ARGOeu/argo-messaging/messages"
@@ -14,7 +15,7 @@ type Broker interface {
 	Publish(topic string, payload messages.Message) (string, string, int, int64, error)
 	GetMinOffset(topic string) int64
 	GetMaxOffset(topic string) int64
-	Consume(topic string, offset int64, imm bool, max int64) ([]string, error)
+	Consume(ctx context.Context, topic string, offset int64, imm bool, max int64) ([]string, error)
 }
 
 var ErrOffsetOff = errors.New("Offset is off")

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -1,6 +1,7 @@
 package brokers
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/ARGOeu/argo-messaging/messages"
@@ -100,6 +101,6 @@ func (b *MockBroker) GetMinOffset(topic string) int64 {
 }
 
 // Consume function to consume a message from the broker
-func (b *MockBroker) Consume(topic string, offset int64, imm bool, max int64) ([]string, error) {
+func (b *MockBroker) Consume(ctx context.Context, topic string, offset int64, imm bool, max int64) ([]string, error) {
 	return b.MsgList, nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -2135,7 +2135,7 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 	if pullInfo.RetImm == "true" {
 		retImm = true
 	}
-	msgs, err := refBrk.Consume(fullTopic, targSub.Offset, retImm, int64(max))
+	msgs, err := refBrk.Consume(r.Context(), fullTopic, targSub.Offset, retImm, int64(max))
 	if err != nil {
 		// If tracked offset is off
 		if err == brokers.ErrOffsetOff {
@@ -2144,7 +2144,7 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 			targSub.Offset = refBrk.GetMinOffset(fullTopic)
 			refStr.UpdateSubOffset(projectUUID, targSub.Name, targSub.Offset)
 			// Try again to consume
-			msgs, err = refBrk.Consume(fullTopic, targSub.Offset, retImm, int64(max))
+			msgs, err = refBrk.Consume(r.Context(), fullTopic, targSub.Offset, retImm, int64(max))
 			// If still error respond and return
 			if err != nil {
 				respondErr(w, 500, "Cannot consume message", "INTERNAL_SERVER_ERROR")

--- a/push/push.go
+++ b/push/push.go
@@ -1,6 +1,7 @@
 package push
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -107,13 +108,13 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	// Init Received Message List
 
 	fullTopic := p.sub.ProjectUUID + "." + p.sub.Topic
-	msgs, err := brk.Consume(fullTopic, p.sub.Offset, true, 1)
+	msgs, err := brk.Consume(nil, fullTopic, p.sub.Offset, true, 1)
 	if err != nil {
 		// If tracked offset is off, update it to the latest min offset
 		if err == brokers.ErrOffsetOff {
 			// Get Current Min Offset and advanced tracked one
 			p.sub.Offset = brk.GetMinOffset(fullTopic)
-			msgs, err = brk.Consume(fullTopic, p.sub.Offset, true, 1)
+			msgs, err = brk.Consume(context.Background(), fullTopic, p.sub.Offset, true, 1)
 			if err != nil {
 				log.Error("Unable to consume after updating offset")
 				return


### PR DESCRIPTION
## Issue
returnImmediately=true functionality during a pull operation doesn't seem to work when a previous non-returnImmediately pull operation has been requested on the specific topic.
This is due to the fact that the consume operation doesn't watch if the previous request has been canceled from the client and still waits for the timeout

## Fix
Provide request context object to the broker consume loop. Break if request has been canceled
