### PR TITLE
ARGO-1003 Fix publishedTime to be in UTC instead of localtime

### DIFF
--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -126,7 +126,8 @@ func (b *KafkaBroker) Publish(topic string, msg messages.Message) (string, strin
 	msg.ID = strconv.FormatInt(off, 10)
 	// Stamp time to UTC Z to nanoseconds
 	zNano := "2006-01-02T15:04:05.999999999Z"
-	t := time.Now()
+	// Timestamp on publish time -- should be in UTC
+	t := time.Now().UTC()
 	msg.PubTime = t.Format(zNano)
 
 	// Publish the message


### PR DESCRIPTION
# Issue
Meta-data field publishedTime contains timestamp in AMS cluster localtime. Use UTC instead

# Fix
Convert time to UTC before exporting timestamp