### PR TITLE
ARGO-421 Modify sub's ack deadline

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -807,6 +807,48 @@ paths:
           $ref: "#/responses/404"
         500:
           $ref: "#/responses/500"
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyAckDeadline:
+    post:
+      summary: Modify Ack Deadline of a given subscription
+      description: |
+        Modify Ack Deadline of a given subscription. Ack deadline is in seconds. Min value allowed: 0sec. Maximum value allowed: 600sec.
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the subscription
+          required: true
+          type: string
+        - name: AckDeadline
+          in: body
+          description: AckDeadline
+          required: true
+          schema:
+           $ref: '#/definitions/AckDeadline'
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: An empty response if Ack Deadline is succesfully updated
+          schema:
+            type: string
+            default: ""
+            description: empty string
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
 
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:offsets:
     get:
@@ -1443,6 +1485,13 @@ definitions:
         description: endpoint url for endpoint to push messages
       retryPolicy:
         $ref: '#/definitions/RetryPolicy'
+
+  AckDeadline:
+    type: object
+    properties:
+      ackDeadlineSeconds:
+       type: integer
+       description: deadline to acknowledge a pulled message (in seconds)
 
   Offset:
     type: object

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -131,6 +131,47 @@ Code: `200 OK`, Empty response if successful.
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+## [POST] Modify Ack Deadline
+This request modifies the acknowledgment deadline for the subscription. The ack deadline value is measured in seconds. The minimum ack deadline value allowed is 0sec and the maximum 600sec.
+
+### Request
+`POST /v1/projects/{project_name}/subscriptions/{subscription_name}:modifyAckDeadline`
+
+### Post body:
+```
+{
+  "ackDeadlineSeconds": 20
+}
+```
+
+### Where
+- Project_name: Name of the project
+- subscription_name: The subscription name to consume
+- ackDeadlineSeconds: integer representing seconds for the acknowledgment deadline (min=0sec, max=600sec).
+
+
+### Example request
+
+```json
+curl -X POST -H "Content-Type: application/json"  
+-d POSTDATA http://{URL}/v1/projects/BRAND_NEW/subscriptions/alert_engine:modifyAckDeadline?key=S3CR3T
+```
+
+### post body:
+```
+{
+  "ackDeadlineSeconds": 30
+}
+```
+
+### Responses  
+
+Success Response
+Code: `200 OK`, Empty response if successful. The deadline will change to 30seconds
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [POST] Modify Push Configuration
 This request modifies the push configuration of a subscription
 
@@ -156,7 +197,7 @@ This request modifies the push configuration of a subscription
 
 ```json
 curl -X POST -H "Content-Type: application/json"  
--d POSTDATA http://{URL}/v1/projects/BRAND_NEW/subscriptions/alert_engine:modifyPushConfig?key=S3CR3T"
+-d POSTDATA http://{URL}/v1/projects/BRAND_NEW/subscriptions/alert_engine:modifyPushConfig?key=S3CR3T
 ```
 
 ### post body:
