### PR TITLE
ARGO-1364 Set-cap option in spec file

### DIFF
--- a/argo-messaging.spec
+++ b/argo-messaging.spec
@@ -58,6 +58,7 @@ go clean
 %defattr(0644,argo-messaging,argo-messaging)
 %attr(0750,argo-messaging,argo-messaging) /var/www/argo-messaging
 %attr(0755,argo-messaging,argo-messaging) /var/www/argo-messaging/argo-messaging
+%caps(cap_net_bind_service=+ep) /var/www/argo-messaging/argo-messaging
 %attr(0644,argo-messaging,argo-messaging) /etc/argo-messaging/config.json
 %attr(0644,root,root) /etc/init/argo-messaging.conf
 %attr(0644,root,root) /usr/lib/systemd/system/argo-messaging.service
@@ -65,27 +66,27 @@ go clean
 %changelog
 * Tue Oct 27 2017 Kostas Koumantaros <kkoumantaros@gmail.com> 1.0.1-1%{?dist}
 * Kostas Kaggelidis <kaggis> Added Support for Metrics and CORS
-- ARGO-925 Fix return Immediately functionality in pull operation 
-- ARGO-909 Fix bug on project metrics topics,sub zero values 
-- ARGO-891 Implement ams request: get User info by Token. Expand user info 
-- Fix metrics typo. Fix package dependencies 
-- Add CORS support 
-- ARGO-859 Add operational metric: memory usage for ams nodes 
-- ARGO-860 Add CPU Usage metric for ams service nodes  
-- ARGO-863 Add metric: Aggregation of topics per user at project. 
-- ARGO-865 aggregation of subscriptions based on project_admin 
-- Change precedence of project:metrics route 
-- ARGO-866 Metric: number of subscriptions per topic 
-- ARGO-862 Add metric: number of topics per project/user 
-- ARGO-780 Implement Metric: data volume consumed by subscription 
-- ARGO-779 Implement metric: data volume published to a topic 
-- ARGO-778 Implement Sub Metric: number of messages consumed 
-- ARGO-777 Implement metric: number of messages per topic 
-- ARGO-669 Enable offset changes in subscriptions for event replay 
-- ARGO-813 Handle gracefully "not found" error during datastore updates 
-- ARGO-796 Increase consumer default fetch size to handle larger messages 
-- Updated messaging documentation 
-- Correct reference to sub/topic in api_subs.md 
+- ARGO-925 Fix return Immediately functionality in pull operation
+- ARGO-909 Fix bug on project metrics topics,sub zero values
+- ARGO-891 Implement ams request: get User info by Token. Expand user info
+- Fix metrics typo. Fix package dependencies
+- Add CORS support
+- ARGO-859 Add operational metric: memory usage for ams nodes
+- ARGO-860 Add CPU Usage metric for ams service nodes
+- ARGO-863 Add metric: Aggregation of topics per user at project.
+- ARGO-865 aggregation of subscriptions based on project_admin
+- Change precedence of project:metrics route
+- ARGO-866 Metric: number of subscriptions per topic
+- ARGO-862 Add metric: number of topics per project/user
+- ARGO-780 Implement Metric: data volume consumed by subscription
+- ARGO-779 Implement metric: data volume published to a topic
+- ARGO-778 Implement Sub Metric: number of messages consumed
+- ARGO-777 Implement metric: number of messages per topic
+- ARGO-669 Enable offset changes in subscriptions for event replay
+- ARGO-813 Handle gracefully "not found" error during datastore updates
+- ARGO-796 Increase consumer default fetch size to handle larger messages
+- Updated messaging documentation
+- Correct reference to sub/topic in api_subs.md
 - Updated example to api_subs documentation  
 - ARGO-650 Push endpoint should be https  
 - ARGO-646 Sub pull update fix   
@@ -96,7 +97,7 @@ go clean
 - ARGO-615 Add secondary logging of messages that exceed size threshold  
 - ARGO-595 Fix users listing null details if user doesn't exist  
 - ARGO-519 Implement configurable level-logging  
-- ARGO-580 Add command line config parameters and help 
+- ARGO-580 Add command line config parameters and help
 * Tue Oct 25 2016 Themis Zamani <themiszamani@gmail.com> - 1.0.0-1%{?dist}
 - New RPM package release.
 * Thu Mar 24 2016 Themis Zamani <themiszamani@gmail.com> - 0.9.2-1%{?dist}


### PR DESCRIPTION
Set cap cap_net_bind_service=+ep for argo-messaging binary directly in the spec file 