### PR TITLE
ARGO-1359 Handle empty project_uuid references

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -117,7 +117,7 @@ func GetUserByToken(token string, store stores.Store) (User, error) {
 		pRoles = append(pRoles, ProjectRoles{Project: prName, Roles: pItem.Roles, Topics: topicNames, Subs: subNames})
 	}
 
-	curUser := NewUser(user.UUID, pRoles, user.Name, user.Token, user.Email, user.ServiceRoles, user.CreatedOn, user.ModifiedOn, usernameC)
+	curUser := NewUser(user.UUID, pRoles, user.Name, user.Token, user.Email, user.ServiceRoles, user.CreatedOn.UTC(), user.ModifiedOn.UTC(), usernameC)
 
 	result = curUser
 
@@ -162,7 +162,7 @@ func FindUsers(projectUUID string, uuid string, name string, store stores.Store)
 			pRoles = append(pRoles, ProjectRoles{Project: prName, Roles: pItem.Roles, Topics: topicNames, Subs: subNames})
 		}
 
-		curUser := NewUser(item.UUID, pRoles, item.Name, item.Token, item.Email, item.ServiceRoles, item.CreatedOn, item.ModifiedOn, usernameC)
+		curUser := NewUser(item.UUID, pRoles, item.Name, item.Token, item.Email, item.ServiceRoles, item.CreatedOn.UTC(), item.ModifiedOn.UTC(), usernameC)
 
 		result.List = append(result.List, curUser)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -261,7 +261,7 @@ func (cfg *APICfg) Load() {
 	cfg.CertKey = viper.GetString("certificate_key")
 	log.Info("CONFIG", "\t", "Parameter Loaded - certificate_key: ", cfg.CertKey)
 	cfg.ResAuth = viper.GetBool("per_resource_auth")
-	log.Info("CONFIG", "\t", "Parameter Loaded - per_resource_auth: ", cfg.CertKey)
+	log.Info("CONFIG", "\t", "Parameter Loaded - per_resource_auth: ", cfg.ResAuth)
 	cfg.ServiceToken = viper.GetString("service_token")
 	log.Info("CONFIG", "\t", "Parameter Loaded - service_token: ", cfg.ServiceToken)
 

--- a/handlers.go
+++ b/handlers.go
@@ -124,7 +124,18 @@ func WrapAuthenticate(hfn http.Handler) http.HandlerFunc {
 		refStr := context.Get(r, "str").(stores.Store)
 		serviceToken := context.Get(r, "auth_service_token").(string)
 
+		project_name := urlVars["project"]
 		projectUUID := projects.GetUUIDByName(urlVars["project"], refStr)
+
+		// In all cases instead of project create
+		if "projects:create" != mux.CurrentRoute(r).GetName() {
+			// Check if given a project name the project wasn't found
+			if project_name != "" && projectUUID == "" {
+				apiErr := APIErrorNotFound("project")
+				respondErr(w, apiErr)
+				return
+			}
+		}
 
 		// Check first if service token is used
 		if serviceToken != "" && serviceToken == urlValues.Get("key") {
@@ -327,6 +338,7 @@ func ProjectCreate(w http.ResponseWriter, r *http.Request) {
 	uuid := uuid.NewV4().String() // generate a new uuid to attach to the new project
 	created := time.Now().UTC()
 	// Get Result Object
+
 	res, err := projects.CreateProject(uuid, urlProject, created, refUserUUID, postBody.Description, refStr)
 
 	if err != nil {

--- a/projects/project.go
+++ b/projects/project.go
@@ -81,7 +81,7 @@ func Find(uuid string, name string, store stores.Store) (Projects, error) {
 				username = usr[0].Name
 			}
 		}
-		curProject := NewProject(item.UUID, item.Name, item.CreatedOn, item.ModifiedOn, username, item.Description)
+		curProject := NewProject(item.UUID, item.Name, item.CreatedOn.UTC(), item.ModifiedOn.UTC(), username, item.Description)
 		result.List = append(result.List, curProject)
 	}
 
@@ -155,7 +155,6 @@ func HasProject(name string, store stores.Store) bool {
 
 // CreateProject creates a new project
 func CreateProject(uuid string, name string, createdOn time.Time, createdBy string, description string, store stores.Store) (Project, error) {
-
 	// check if project with the same name exists
 	if ExistsWithName(name, store) {
 		return Project{}, errors.New("exists")
@@ -167,6 +166,7 @@ func CreateProject(uuid string, name string, createdOn time.Time, createdBy stri
 
 	// reflect stored object
 	stored, err := Find("", name, store)
+
 	return stored.One(), err
 }
 

--- a/routing.go
+++ b/routing.go
@@ -58,6 +58,7 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *p
 			PathPrefix("/v1").
 			Methods(route.Method).
 			Path(route.Path).
+			Name(route.Name).
 			Handler(context.ClearHandler(handler))
 	}
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -787,7 +787,7 @@ func (mong *MongoStore) QueryPushSubs() []QSub {
 	db := mong.Session.DB(mong.Database)
 	c := db.C("subscriptions")
 	var results []QSub
-	err := c.Find(bson.M{"push_endpoint": bson.M{"$ne": nil}}).All(&results)
+	err := c.Find(bson.M{"push_endpoint": bson.M{"$ne": ""}}).All(&results)
 	if err != nil {
 		log.Fatal("STORE", "\t", err.Error())
 	}


### PR DESCRIPTION
- In any request (except create new project) if url path has a {{project_name}} reference check immediately  for project existence and if false return. (In project create call {{project_name}} reference should indeed reference a non-existent project)

Additional fixes:
- Fix utc timestamps in get projects, get users (timestamps were inserted correctly in utc  but loaded in non-utc)
- Fix query push subs (non-push subs have `push_endpoint == " "` (instead of `null`) 
- Fix logging config.per_resource_auth param value (show correct value in logging during service initialization)