@@ -427,6 +468,8 @@ Success Response
    ]
 }
 ```
+
+
 
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/routing.go
+++ b/routing.go
@@ -94,6 +94,7 @@ var defaultRoutes = []APIRoute{
 	{"subscriptions:delete", "DELETE", "/projects/{project}/subscriptions/{subscription}", SubDelete},
 	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
 	{"subscriptions:acknowledge", "POST", "/projects/{project}/subscriptions/{subscription}:acknowledge", SubAck},
+	{"subscriptions:modifyAckDeadline", "POST", "/projects/{project}/subscriptions/{subscription}:modifyAckDeadline", SubModAck},
 	{"subscriptions:modifyPushConfig", "POST", "/projects/{project}/subscriptions/{subscription}:modifyPushConfig", SubModPush},
 	{"subscriptions:modifyOffset", "POST", "/projects/{project}/subscriptions/{subscription}:modifyOffset", SubSetOffset},
 	{"subscriptions:modifyAcl", "POST", "/projects/{project}/subscriptions/{subscription}:modifyAcl", SubModACL},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -236,6 +236,19 @@ func (mk *MockStore) UpdateSubOffset(projectUUID string, name string, offset int
 }
 
 // ModSubPush modifies the subscription ack
+func (mk *MockStore) ModAck(projectUUID string, name string, ack int) error {
+	for i, item := range mk.SubList {
+		if item.ProjectUUID == projectUUID && item.Name == name {
+			mk.SubList[i].Ack = ack
+
+			return nil
+		}
+	}
+
+	return errors.New("not found")
+}
+
+// ModSubPush modifies the subscription push configuration
 func (mk *MockStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error {
 	for i, item := range mk.SubList {
 		if item.ProjectUUID == projectUUID {

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -716,6 +716,15 @@ func (mong *MongoStore) ModACL(projectUUID string, resource string, name string,
 	return err
 }
 
+// ModAck modifies the subscription's ack timeout field in mongodb
+func (mong *MongoStore) ModAck(projectUUID string, name string, ack int) error {
+	log.Info("Modifying Ack Deadline", ack)
+	db := mong.Session.DB(mong.Database)
+	c := db.C("subscriptions")
+	err := c.Update(bson.M{"project_uuid": projectUUID, "name": name}, bson.M{"$set": bson.M{"ack": ack}})
+	return err
+}
+
 // ModSubPush modifies the push configuration
 func (mong *MongoStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error {
 	db := mong.Session.DB(mong.Database)

--- a/stores/store.go
+++ b/stores/store.go
@@ -44,6 +44,7 @@ type Store interface {
 	ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error
 	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
 	ModACL(projectUUID string, resource string, name string, acl []string) error
+	ModAck(projectUUID string, name string, ack int) error
 	GetAllRoles() []string
 	Clone() Store
 	Close()

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -90,6 +90,11 @@ func (suite *StoreTestSuite) TestMockStore() {
 	sb, err := store.QueryOneSub("argo_uuid", "sub1")
 	suite.Equal(sb, eSubList[0])
 
+	// Test modify ack deadline in store
+	store.ModAck("argo_uuid", "sub1", 66)
+	subAck, _ := store.QueryOneSub("argo_uuid", "sub1")
+	suite.Equal(66, subAck.Ack)
+
 	// Query ACLS
 	ExpectedACL01 := QAcl{[]string{"uuid1", "uuid2"}}
 	QAcl01, _ := store.QueryACL("argo_uuid", "topics", "topic1")

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -1,6 +1,7 @@
 package subscriptions
 
 import (
+	"errors"
 	"io/ioutil"
 	"testing"
 
@@ -177,6 +178,26 @@ func (suite *SubTestSuite) TestCreateSubStore() {
 	suite.Equal(expSub, sub2)
 	suite.Equal(nil, err2)
 
+}
+
+func (suite *SubTestSuite) TestModAck() {
+
+	APIcfg := config.NewAPICfg()
+	APIcfg.LoadStrJSON(suite.cfgStr)
+
+	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
+
+	err := ModAck("argo_uuid", "sub1", 300, store)
+	suite.Equal(nil, err)
+
+	err = ModAck("argo_uuid", "sub1", 0, store)
+	suite.Equal(nil, err)
+
+	err = ModAck("argo_uuid", "sub1", -300, store)
+	suite.Equal(errors.New("wrong value"), err)
+
+	err = ModAck("argo_uuid", "sub1", 601, store)
+	suite.Equal(errors.New("wrong value"), err)
 }
 
 func (suite *SubTestSuite) TestExtractFullTopic() {


### PR DESCRIPTION
# Task 
Give the ability to modify the ack deadline in a subscription (time available to ack messages after pull)

# Implementation
- Implement handling of subscriptions:modifyAckDeadline POST request
- Update store package with ModAck method
- Update subscription package with ModAck method
- Implement SubModAck handler
- Update routing
- Update swagger
- Add unit tests
- Update mkdocs