### PR TITLE
ARGO-1650 Internal function - append user(s) to topic/sub ACL

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -44,6 +44,19 @@ func ModACL(projectUUID string, resourceType string, resourceName string, acl []
 	return store.ModACL(projectUUID, resourceType, resourceName, userUUIDs)
 }
 
+// AppendToACL is used to append unique users to a topic's or sub's ACL
+func AppendToACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
+
+	// Transform user name to user uuid
+	userUUIDs := []string{}
+	for _, username := range acl {
+		userUUID := GetUUIDByName(username, store)
+		userUUIDs = append(userUUIDs, userUUID)
+	}
+
+	return store.AppendToACL(projectUUID, resourceType, resourceName, userUUIDs)
+}
+
 // GetACL returns an authorized list of user for the resource (topic or subscription)
 func GetACL(projectUUID string, resourceType string, resourceName string, store stores.Store) (ACL, error) {
 	result := ACL{}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -655,6 +655,46 @@ func (suite *AuthTestSuite) TestTopicACL() {
 	suite.Equal(expJSON01deleted, outJSONd)
 }
 
+func (suite *AuthTestSuite) TestModACL() {
+
+	store := stores.NewMockStore("", "")
+
+	e1 := ModACL("argo_uuid", "topics", "topic1", []string{"UserX", "UserZ"}, store)
+	suite.Nil(e1)
+
+	tACL1, _ := store.TopicsACL["topic1"]
+	suite.Equal([]string{"uuid3", "uuid4"}, tACL1.ACL)
+
+	e2 := ModACL("argo_uuid", "subscriptions", "sub1", []string{"UserX", "UserZ"}, store)
+	suite.Nil(e2)
+
+	sACL1, _ := store.SubsACL["sub1"]
+	suite.Equal([]string{"uuid3", "uuid4"}, sACL1.ACL)
+
+	e3 := ModACL("argo_uuid", "mistype", "sub1", []string{"UserX", "UserZ"}, store)
+	suite.Equal("wrong resource type", e3.Error())
+}
+
+func (suite *AuthTestSuite) TestAppendToACL() {
+
+	store := stores.NewMockStore("", "")
+
+	e1 := AppendToACL("argo_uuid", "topics", "topic1", []string{"UserX", "UserZ", "UserZ"}, store)
+	suite.Nil(e1)
+
+	tACL1, _ := store.TopicsACL["topic1"]
+	suite.Equal([]string{"uuid1", "uuid2", "uuid3", "uuid4"}, tACL1.ACL)
+
+	e2 := AppendToACL("argo_uuid", "subscriptions", "sub1", []string{"UserX", "UserZ", "UserZ"}, store)
+	suite.Nil(e2)
+
+	sACL1, _ := store.SubsACL["sub1"]
+	suite.Equal([]string{"uuid1", "uuid2", "uuid3", "uuid4"}, sACL1.ACL)
+
+	e3 := AppendToACL("argo_uuid", "mistype", "sub1", []string{"UserX", "UserZ"}, store)
+	suite.Equal("wrong resource type", e3.Error())
+}
+
 func TestAuthTestSuite(t *testing.T) {
 	suite.Run(t, new(AuthTestSuite))
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -159,7 +159,41 @@ func (mk *MockStore) ModACL(projectUUID string, resource string, name string, ac
 		}
 	}
 
-	return errors.New("not found")
+	return errors.New("wrong resource type")
+}
+
+func (mk *MockStore) AppendToACL(projectUUID string, resource string, name string, acl []string) error {
+	if resource == "topics" {
+		if qACL, exists := mk.TopicsACL[name]; exists {
+			qACL.ACL = appendUniqueValues(qACL.ACL, acl...)
+			mk.TopicsACL[name] = qACL
+			return nil
+		}
+	} else if resource == "subscriptions" {
+		if qACL, exists := mk.SubsACL[name]; exists {
+			qACL.ACL = appendUniqueValues(qACL.ACL, acl...)
+			mk.SubsACL[name] = qACL
+			return nil
+		}
+	}
+
+	return errors.New("wrong resource type")
+}
+
+func appendUniqueValues(existingValues []string, newValues ...string) []string {
+	for _, value := range newValues {
+		found := false
+		for _, ev := range existingValues {
+			if ev == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			existingValues = append(existingValues, value)
+		}
+	}
+	return existingValues
 }
 
 // UpdateProject updates project information

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -914,6 +914,30 @@ func (mong *MongoStore) ModACL(projectUUID string, resource string, name string,
 	return err
 }
 
