### PR TITLE
ARGO-1216 Retry if backends are unavailable

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	store.Initialize()
 
 	// create and initialize broker based on configuration
-	broker := brokers.NewKafkaBroker(cfg.GetZooList())
+	broker := brokers.NewKafkaBroker(cfg.GetBrokerInfo())
 	defer broker.CloseConnections()
 
 	sndr := push.NewHTTPSender(1)

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -41,16 +41,21 @@ func (mong *MongoStore) Clone() Store {
 // Initialize initializes the mongo store struct
 func (mong *MongoStore) Initialize() {
 
-	session, err := mgo.Dial(mong.Server)
-	if err != nil {
-
-		log.Fatal("STORE", "\t", err.Error())
-
+	// Iterate trying to connect
+	for {
+		log.Info("STORE", "\t", "Trying to connect to Mongo: ", mong.Server)
+		session, err := mgo.Dial(mong.Server)
+		if err != nil {
+			// If connection to datastore failed log error and retry
+			log.Error("STORE", "\t", err.Error())
+		} else {
+			// If connection succesfull continue
+			mong.Session = session
+			log.Info("STORE", "\t", "Connected to Mongo: ", mong.Server)
+			break // connected so continue
+		}
 	}
 
-	mong.Session = session
-
-	log.Info("STORE", "\t", "Connected to Mongo: ", mong.Server)
 }
 
 // QueryProjects queries the database for a specific project or a list of all projects


### PR DESCRIPTION
Refactor AMS start-up process to rely on retries while connecting to the back-end services (broker, datastore, zookeeper)
- Refactor store package to use retry to connect during init
- Refactor broker package to use retry to connect during init
- Refactor config package to use retry to connect (zookeeper) during init