### PR TITLE
ARGO-1606 Update push status field api call

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1018,6 +1018,44 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyPushStatus:
+    post:
+      summary: Modify the push status of th subscription
+      description: |
+        Push status is mainly used to contain information about the state of a subscription on the push server
+      parameters:
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the subscription
+          required: true
+          type: string
+        - name: Push Status
+          in: body
+          description: push status
+          required: true
+          schema:
+           $ref: '#/definitions/PushStatus'
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: Empty response if successful
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:metrics:
     get:
       summary: List of metrics related to the specific subscription
@@ -1505,6 +1543,13 @@ definitions:
         description: endpoint url for endpoint to push messages
       retryPolicy:
         $ref: '#/definitions/RetryPolicy'
+
+  PushStatus:
+    type: object
+    properties:
+      push_status:
+        type: string
+        description: push status
 
   AckDeadline:
     type: object

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -316,6 +316,47 @@ Code: `200 OK`, Empty response if successful.
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+## [POST] Modify Push Status
+This request modifies the push status of a subscription
+
+### Request
+`POST /v1/projects/{project_name}/subscriptions/{subscription_name}:modifyPushStatus`
+
+### Post body:
+```json
+{
+  "push_status": "push enabled"
+}
+```
+
+### Where
+- Project_name: Name of the project
+- subscription_name: The subscription name to consume
+- push_status: Contains information about the state of a subscription on the push server
+
+
+### Example request
+
+```json
+curl -X POST -H "Content-Type: application/json"  
+-d POSTDATA http://{URL}/v1/projects/BRAND_NEW/subscriptions/alert_engine:modifyPushStatus?key=S3CR3T
+```
+
+### Post body:
+```json
+{
+  "push_status": "push enabled"
+}
+```
+
+### Responses  
+
+Success Response
+Code: `200 OK`, Empty response if successful.
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [POST] Pull messages from a subscription (Consume)
 
 This request consumes messages from a subscription in a project with a POST request

