### PR TITLE
ARGO-1651 Internal function - remove user(s) from topic/sub ACL

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -57,6 +57,19 @@ func AppendToACL(projectUUID string, resourceType string, resourceName string, a
 	return store.AppendToACL(projectUUID, resourceType, resourceName, userUUIDs)
 }
 
+// AppendToACL is used to remove users from a topic's or sub's acl
+func RemoveFromACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
+
+	// Transform user name to user uuid
+	userUUIDs := []string{}
+	for _, username := range acl {
+		userUUID := GetUUIDByName(username, store)
+		userUUIDs = append(userUUIDs, userUUID)
+	}
+
+	return store.RemoveFromACL(projectUUID, resourceType, resourceName, userUUIDs)
+}
+
 // GetACL returns an authorized list of user for the resource (topic or subscription)
 func GetACL(projectUUID string, resourceType string, resourceName string, store stores.Store) (ACL, error) {
 	result := ACL{}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -695,6 +695,26 @@ func (suite *AuthTestSuite) TestAppendToACL() {
 	suite.Equal("wrong resource type", e3.Error())
 }
 
+func (suite *AuthTestSuite) TestRemoveFromACL() {
+
+	store := stores.NewMockStore("", "")
+
+	e1 := RemoveFromACL("argo_uuid", "topics", "topic1", []string{"UserA", "UserK"}, store)
+	suite.Nil(e1)
+
+	tACL1, _ := store.TopicsACL["topic1"]
+	suite.Equal([]string{"uuid2"}, tACL1.ACL)
+
+	e2 := RemoveFromACL("argo_uuid", "subscriptions", "sub1", []string{"UserA", "UserK"}, store)
+	suite.Nil(e2)
+
+	sACL1, _ := store.SubsACL["sub1"]
+	suite.Equal([]string{"uuid2"}, sACL1.ACL)
+
+	e3 := RemoveFromACL("argo_uuid", "mistype", "sub1", []string{"UserX", "UserZ"}, store)
+	suite.Equal("wrong resource type", e3.Error())
+}
+
 func TestAuthTestSuite(t *testing.T) {
 	suite.Run(t, new(AuthTestSuite))
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -196,6 +196,44 @@ func appendUniqueValues(existingValues []string, newValues ...string) []string {
 	return existingValues
 }
 
+func (mk *MockStore) RemoveFromACL(projectUUID string, resource string, name string, acl []string) error {
+	if resource == "topics" {
+		if qACL, exists := mk.TopicsACL[name]; exists {
+			qACL.ACL = removeValues(qACL.ACL, acl...)
+			mk.TopicsACL[name] = qACL
+			return nil
+		}
+	} else if resource == "subscriptions" {
+		if qACL, exists := mk.SubsACL[name]; exists {
+			qACL.ACL = removeValues(qACL.ACL, acl...)
+			mk.SubsACL[name] = qACL
+			return nil
+		}
+	}
+
+	return errors.New("wrong resource type")
+}
+
+func removeValues(existingValues []string, valuesToRemove ...string) []string {
+
+	for _, value := range valuesToRemove {
+		existingValues = removeSingleValue(existingValues, value)
+	}
+
+	return existingValues
+}
+
+func removeSingleValue(existingValues []string, valueToRemove string) []string {
+
+	for idx, value := range existingValues {
+		if value == valueToRemove {
+			existingValues = append(existingValues[:idx], existingValues[idx+1:]...)
+		}
+	}
+
+	return existingValues
+}
+
 // UpdateProject updates project information
 func (mk *MockStore) UpdateProject(projectUUID string, name string, description string, modifiedOn time.Time) error {
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -938,6 +938,30 @@ func (mong *MongoStore) AppendToACL(projectUUID string, resource string, name st
 	return err
 }
 
+func (mong *MongoStore) RemoveFromACL(projectUUID string, resource string, name string, acl []string) error {
+
+	db := mong.Session.DB(mong.Database)
+
+	if resource != "topics" && resource != "subscriptions" {
+		return errors.New("wrong resource type")
+	}
+
+	c := db.C(resource)
+
+	err := c.Update(
+		bson.M{
+			"project_uuid": projectUUID,
+			"name":         name,
+		},
+		bson.M{
+			"$pullAll": bson.M{
+				"acl": acl,
+			},
+		})
+
+	return err
+}
+
 // ModAck modifies the subscription's ack timeout field in mongodb
 func (mong *MongoStore) ModAck(projectUUID string, name string, ack int) error {
 	log.Info("Modifying Ack Deadline", ack)

--- a/stores/store.go
+++ b/stores/store.go
@@ -50,6 +50,7 @@ type Store interface {
 	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
 	ModACL(projectUUID string, resource string, name string, acl []string) error
 	AppendToACL(projectUUID string, resource string, name string, acl []string) error
+	RemoveFromACL(projectUUID string, resource string, name string, acl []string) error
 	ModAck(projectUUID string, name string, ack int) error
 	GetAllRoles() []string
 	Clone() Store

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -252,6 +252,20 @@ func (suite *StoreTestSuite) TestMockStore() {
 	eAppAcl3 := store.AppendToACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
 	suite.Equal("wrong resource type", eAppAcl3.Error())
 
+	// test remove acl
+	eRemAcl1 := store.RemoveFromACL("argo_uuid", "topics", "topic1", []string{"u1", "u4", "u5"})
+	suite.Nil(eRemAcl1)
+	tACLRem := store.TopicsACL["topic1"].ACL
+	suite.Equal([]string{"u2", "u3"}, tACLRem)
+
+	eRemAcl2 := store.RemoveFromACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u4", "u5"})
+	suite.Nil(eRemAcl2)
+	sACLRem := store.SubsACL["sub1"].ACL
+	suite.Equal([]string{"u2", "u3"}, sACLRem)
+
+	eRemAcl3 := store.RemoveFromACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
+	suite.Equal("wrong resource type", eRemAcl3.Error())
+
 	//Check has users
 	allFound, notFound := store.HasUsers("argo_uuid", []string{"UserA", "UserB", "FooUser"})
 	suite.Equal(false, allFound)


### PR DESCRIPTION
Add to the store interface a new remove from acl method.
The mongo store implements this method by using the **$pullAll** operator.