### PR TITLE
ARGO-1631 Add ACL-based access to topics:list

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -524,6 +524,28 @@ func IsConsumer(roles []string) bool {
 	return false
 }
 
+// IsProjectAdmin checks if the user is a project admin
+func IsProjectAdmin(roles []string) bool {
+	for _, role := range roles {
+		if role == "project_admin" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsServiceAdmin checks if the user is a service admin
+func IsServiceAdmin(roles []string) bool {
+	for _, role := range roles {
+		if role == "project_admin" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // RemoveUser removes an existing user
 func RemoveUser(uuid string, store stores.Store) error {
 	return store.RemoveUser(uuid)

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1131,7 +1131,9 @@ paths:
     get:
       summary: List topics in a project
       description: |
-        The Topics endpoint returns a list of available topics for a given project
+        The Topics endpoint returns a list of available topics for a given project.
+        If the user making the request has only publisher role for the given project, it will load
+        the topics that he has access to(being in a topic's acl).
       parameters:
         - $ref: '#/parameters/ApiKey'
         - $ref: '#/parameters/PageToken'

--- a/doc/v1/docs/api_topics.md
+++ b/doc/v1/docs/api_topics.md
@@ -98,7 +98,10 @@ Success Response
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
 ## [GET] Manage Topics - List Topics
-This request lists all available topics under a specific project in the service using pagination
+This request lists all available topics under a specific project in the service using pagination.
+
+If the `USER` making the request has only `publisher` role for the respective project, it will load
+only the topics that he has access to(being present in a topic's acl).
 
 It is important to note that if there are no results to return the service will return the following:
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3083,11 +3083,74 @@ func (suite *HandlerTestSuite) TestTopicListAll() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := oldPush.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil))
+	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil, "project_admin"))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
 
+}
+
+func (suite *HandlerTestSuite) TestTopicListAllPublisher() {
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/projects/ARGO/topics", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{
+   "topics": [
+      {
+         "name": "/projects/ARGO/topics/topic2"
+      },
+      {
+         "name": "/projects/ARGO/topics/topic1"
+      }
+   ],
+   "nextPageToken": "",
+   "totalSize": 2
+}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := oldPush.Manager{}
+	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil, "publisher"))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
+func (suite *HandlerTestSuite) TestTopicListAllPublisherWithPagination() {
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/projects/ARGO/topics?pageSize=1", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{
+   "topics": [
+      {
+         "name": "/projects/ARGO/topics/topic2"
+      }
+   ],
+   "nextPageToken": "MA==",
+   "totalSize": 2
+}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := oldPush.Manager{}
+	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil, "publisher"))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
 }
 
 func (suite *HandlerTestSuite) TestTopicListAllFirstPage() {
@@ -3117,7 +3180,7 @@ func (suite *HandlerTestSuite) TestTopicListAllFirstPage() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := oldPush.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil))
+	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil, "project_admin"))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
@@ -3148,7 +3211,7 @@ func (suite *HandlerTestSuite) TestTopicListAllNextPage() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := oldPush.Manager{}
-	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil))
+	router.HandleFunc("/v1/projects/{project}/topics", WrapMockAuthConfig(TopicListAll, cfgKafka, &brk, str, &mgr, nil, "project_admin"))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -6,7 +6,7 @@ import (
 )
 
 func GetProjectTopics(projectUUID string, store stores.Store) (int64, error) {
-	topics, _, _, err := store.QueryTopics(projectUUID, "", "", 0)
+	topics, _, _, err := store.QueryTopics(projectUUID, "", "", "", 0)
 	return int64(len(topics)), err
 }
 

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -170,7 +170,7 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	suite.Equal(errors.New("not found"), err)
 	// Check to see that also projects topics and subscriptions have been removed from the store
 
-	resTop, _, _, _ := store.QueryTopics("argo_uuid", "", "", 0)
+	resTop, _, _, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(0, len(resTop))
 	resSub, _, _, _ := store.QuerySubs("argo_uuid", "", "", 0)
 	suite.Equal(0, len(resSub))

--- a/stores/store.go
+++ b/stores/store.go
@@ -9,7 +9,7 @@ type Store interface {
 	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
 	QuerySubsByACL(projectUUID, user string) ([]QSub, error)
 	QuerySubs(projectUUID string, name string, pageToken string, pageSize int32) ([]QSub, int32, string, error)
-	QueryTopics(projectUUID string, name string, pageToken string, pageSize int32) ([]QTopic, int32, string, error)
+	QueryTopics(projectUUID string, userUUID string, name string, pageToken string, pageSize int32) ([]QTopic, int32, string, error)
 	QueryDailyTopicMsgCount(projectUUID string, name string, date time.Time) ([]QDailyTopicMsgCount, error)
 	RemoveTopic(projectUUID string, name string) error
 	RemoveSub(projectUUID string, name string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -30,7 +30,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}}
 
 	// retrieve all topics
-	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", 0)
+	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList, tpList)
 	suite.Equal(int32(3), ts1)
 	suite.Equal("", pg1)
