### PR TITLE
 ARGO-1661 Ams handling of push worker initialisation

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -469,6 +469,7 @@ func (suite *AuthTestSuite) TestAuth() {
 	modified := "2009-11-10T23:00:00Z"
 
 	var qUsers1 []User
+	qUsers1 = append(qUsers1, User{"uuid7", []ProjectRoles{}, "push_worker_0", "push_token", "foo-email", []string{"push_worker"}, created, modified, ""})
 	qUsers1 = append(qUsers1, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame2", "S3CR3T42", "foo-email", []string{}, created, modified, "UserA"})
 	qUsers1 = append(qUsers1, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame1", "S3CR3T41", "foo-email", []string{}, created, modified, "UserA"})
 	qUsers1 = append(qUsers1, User{"uuid4", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{"topic2"}, []string{"sub3", "sub4"}}}, "UserZ", "S3CR3T4", "foo-email", []string{}, created, modified, "UserA"})
@@ -480,8 +481,9 @@ func (suite *AuthTestSuite) TestAuth() {
 	pu1, e1 := PaginatedFindUsers("", 0, store2)
 
 	var qUsers2 []User
+	qUsers2 = append(qUsers2, User{"uuid7", []ProjectRoles{}, "push_worker_0", "push_token", "foo-email", []string{"push_worker"}, created, modified, ""})
 	qUsers2 = append(qUsers2, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame2", "S3CR3T42", "foo-email", []string{}, created, modified, "UserA"})
-	qUsers2 = append(qUsers2, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame1", "S3CR3T41", "foo-email", []string{}, created, modified, "UserA"})
+
 	// return the first page with 2 users
 	pu2, e2 := PaginatedFindUsers("", 2, store2)
 
@@ -500,17 +502,17 @@ func (suite *AuthTestSuite) TestAuth() {
 	_, e5 := PaginatedFindUsers("invalid", 0, store2)
 
 	suite.Equal(qUsers1, pu1.Users)
-	suite.Equal(int32(7), pu1.TotalSize)
+	suite.Equal(int32(8), pu1.TotalSize)
 	suite.Equal("", pu1.NextPageToken)
 	suite.Nil(e1)
 
 	suite.Equal(qUsers2, pu2.Users)
-	suite.Equal(int32(7), pu2.TotalSize)
-	suite.Equal("NA==", pu2.NextPageToken)
+	suite.Equal(int32(8), pu2.TotalSize)
+	suite.Equal("NQ==", pu2.NextPageToken)
 	suite.Nil(e2)
 
 	suite.Equal(qUsers3, pu3.Users)
-	suite.Equal(int32(7), pu3.TotalSize)
+	suite.Equal(int32(8), pu3.TotalSize)
 	suite.Equal("Mg==", pu3.NextPageToken)
 	suite.Nil(e3)
 
@@ -739,6 +741,21 @@ func (suite *AuthTestSuite) TestRemoveFromACL() {
 
 	e3 := RemoveFromACL("argo_uuid", "mistype", "sub1", []string{"UserX", "UserZ"}, store)
 	suite.Equal("wrong resource type", e3.Error())
+}
+
+func (suite *AuthTestSuite) TestGetPushWorkerToken() {
+
+	store := stores.NewMockStore("", "")
+
+	// normal case of push enabled true and correct push worker token
+	u1, err1 := GetPushWorker("push_token", store)
+	suite.Equal(User{"uuid7", []ProjectRoles{}, "push_worker_0", "push_token", "foo-email", []string{"push_worker"}, "2009-11-10T23:00:00Z", "2009-11-10T23:00:00Z", ""}, u1)
+	suite.Nil(err1)
+
+	//  incorrect push worker token
+	u4, err4 := GetPushWorker("missing", store)
+	suite.Equal(User{}, u4)
+	suite.Equal("push_500", err4.Error())
 }
 
 func TestAuthTestSuite(t *testing.T) {

--- a/auth/users.go
+++ b/auth/users.go
@@ -94,6 +94,16 @@ func NewUser(uuid string, projects []ProjectRoles, name string, token string, em
 	return User{UUID: uuid, Projects: projects, Name: name, Token: token, Email: email, ServiceRoles: serviceRoles, CreatedOn: createdOn.Format(zuluForm), ModifiedOn: modifiedOn.Format(zuluForm), CreatedBy: createdBy}
 }
 
+func GetPushWorker(pwToken string, store stores.Store) (User, error) {
+
+	pw, err := GetUserByToken(pwToken, store)
+	if err != nil {
+		return User{}, errors.New("push_500")
+	}
+
+	return pw, nil
+}
+
 // GetUserByToken returns a specific user by his token
 func GetUserByToken(token string, store stores.Store) (User, error) {
 	result := User{}

--- a/config.json
+++ b/config.json
@@ -14,5 +14,6 @@
   "push_tls_enabled": true,
   "push_server_host": "localhost",
   "push_server_port": 5555,
-  "verify_push_server": true
+  "verify_push_server": true,
+  "push_worker_token": "18492e78a1e95be564c00ba4537c4171ec628f98"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,8 @@ type APICfg struct {
 	PushServerPort int
 	// If tls is enabled, whether or not it should verify the push server's certificate
 	VerifyPushServer bool
+	// The token that corresponds to the registered push worker user
+	PushWorkerToken string
 }
 
 // NewAPICfg creates a new kafka configuration object
@@ -240,6 +242,8 @@ func (cfg *APICfg) LoadTest() {
 	log.Info("CONFIG", "\t", "Parameter Loaded - push_server_port: ", cfg.PushServerPort)
 	cfg.VerifyPushServer = viper.GetBool("verify_push_server")
 	log.Info("CONFIG", "\t", "Parameter Loaded - verify_push_server: ", cfg.VerifyPushServer)
+	cfg.PushWorkerToken = viper.GetString("push_worker_token")
+	log.Info("CONFIG", "\t", "Parameter Loaded - push_worker_token: ", cfg.PushWorkerToken)
 }
 
 // Load the configuration
@@ -300,6 +304,9 @@ func (cfg *APICfg) Load() {
 		pflag.Bool("push-verify", true, "verify push server's certificate if tls is enabled")
 		viper.BindPFlag("verify_push_server", pflag.Lookup("push-verify"))
 
+		pflag.String("push-worker-token", "", "token corresponding to the registered push worker user")
+		viper.BindPFlag("push_worker_token", pflag.Lookup("push-worker-token"))
+
 		configPath = pflag.String("config-dir", "", "directory path to an alternative json config file")
 
 		pflag.Parse()
@@ -356,6 +363,8 @@ func (cfg *APICfg) Load() {
 	log.Info("CONFIG", "\t", "Parameter Loaded - push_server_port: ", cfg.PushServerPort)
 	cfg.VerifyPushServer = viper.GetBool("verify_push_server")
 	log.Info("CONFIG", "\t", "Parameter Loaded - verify_push_server: ", cfg.VerifyPushServer)
+	cfg.PushWorkerToken = viper.GetString("push_worker_token")
+	log.Info("CONFIG", "\t", "Parameter Loaded - push_worker_token: ", cfg.PushWorkerToken)
 }
 
 // LoadStrJSON Loads configuration from a JSON string
@@ -395,4 +404,6 @@ func (cfg *APICfg) LoadStrJSON(input string) {
 	log.Info("CONFIG", "\t", "Parameter Loaded - push_server_port: ", cfg.PushServerPort)
 	cfg.VerifyPushServer = viper.GetBool("verify_push_server")
 	log.Info("CONFIG", "\t", "Parameter Loaded - verify_push_server: ", cfg.VerifyPushServer)
+	cfg.PushWorkerToken = viper.GetString("push_worker_token")
+	log.Info("CONFIG", "\t", "Parameter Loaded - push_worker_token: ", cfg.PushWorkerToken)
 }

--- a/config/config.json
+++ b/config/config.json
@@ -14,5 +14,6 @@
   "push_tls_enabled": true,
   "push_server_host": "localhost",
   "push_server_port": 5555,
-  "verify_push_server": true
+  "verify_push_server": true,
+  "push_worker_token": "lol"
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -653,6 +653,7 @@ func (mk *MockStore) Initialize() {
 	mk.UserList = append(mk.UserList, QUser{4, "uuid4", qRoleConsumerPub, "UserZ", "S3CR3T4", "foo-email", []string{}, created, modified, "uuid1"})
 	mk.UserList = append(mk.UserList, QUser{5, "same_uuid", qRoleConsumerPub, "UserSame1", "S3CR3T41", "foo-email", []string{}, created, modified, "uuid1"})
 	mk.UserList = append(mk.UserList, QUser{6, "same_uuid", qRoleConsumerPub, "UserSame2", "S3CR3T42", "foo-email", []string{}, created, modified, "uuid1"})
+	mk.UserList = append(mk.UserList, QUser{7, "uuid7", []QProjectRoles{}, "push_worker_0", "push_token", "foo-email", []string{"push_worker"}, created, modified, ""})
 
 	qRole1 := QRole{"topics:list_all", []string{"admin", "reader", "publisher"}}
 	qRole2 := QRole{"topics:publish", []string{"admin", "publisher"}}

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -446,12 +446,12 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	suite.Equal(store2.UserList, qUsers1)
 	suite.Equal("", pg1)
-	suite.Equal(int32(7), ts1)
+	suite.Equal(int32(8), ts1)
 
-	suite.Equal(6, qUsers2[0].ID)
-	suite.Equal(5, qUsers2[1].ID)
-	suite.Equal("4", pg2)
-	suite.Equal(int32(7), ts2)
+	suite.Equal(7, qUsers2[0].ID)
+	suite.Equal(6, qUsers2[1].ID)
+	suite.Equal("5", pg2)
+	suite.Equal(int32(8), ts2)
 
 	suite.Equal(0, len(qUsers3))
 	suite.Equal("", pg3)
@@ -460,7 +460,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(4, qUsers4[0].ID)
 	suite.Equal(3, qUsers4[1].ID)
 	suite.Equal("2", pg4)
-	suite.Equal(int32(7), ts4)
+	suite.Equal(int32(8), ts4)
 
 }
 


### PR DESCRIPTION
Provide a new function in the auth package that attempts to retrieve the push worker user based on the provided parameters.

Also, modify the SubCreate and SubModPush handlers to use the above-mentioned function in order to take care of all the push functionality cases that might occur as they are being described in the respective jira ticket.