### PR TITLE
ARGO-1657 Add/remove push worker from sub's acl and link him with sub's project

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -576,7 +576,8 @@ func (suite *AuthTestSuite) TestSubACL() {
 	expJSON04 := `{
    "authorized_users": [
       "UserB",
-      "UserZ"
+      "UserZ",
+      "push_worker_0"
    ]
 }`
 

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "certificate_authorities_dir": "/etc/grid-security/myca",
   "service_token":"b328c3861f061f87cbd34cf34f36ba2ae20883a5",
   "log_level":"INFO",
-  "push_enabled":false,
+  "push_enabled":true,
   "push_tls_enabled": true,
   "push_server_host": "localhost",
   "push_server_port": 5555,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1108,6 +1108,9 @@ func (suite *HandlerTestSuite) TestSubModPushConfigToActive() {
 	suite.Equal(3000, sub.RetPeriod)
 	suite.Equal("linear", sub.RetPolicy)
 	suite.Equal("Success: Subscription /projects/ARGO/subscriptions/sub1 activated", sub.PushStatus)
+	// check to see that the push worker user has been added to the subscription's acl
+	a1, _ := str.QueryACL("argo_uuid", "subscriptions", "sub1")
+	suite.Equal([]string{"uuid1", "uuid2", "uuid7"}, a1.ACL)
 }
 
 // TestSubModPushConfigToInactive tests the use case where the user modifies the push configuration
@@ -1141,6 +1144,9 @@ func (suite *HandlerTestSuite) TestSubModPushConfigToInactive() {
 	suite.Equal(0, sub.RetPeriod)
 	suite.Equal("", sub.RetPolicy)
 	suite.Equal("Subscription /projects/ARGO/subscriptions/sub4 deactivated", sub.PushStatus)
+	// check to see that the push worker user has been removed from the subscription's acl
+	a1, _ := str.QueryACL("argo_uuid", "subscriptions", "sub4")
+	suite.Equal([]string{"uuid2", "uuid4"}, a1.ACL)
 }
 
 // TestSubModPushConfigToInactivePushDisabled tests the use case where the user modifies the push configuration
@@ -1382,6 +1388,9 @@ func (suite *HandlerTestSuite) TestSubCreatePushConfig() {
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
 	suite.Equal("Subscription /projects/ARGO/subscriptions/subNew activated", sub.PushStatus)
+	// check to see that the push worker user has been added to the subscription's acl
+	a1, _ := str.QueryACL("argo_uuid", "subscriptions", "subNew")
+	suite.Equal([]string{"uuid7"}, a1.ACL)
 }
 
 func (suite *HandlerTestSuite) TestSubCreatePushConfigMissingPushWorker() {

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -205,9 +205,11 @@ func (mk *MockStore) AppendToACL(projectUUID string, resource string, name strin
 			mk.SubsACL[name] = qACL
 			return nil
 		}
+	} else {
+		return errors.New("wrong resource type")
 	}
 
-	return errors.New("wrong resource type")
+	return errors.New("no acl found")
 }
 
 func appendUniqueValues(existingValues []string, newValues ...string) []string {
@@ -239,9 +241,11 @@ func (mk *MockStore) RemoveFromACL(projectUUID string, resource string, name str
 			mk.SubsACL[name] = qACL
 			return nil
 		}
+	} else {
+		return errors.New("wrong resource type")
 	}
 
-	return errors.New("wrong resource type")
+	return errors.New("no acl found")
 }
 
 func removeValues(existingValues []string, valuesToRemove ...string) []string {
@@ -667,7 +671,7 @@ func (mk *MockStore) Initialize() {
 	qSubACL01 := QAcl{[]string{"uuid1", "uuid2"}}
 	qSubACL02 := QAcl{[]string{"uuid1", "uuid3"}}
 	qSubACL03 := QAcl{[]string{"uuid4", "uuid2", "uuid1"}}
-	qSubACL04 := QAcl{[]string{"uuid2", "uuid4"}}
+	qSubACL04 := QAcl{[]string{"uuid2", "uuid4", "uuid7"}}
 
 	mk.TopicsACL = make(map[string]QAcl)
 	mk.SubsACL = make(map[string]QAcl)
@@ -779,6 +783,7 @@ func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, of
 		TotalBytes:   0,
 	}
 	mk.SubList = append(mk.SubList, sub)
+	mk.SubsACL[name] = QAcl{}
 	return nil
 }
 

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -238,7 +238,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	QAcl06, _ := store.QueryACL("argo_uuid", "subscriptions", "sub3")
 	suite.Equal(ExpectedACL06, QAcl06)
 
-	ExpectedACL07 := QAcl{[]string{"uuid2", "uuid4"}}
+	ExpectedACL07 := QAcl{[]string{"uuid2", "uuid4", "uuid7"}}
 	QAcl07, _ := store.QueryACL("argo_uuid", "subscriptions", "sub4")
 	suite.Equal(ExpectedACL07, QAcl07)
 


### PR DESCRIPTION
Upgrade the SubCreate and ModPushStatus handlers to link the push worker user to the sub's project and append him to the sub's acl(when creating or updating). Also, remove the push worker user from a sub's acl when turning a push subscription to pull.