@@ -39,7 +39,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	eTopList1st2 := []QTopic{
 		{2, "argo_uuid", "topic3", 0, 0},
 		{1, "argo_uuid", "topic2", 0, 0}}
-	tpList2, ts2, pg2, _ := store.QueryTopics("argo_uuid", "", "", 2)
+	tpList2, ts2, pg2, _ := store.QueryTopics("argo_uuid", "", "", "", 2)
 	suite.Equal(eTopList1st2, tpList2)
 	suite.Equal(int32(3), ts2)
 	suite.Equal("0", pg2)
@@ -47,7 +47,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	// retrieve the last one
 	eTopList3 := []QTopic{
 		{0, "argo_uuid", "topic1", 0, 0}}
-	tpList3, ts3, pg3, _ := store.QueryTopics("argo_uuid", "", "0", 1)
+	tpList3, ts3, pg3, _ := store.QueryTopics("argo_uuid", "", "", "0", 1)
 	suite.Equal(eTopList3, tpList3)
 	suite.Equal(int32(3), ts3)
 	suite.Equal("", pg3)
@@ -55,10 +55,30 @@ func (suite *StoreTestSuite) TestMockStore() {
 	// retrieve a single topic
 	eTopList4 := []QTopic{
 		{0, "argo_uuid", "topic1", 0, 0}}
-	tpList4, ts4, pg4, _ := store.QueryTopics("argo_uuid", "topic1", "", 0)
+	tpList4, ts4, pg4, _ := store.QueryTopics("argo_uuid", "", "topic1", "", 0)
 	suite.Equal(eTopList4, tpList4)
 	suite.Equal(int32(0), ts4)
 	suite.Equal("", pg4)
+
+	// retrieve user's topics
+	eTopList5 := []QTopic{
+		{1, "argo_uuid", "topic2", 0, 0},
+		{0, "argo_uuid", "topic1", 0, 0},
+	}
+	tpList5, ts5, pg5, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 0)
+	suite.Equal(eTopList5, tpList5)
+	suite.Equal(int32(2), ts5)
+	suite.Equal("", pg5)
+
+	// retrieve use's topic with pagination
+	eTopList6 := []QTopic{
+		{1, "argo_uuid", "topic2", 0, 0},
+	}
+
+	tpList6, ts6, pg6, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 1)
+	suite.Equal(eTopList6, tpList6)
+	suite.Equal(int32(2), ts6)
+	suite.Equal("0", pg6)
 
 	// retrieve all subs
 	subList, ts1, pg1, err1 := store.QuerySubs("argo_uuid", "", "", 0)
@@ -163,7 +183,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, ""},
 		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}}
 
-	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", 0)
+	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList2, tpList)
 	subList, _, _, _ = store.QuerySubs("argo_uuid", "", "", 0)
 	suite.Equal(eSubList2, subList)
@@ -171,7 +191,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	// Test delete on topic
 	err := store.RemoveTopic("argo_uuid", "topicFresh")
 	suite.Equal(nil, err)
-	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", 0)
+	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList, tpList)
 	err = store.RemoveTopic("argo_uuid", "topicFresh")
 	suite.Equal("not found", err.Error())
@@ -365,7 +385,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("2016-10-11T12:00:35:15Z", qSubUpd[0].PendingAck)
 	// Test RemoveProjectTopics
 	store.RemoveProjectTopics("argo_uuid")
