### PR TITLE
ARGO-1639 API Call - List topic's subscriptions

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -577,6 +577,42 @@ paths:
           $ref: "#/responses/500"
 
 
+  /projects/{PROJECT}/topics/{TOPIC}/subscriptions:
+    get:
+      summary: List subscriptions in a topic
+      description: |
+        Returns all the subscriptions associated with a specific topic
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: TOPIC
+          in: path
+          description: Name of the topic
+          required: true
+          type: string
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: An array of subscription names
+          schema:
+            $ref: '#/definitions/SubNamesList'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:
     get:
       summary: Show infromation about a specific subscription
@@ -1767,6 +1803,14 @@ definitions:
         type: string
       status:
         type: string
+
+  SubNamesList:
+    type: object
+    properties:
+      subscriptions:
+        type: array
+        items:
+          type: string
 
   ErrorMsg:
     type: object

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -39,6 +39,38 @@ Success Response
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+## [GET] Manage Subscriptions - List All Subscriptions under a specific Topic
+
+This request lists all available subscriptions under a specific topic in the service.
+
+### Request
+`GET /v1/projects/{project_name}/topics/{topic_name}/subscriptions`
+
+### Where
+- Project_name: Name of the project the topic belongs to
+- Topic_name: Name of the topic
+
+### Example request
+```
+curl -X GET -H "Content-Type: application/json"
+  "https://{URL}/v1/projects/p1/topics/t1/subscriptions?key=S3CR3T"
+```
+
+Success Response
+`200 OK`
+
+```json
+{
+ "subscriptions": [
+ "/projects/p1/subscriptions/sub1",
+ "/projects/p1/subscriptions/sub2"
+ ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [GET] Manage Subscriptions - List All Subscriptions
 
 This request lists all available subscriptions under a specific project in the service using pagination
@@ -50,7 +82,7 @@ Success Response
 
 ```json
 {
- "users": [],
+ "subscriptions": [],
   "nextPageToken": "",
   "totalSize": 0
  }
@@ -70,7 +102,7 @@ This request lists all subscriptions  in a project with a GET  request
 
 ### Example request
 ```
-curl -X PUT -H "Content-Type: application/json"
+curl -X GET -H "Content-Type: application/json"
   "https://{URL}/v1/projects/BRAND_NEW/subscriptions?key=S3CR3T"
 ```
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -2005,6 +2005,51 @@ func (suite *HandlerTestSuite) TestTopicListOne() {
 	suite.Equal(expResp, w.Body.String())
 }
 
+func (suite *HandlerTestSuite) TestTopicListSubscriptions() {
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/projects/ARGO/topics/topic1/subscriptions", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{"subscriptions":["/projects/ARGO/subscriptions/sub1"]}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := oldPush.Manager{}
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}/subscriptions", WrapMockAuthConfig(ListSubsByTopic, cfgKafka, &brk, str, &mgr, nil))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
+func (suite *HandlerTestSuite) TestTopicListSubscriptionsEmpty() {
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/projects/ARGO/topics/topic1/subscriptions", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{"subscriptions":[]}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	str.SubList = nil
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := oldPush.Manager{}
+	router.HandleFunc("/v1/projects/{project}/topics/{topic}/subscriptions", WrapMockAuthConfig(ListSubsByTopic, cfgKafka, &brk, str, &mgr, nil))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
 func (suite *HandlerTestSuite) TestSubMetrics() {
 
 	req, err := http.NewRequest("GET", "http://localhost:8080/v1/projects/ARGO/subscriptions/sub1:metrics", nil)

--- a/routing.go
+++ b/routing.go
@@ -87,6 +87,7 @@ var defaultRoutes = []APIRoute{
 	{"projects:update", "PUT", "/projects/{project}", ProjectUpdate},
 	{"projects:delete", "DELETE", "/projects/{project}", ProjectDelete},
 	{"subscriptions:list", "GET", "/projects/{project}/subscriptions", SubListAll},
+	{"subscriptions:listByTopic", "GET", "/projects/{project}/topics/{topic}/subscriptions", ListSubsByTopic},
 	{"subscriptions:offsets", "GET", "/projects/{project}/subscriptions/{subscription}:offsets", SubGetOffsets},
 	{"subscriptions:acl", "GET", "/projects/{project}/subscriptions/{subscription}:acl", SubACL},
 	{"subscriptions:metrics", "GET", "/projects/{project}/subscriptions/{subscription}:metrics", SubMetrics},

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -90,6 +90,28 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Nil(err2)
 	suite.Nil(err3)
 
+	// test retrieve subs by topic
+	subListByTopic, errSublistByTopic := store.QuerySubsByTopic("argo_uuid", "topic1")
+	suite.Equal([]QSub{
+		{
+			ID:           0,
+			ProjectUUID:  "argo_uuid",
+			Name:         "sub1",
+			Topic:        "topic1",
+			Offset:       0,
+			NextOffset:   0,
+			PendingAck:   "",
+			PushEndpoint: "",
+			Ack:          10,
+			RetPolicy:    "",
+			RetPeriod:    0,
+			MsgNum:       0,
+			TotalBytes:   0,
+			PushStatus:   "",
+		},
+	}, subListByTopic)
+	suite.Nil(errSublistByTopic)
+
 	// Test Project
 	suite.Equal(true, store.HasProject("ARGO"))
 	suite.Equal(false, store.HasProject("FOO"))

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -31,6 +31,27 @@ func (suite *SubTestSuite) SetupTest() {
 	log.SetOutput(ioutil.Discard)
 }
 
+func (suite *SubTestSuite) TestNewNamesLIst() {
+	nl := NewNamesList()
+	// make sure that the subscriptions slice has been initialised
+	suite.NotNil(nl.Subscriptions)
+}
+
+func (suite *SubTestSuite) TestFindByTopic() {
+
+	store := stores.NewMockStore("", "")
+
+	nl1, err1 := FindByTopic("argo_uuid", "topic1", store)
+	suite.Equal([]string{"/projects/ARGO/subscriptions/sub1"}, nl1.Subscriptions)
+	suite.Nil(err1)
+
+	// check empty case
+	store.SubList = nil
+	nl2, err2 := FindByTopic("argo_uuid", "topic1", store)
+	suite.Equal([]string{}, nl2.Subscriptions)
+	suite.Nil(err2)
+}
+
 func (suite *SubTestSuite) TestCreate() {
 	mySub := New("argo_uuid", "ARGO", "test-sub", "topic1")
 	suite.Equal("test-sub", mySub.Name)


### PR DESCRIPTION
Introduce a new api call that lists all subscription's linked to the respective topic. Update swagger and mkdocs aswell.

**/projects/p1/topics/t1/subscriptions**
- Add a new handler for the respective api call.
- Add a new struct to hold the sub's names as a list
- Create a wrapper function around the already existing store method, **QuerySubsByTopic**