--- a/routing.go
+++ b/routing.go
@@ -97,6 +97,7 @@ var defaultRoutes = []APIRoute{
 	{"subscriptions:acknowledge", "POST", "/projects/{project}/subscriptions/{subscription}:acknowledge", SubAck},
 	{"subscriptions:modifyAckDeadline", "POST", "/projects/{project}/subscriptions/{subscription}:modifyAckDeadline", SubModAck},
 	{"subscriptions:modifyPushConfig", "POST", "/projects/{project}/subscriptions/{subscription}:modifyPushConfig", SubModPush},
+	{"subscriptions:modifyPushStatus", "POST", "/projects/{project}/subscriptions/{subscription}:modifyPushStatus", SubModPushStatus},
 	{"subscriptions:modifyOffset", "POST", "/projects/{project}/subscriptions/{subscription}:modifyOffset", SubSetOffset},
 	{"subscriptions:modifyAcl", "POST", "/projects/{project}/subscriptions/{subscription}:modifyAcl", SubModACL},
 	{"topics:list", "GET", "/projects/{project}/topics", TopicListAll},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -314,6 +314,17 @@ func (mk *MockStore) ModSubPush(projectUUID string, name string, push string, rP
 	return errors.New("not found")
 }
 
+// ModSubPush modifies the subscription push configuration
+func (mk *MockStore) ModSubPushStatus(projectUUID string, name string, status string) error {
+	for i, item := range mk.SubList {
+		if item.ProjectUUID == projectUUID && item.Name == name {
+			mk.SubList[i].PushStatus = status
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
 // UpdateSubOffsetAck updates the offset of the current subscription
 func (mk *MockStore) UpdateSubOffsetAck(projectUUID string, name string, offset int64, ts string) error {
 	// find sub
@@ -651,7 +662,7 @@ func (mk *MockStore) InsertTopic(projectUUID string, name string) error {
 }
 
 // InsertSub inserts a new sub object to the store
-func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int, status string) error {
+func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
 	sub := QSub{
 		ID:           len(mk.SubList),
 		ProjectUUID:  projectUUID,
@@ -664,7 +675,6 @@ func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, of
 		RetPeriod:    rPeriod,
 		MsgNum:       0,
 		TotalBytes:   0,
-		PushStatus:   status,
 	}
 	mk.SubList = append(mk.SubList, sub)
 	return nil

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -816,11 +816,21 @@ func (mong *MongoStore) InsertProject(uuid string, name string, createdOn time.T
 }
 
 // InsertSub inserts a subscription to the store
-func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int, status string) error {
+func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
 	sub := QSub{
-		ProjectUUID: projectUUID, Name: name, Topic: topic, Offset: offset, NextOffset: 0,
-		PendingAck: "", Ack: ack, PushEndpoint: push, RetPolicy: rPolicy, RetPeriod: rPeriod,
-		PushStatus: status, MsgNum: 0, TotalBytes: 0}
+		ProjectUUID:  projectUUID,
+		Name:         name,
+		Topic:        topic,
+		Offset:       offset,
+		NextOffset:   0,
+		PendingAck:   "",
+		Ack:          ack,
+		PushEndpoint: push,
+		RetPolicy:    rPolicy,
+		RetPeriod:    rPeriod,
+		MsgNum:       0,
+		TotalBytes:   0,
+	}
 	return mong.InsertResource("subscriptions", sub)
 }
 
@@ -927,6 +937,22 @@ func (mong *MongoStore) ModSubPush(projectUUID string, name string, push string,
 			"retry_policy":  rPolicy,
 			"retry_period":  rPeriod,
 			"push_status":   status,
+		},
+		})
+	return err
+}
+
+// ModSubPushStatus modifies the push status
+func (mong *MongoStore) ModSubPushStatus(projectUUID string, name string, status string) error {
+	db := mong.Session.DB(mong.Database)
+	c := db.C("subscriptions")
+
+	err := c.Update(bson.M{
+		"project_uuid": projectUUID,
+		"name":         name,
+	},
+		bson.M{"$set": bson.M{
+			"push_status": status,
 		},
 		})
 	return err

--- a/stores/store.go
+++ b/stores/store.go
@@ -33,7 +33,7 @@ type Store interface {
 	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubMsgNum(projectUUID string, name string, num int64) error
-	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int, status string) error
+	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
 	HasProject(name string) bool
 	HasUsers(projectUUID string, users []string) (bool, []string)
 	QueryOneSub(projectUUID string, name string) (QSub, error)
@@ -46,6 +46,7 @@ type Store interface {
 	UpdateSubPull(projectUUID string, name string, offset int64, ts string) error
 	UpdateSubOffsetAck(projectUUID string, name string, offset int64, ts string) error
 	ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int, status string) error
+	ModSubPushStatus(projectUUID string, name string, status string) error
 	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
 	ModACL(projectUUID string, resource string, name string, acl []string) error
 	ModAck(projectUUID string, name string, ack int) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -125,7 +125,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
 	store.InsertTopic("argo_uuid", "topicFresh")
-	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, "", "", 0, "")
+	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, "", "", 0)
 
 	eTopList2 := []QTopic{
 		{3, "argo_uuid", "topicFresh", 0, 0},
@@ -182,6 +182,15 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	e2 := store.ModSubPush("argo_uuid", "unknown", "", "", 0, "")
 	suite.Equal("not found", e2.Error())
+
+	// Test mod push sub
+	statusE1 := store.ModSubPushStatus("argo_uuid", "sub1", "status update")
+	statusSub1, _ := store.QueryOneSub("argo_uuid", "sub1")
+	suite.Nil(statusE1)
+	suite.Equal("status update", statusSub1.PushStatus)
+
+	statusE2 := store.ModSubPushStatus("argo_uuid", "unknown", "")
+	suite.Equal("not found", statusE2.Error())
 
 	// Query ACLS
 	ExpectedACL01 := QAcl{[]string{"uuid1", "uuid2"}}

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -80,6 +80,11 @@ type AckDeadline struct {
 	AckDeadline int `json:"ackDeadlineSeconds"`
 }
 
+// PushStatus utility struct
+type PushStatus struct {
+	PushStatus string `json:"push_status"`
+}
+
 // FindMetric returns the metric of a specific subscription
 func FindMetric(projectUUID string, name string, store stores.Store) (SubMetrics, error) {
 	result := SubMetrics{MsgNum: 0}
@@ -133,6 +138,12 @@ func GetAckDeadlineFromJSON(input []byte) (AckDeadline, error) {
 	s := AckDeadline{}
 	err := json.Unmarshal([]byte(input), &s)
 	return s, err
+}
+
+func GetPushStatusFromJSON(input []byte) (PushStatus, error) {
+	p := PushStatus{}
+	err := json.Unmarshal(input, &p)
+	return p, err
 }
 
 // GetFromJSON retrieves Sub Info From Json
@@ -240,7 +251,7 @@ func LoadPushSubs(store stores.Store) PaginatedSubscriptions {
 }
 
 // CreateSub creates a new subscription
-func CreateSub(projectUUID string, name string, topic string, push string, offset int64, ack int, retPolicy string, retPeriod int, status string, store stores.Store) (Subscription, error) {
+func CreateSub(projectUUID string, name string, topic string, push string, offset int64, ack int, retPolicy string, retPeriod int, store stores.Store) (Subscription, error) {
 
 	if HasSub(projectUUID, name, store) {
 		return Subscription{}, errors.New("exists")
@@ -249,7 +260,7 @@ func CreateSub(projectUUID string, name string, topic string, push string, offse
 	if ack == 0 {
 		ack = 10
 	}
-	err := store.InsertSub(projectUUID, name, topic, offset, ack, push, retPolicy, retPeriod, status)
+	err := store.InsertSub(projectUUID, name, topic, offset, ack, push, retPolicy, retPeriod)
 	if err != nil {
 		return Subscription{}, errors.New("backend error")
 	}
@@ -284,6 +295,16 @@ func ModSubPush(projectUUID string, name string, push string, retPolicy string, 
 	}
 
 	return store.ModSubPush(projectUUID, name, push, retPolicy, retPeriod, status)
+}
+
+// ModSubPush updates the subscription push config
+func ModSubPushStatus(projectUUID string, name string, status string, store stores.Store) error {
+
+	if HasSub(projectUUID, name, store) == false {
+		return errors.New("not found")
+	}
+
+	return store.ModSubPushStatus(projectUUID, name, status)
 }
 
 // RemoveSub removes an existing subscription

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -201,11 +201,11 @@ func (suite *SubTestSuite) TestCreateSubStore() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	sub, err := CreateSub("argo_uuid", "sub1", "topic1", "", 0, 0, "linear", 300, "", store)
+	sub, err := CreateSub("argo_uuid", "sub1", "topic1", "", 0, 0, "linear", 300, store)
 	suite.Equal(Subscription{}, sub)
 	suite.Equal("exists", err.Error())
 
-	sub2, err2 := CreateSub("argo_uuid", "subNew", "topicNew", "", 0, 0, "linear", 300, "", store)
+	sub2, err2 := CreateSub("argo_uuid", "subNew", "topicNew", "", 0, 0, "linear", 300, store)
 	expSub := New("argo_uuid", "ARGO", "subNew", "topicNew")
 	suite.Equal(expSub, sub2)
 	suite.Equal(nil, err2)
@@ -376,6 +376,15 @@ func (suite *SubTestSuite) TestGetOffsetFromAckID() {
 		suite.Equal(expOffsets[i], off)
 	}
 
+}
+
+func (suite *SubTestSuite) TestModSubPushStatus() {
+
+	store := stores.NewMockStore("", "")
+	err := ModSubPushStatus("argo_uuid", "sub4", "new push status", store)
+	sub, _ := store.QueryOneSub("argo_uuid", "sub4")
+	suite.Nil(err)
+	suite.Equal("new push status", sub.PushStatus)
 }
 
 func TestSubTestSuite(t *testing.T) {


### PR DESCRIPTION
add a new api call to modify the push status field of a subscription. The call is mostly to be used by the ams push server in order to update the status of a subscription in ams when various errors occur. Also updated swagger and mkdocs

**/projects/p1/subscriptions/s1:modifyPushStatus**

- Added a new handler for the respective route
- Added a new store function for updating the status field
- Since the push status field now has its own functions to take care of it, refactor any previous functions that needed extra arguments in order to take care of the push status field aswell