-	resTop, _, _, _ := store.QueryTopics("argo_uuid", "", "", 0)
+	resTop, _, _, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(0, len(resTop))
 	store.RemoveProjectSubs("argo_uuid")
 	resSub, _, _, _ := store.QuerySubs("argo_uuid", "", "", 0)

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -44,7 +44,7 @@ func New(projectUUID string, projectName string, name string) Topic {
 // Find searches and returns a specific topic or all topics of a given project
 func FindMetric(projectUUID string, name string, store stores.Store) (TopicMetrics, error) {
 	result := TopicMetrics{MsgNum: 0}
-	topics, _, _, err := store.QueryTopics(projectUUID, name, "", 0)
+	topics, _, _, err := store.QueryTopics(projectUUID, "", name, "", 0)
 
 	// check if the topic exists
 	if len(topics) == 0 {
@@ -64,7 +64,7 @@ func FindMetric(projectUUID string, name string, store stores.Store) (TopicMetri
 }
 
 // Find searches and returns a specific topic or all topics of a given project
-func Find(projectUUID string, name string, pageToken string, pageSize int32, store stores.Store) (PaginatedTopics, error) {
+func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store stores.Store) (PaginatedTopics, error) {
 
 	var err error
 	var qTopics []stores.QTopic
@@ -80,7 +80,7 @@ func Find(projectUUID string, name string, pageToken string, pageSize int32, sto
 		return result, err
 	}
 
-	if qTopics, totalSize, nextPageToken, err = store.QueryTopics(projectUUID, name, string(pageTokenBytes), pageSize); err != nil {
+	if qTopics, totalSize, nextPageToken, err = store.QueryTopics(projectUUID, userUUID, name, string(pageTokenBytes), pageSize); err != nil {
 		return result, err
 	}
 
@@ -134,7 +134,7 @@ func CreateTopic(projectUUID string, name string, store stores.Store) (Topic, er
 		return Topic{}, errors.New("backend error")
 	}
 
-	results, err := Find(projectUUID, name, "", 0, store)
+	results, err := Find(projectUUID, "", name, "", 0, store)
 
 	if len(results.Topics) != 1 {
 		return Topic{}, errors.New("backend error")
@@ -154,7 +154,7 @@ func RemoveTopic(projectUUID string, name string, store stores.Store) error {
 
 // HasTopic returns true if project & topic combination exist
 func HasTopic(projectUUID string, name string, store stores.Store) bool {
-	res, err := Find(projectUUID, name, "", 0, store)
+	res, err := Find(projectUUID, "", name, "", 0, store)
 	if len(res.Topics) > 0 && err == nil {
 		return true
 	}

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -36,7 +36,7 @@ func (suite *TopicTestSuite) TestGetTopicByName() {
 	APIcfg := config.NewAPICfg()
 	APIcfg.LoadStrJSON(suite.cfgStr)
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
-	myTopics, _ := Find("argo_uuid", "topic1", "", 0, store)
+	myTopics, _ := Find("argo_uuid", "", "topic1", "", 0, store)
 	expTopic := New("argo_uuid", "ARGO", "topic1")
 	suite.Equal(expTopic, myTopics.Topics[0])
 }
@@ -51,33 +51,49 @@ func (suite *TopicTestSuite) TestGetPaginatedTopics() {
 		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2"},
 		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1"}},
 		NextPageToken: "", TotalSize: 3}
-	pgTopics1, err1 := Find("argo_uuid", "", "", 0, store)
+	pgTopics1, err1 := Find("argo_uuid", "", "", "", 0, store)
 
 	// retrieve first 2 topics
 	expPt2 := PaginatedTopics{Topics: []Topic{
 		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3"},
 		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2"}},
 		NextPageToken: "MA==", TotalSize: 3}
-	pgTopics2, err2 := Find("argo_uuid", "", "", 2, store)
+	pgTopics2, err2 := Find("argo_uuid", "", "", "", 2, store)
 
 	// retrieve the next topic
 	expPt3 := PaginatedTopics{Topics: []Topic{
 		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1"}},
 		NextPageToken: "", TotalSize: 3}
-	pgTopics3, err3 := Find("argo_uuid", "", "MA==", 1, store)
+	pgTopics3, err3 := Find("argo_uuid", "", "", "MA==", 1, store)
 
 	// invalid page token
-	_, err4 := Find("", "", "invalid", 0, store)
+	_, err4 := Find("", "", "", "invalid", 0, store)
+
+	// retrieve topics for a specific user
+	expPt5 := PaginatedTopics{Topics: []Topic{
+		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2"},
+		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1"}},
+		NextPageToken: "", TotalSize: 2}
+	pgTopics5, err5 := Find("argo_uuid", "uuid1", "", "", 2, store)
+
+	// retrieve topics for a specific user with pagination
+	expPt6 := PaginatedTopics{Topics: []Topic{
+		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2"}},
+		NextPageToken: "MA==", TotalSize: 2}
+	pgTopics6, err6 := Find("argo_uuid", "uuid1", "", "", 1, store)
 
 	suite.Equal(expPt1, pgTopics1)
 	suite.Equal(expPt2, pgTopics2)
 	suite.Equal(expPt3, pgTopics3)
+	suite.Equal(expPt5, pgTopics5)
+	suite.Equal(expPt6, pgTopics6)
 
 	suite.Nil(err1)
 	suite.Nil(err2)
 	suite.Nil(err3)
 	suite.Equal("illegal base64 data at input byte 4", err4.Error())
-
+	suite.Nil(err5)
+	suite.Nil(err6)
 }
 
 func (suite *TopicTestSuite) TestGetTopicMetric() {
@@ -144,7 +160,7 @@ func (suite *TopicTestSuite) TestExportJson() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	topics, _ := Find("argo_uuid", "topic1", "", 0, store)
+	topics, _ := Find("argo_uuid", "", "topic1", "", 0, store)
 	outJSON, _ := topics.Topics[0].ExportJSON()
 	expJSON := `{
    "name": "/projects/ARGO/topics/topic1"
@@ -166,7 +182,7 @@ func (suite *TopicTestSuite) TestExportJson() {
    "nextPageToken": "",
    "totalSize": 3
 }`
-	topics2, _ := Find("argo_uuid", "", "", 0, store)
+	topics2, _ := Find("argo_uuid", "", "", "", 0, store)
 	outJSON2, _ := topics2.ExportJSON()
 	suite.Equal(expJSON2, outJSON2)
 


### PR DESCRIPTION
Update the already existing methods that are used to query the topics collection to accept an extra argument, **userUUID**.

Given the route **/projects/{project}/topics**
if the user making the request is not a project or service admin and he has publisher role for the respective project, we load the topics he has access to.