+func (mong *MongoStore) AppendToACL(projectUUID string, resource string, name string, acl []string) error {
+
+	db := mong.Session.DB(mong.Database)
+
+	if resource != "topics" && resource != "subscriptions" {
+		return errors.New("wrong resource type")
+	}
+
+	c := db.C(resource)
+
+	err := c.Update(
+		bson.M{
+			"project_uuid": projectUUID,
+			"name":         name,
+		},
+		bson.M{
+			"$addToSet": bson.M{
+				"acl": bson.M{
+					"$each": acl,
+				},
+			}})
+	return err
+}
+
 // ModAck modifies the subscription's ack timeout field in mongodb
 func (mong *MongoStore) ModAck(projectUUID string, name string, ack int) error {
 	log.Info("Modifying Ack Deadline", ack)

--- a/stores/store.go
+++ b/stores/store.go
@@ -49,6 +49,7 @@ type Store interface {
 	ModSubPushStatus(projectUUID string, name string, status string) error
 	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
 	ModACL(projectUUID string, resource string, name string, acl []string) error
+	AppendToACL(projectUUID string, resource string, name string, acl []string) error
 	ModAck(projectUUID string, name string, ack int) error
 	GetAllRoles() []string
 	Clone() Store

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -224,6 +224,34 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(QAcl{}, QAcl08)
 	suite.Equal(errors.New("not found"), err08)
 
+	// test mod acl
+	eModAcl1 := store.ModACL("argo_uuid", "topics", "topic1", []string{"u1", "u2"})
+	suite.Nil(eModAcl1)
+	tACL := store.TopicsACL["topic1"].ACL
+	suite.Equal([]string{"u1", "u2"}, tACL)
+
+	eModAcl2 := store.ModACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u2"})
+	suite.Nil(eModAcl2)
+	sACL := store.SubsACL["sub1"].ACL
+	suite.Equal([]string{"u1", "u2"}, sACL)
+
+	eModAcl3 := store.ModACL("argo_uuid", "mistype", "sub1", []string{"u1", "u2"})
+	suite.Equal("wrong resource type", eModAcl3.Error())
+
+	// test append acl
+	eAppAcl1 := store.AppendToACL("argo_uuid", "topics", "topic1", []string{"u3", "u4", "u4"})
+	suite.Nil(eAppAcl1)
+	tACLapp := store.TopicsACL["topic1"].ACL
+	suite.Equal([]string{"u1", "u2", "u3", "u4"}, tACLapp)
+
+	eAppAcl2 := store.AppendToACL("argo_uuid", "subscriptions", "sub1", []string{"u3", "u4", "u4"})
+	suite.Nil(eAppAcl2)
+	sACLapp := store.SubsACL["sub1"].ACL
+	suite.Equal([]string{"u1", "u2", "u3", "u4"}, sACLapp)
+
+	eAppAcl3 := store.AppendToACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
+	suite.Equal("wrong resource type", eAppAcl3.Error())
+
 	//Check has users
 	allFound, notFound := store.HasUsers("argo_uuid", []string{"UserA", "UserB", "FooUser"})
 	suite.Equal(false, allFound)


### PR DESCRIPTION
Add to the store interface a new append to acl method.
The mongo store implements this method by using the **$addToSet** and **$each** operators.