### PR TITLE
ARGO-1632 Add ACL-based access in subscriptions:list

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -109,6 +109,13 @@ func (suite *AuthTestSuite) TestAuth() {
 	suite.Equal(true, IsPublisher([]string{"consumer", "publisher"}))
 	suite.Equal(true, IsPublisher([]string{"publisher"}))
 
+	suite.Equal(true, IsProjectAdmin([]string{"project_admin"}))
+	suite.Equal(true, IsProjectAdmin([]string{"project_admin", "publisher"}))
+	suite.Equal(false, IsProjectAdmin([]string{"publisher"}))
+
+	suite.Equal(true, IsServiceAdmin([]string{"service_admin"}))
+	suite.Equal(true, IsServiceAdmin([]string{"service_admin", "publisher"}))
+	suite.Equal(false, IsServiceAdmin([]string{"publisher"}))
 	// Check ValidUsers mechanism
 	v, err := AreValidUsers("ARGO", []string{"UserA", "foo", "bar"}, store)
 	suite.Equal(false, v)

--- a/auth/users.go
+++ b/auth/users.go
@@ -538,7 +538,7 @@ func IsProjectAdmin(roles []string) bool {
 // IsServiceAdmin checks if the user is a service admin
 func IsServiceAdmin(roles []string) bool {
 	for _, role := range roles {
-		if role == "project_admin" {
+		if role == "service_admin" {
 			return true
 		}
 	}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -548,7 +548,9 @@ paths:
     get:
       summary: List subscriptions in a project
       description: |
-        The subscriptions endpoint returns a list of available subscriptions for a given project
+        The subscriptions endpoint returns a list of available subscriptions for a given project.
+        If the USER making the request has only consumer role for the respective project, it will load
+        only the subscriptions that he has access to(being present in a subscriptions's acl).
       parameters:
         - $ref: '#/parameters/ApiKey'
         - $ref: '#/parameters/PageToken'

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -75,6 +75,9 @@ Please refer to section [Errors](api_errors.md) to see all possible Errors
 
 This request lists all available subscriptions under a specific project in the service using pagination
 
+If the `USER` making the request has only `consumer` role for the respective project, it will load
+only the subscriptions that he has access to(being present in a subscriptions's acl).
+
 It is important to note that if there are no results to return the service will return the following:
 
 Success Response

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -21,7 +21,7 @@ func GetProjectTopicsACL(projectUUID string, username string, store stores.Store
 }
 
 func GetProjectSubs(projectUUID string, store stores.Store) (int64, error) {
-	subs, _, _, err := store.QuerySubs(projectUUID, "", "", 0)
+	subs, _, _, err := store.QuerySubs(projectUUID, "", "", "", 0)
 	return int64(len(subs)), err
 }
 

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -172,7 +172,7 @@ func (suite *ProjectsTestSuite) TestProjects() {
 
 	resTop, _, _, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(0, len(resTop))
-	resSub, _, _, _ := store.QuerySubs("argo_uuid", "", "", 0)
+	resSub, _, _, _ := store.QuerySubs("argo_uuid", "", "", "", 0)
 	suite.Equal(0, len(resSub))
 
 }

--- a/push/push.go
+++ b/push/push.go
@@ -97,7 +97,7 @@ func (p *Pusher) push(brk brokers.Broker, store stores.Store) {
 	log.Debug("pid ", p.id, "pushing")
 	// update sub details
 
-	subs, err := subscriptions.Find(p.sub.ProjectUUID, p.sub.Name, "", 0, store)
+	subs, err := subscriptions.Find(p.sub.ProjectUUID, "", p.sub.Name, "", 0, store)
 
 	// If subscription doesn't exist in store stop and remove it from manager
 	if err == nil && len(subs.Subscriptions) == 0 {
@@ -252,7 +252,7 @@ func (mgr *Manager) Refresh(projectUUID string, sub string) error {
 
 	if p, err := mgr.Get(projectUUID + "/" + sub); err == nil {
 
-		subs, err := subscriptions.Find(projectUUID, sub, "", 0, mgr.store)
+		subs, err := subscriptions.Find(projectUUID, "", sub, "", 0, mgr.store)
 
 		if err != nil {
 			return errors.New("backend error")
@@ -279,7 +279,7 @@ func (mgr *Manager) Add(projectUUID string, subName string) error {
 		return errors.New("Push Manager not set")
 	}
 	// Check if subscription exists
-	subs, err := subscriptions.Find(projectUUID, subName, "", 0, mgr.store)
+	subs, err := subscriptions.Find(projectUUID, "", subName, "", 0, mgr.store)
 
 	if err != nil {
 		return errors.New("Backend error")

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -890,7 +890,7 @@ func (mk *MockStore) QueryPushSubs() []QSub {
 }
 
 // QuerySubs Query Subscription info from store
-func (mk *MockStore) QuerySubs(projectUUID string, name string, pageToken string, pageSize int32) ([]QSub, int32, string, error) {
+func (mk *MockStore) QuerySubs(projectUUID, userUUID, name, pageToken string, pageSize int32) ([]QSub, int32, string, error) {
 
 	var qSubs []QSub
 	var totalSize int32
@@ -902,6 +902,14 @@ func (mk *MockStore) QuerySubs(projectUUID string, name string, pageToken string
 
 	for _, sub := range mk.SubList {
 		if sub.ProjectUUID == projectUUID {
+
+			if userUUID != "" {
+				if !mk.existsInACL("subscriptions", sub.Name, userUUID) {
+					continue
+				}
+
+			}
+
 			counter++
 		}
 	}
@@ -937,6 +945,12 @@ func (mk *MockStore) QuerySubs(projectUUID string, name string, pageToken string
 
 				if sub.ID.(int) <= pg && sub.ProjectUUID == projectUUID {
 
+					if userUUID != "" {
+						if !mk.existsInACL("subscriptions", sub.Name, userUUID) {
+							continue
+						}
+					}
+
 					qSubs = append(qSubs, sub)
 					limit--
 
@@ -964,6 +978,12 @@ func (mk *MockStore) QuerySubs(projectUUID string, name string, pageToken string
 	case false:
 		for _, sub := range mk.SubList {
 			if sub.ProjectUUID == projectUUID && sub.Name == name {
+
+				if userUUID != "" {
+					if !mk.existsInACL("subscriptions", sub.Name, userUUID) {
+						continue
+					}
+				}
 				qSubs = append(qSubs, sub)
 				break
 			}

--- a/stores/store.go
+++ b/stores/store.go
@@ -8,7 +8,7 @@ type Store interface {
 	QuerySubsByTopic(projectUUID, topic string) ([]QSub, error)
 	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
 	QuerySubsByACL(projectUUID, user string) ([]QSub, error)
-	QuerySubs(projectUUID string, name string, pageToken string, pageSize int32) ([]QSub, int32, string, error)
+	QuerySubs(projectUUID string, userUUID string, name string, pageToken string, pageSize int32) ([]QSub, int32, string, error)
 	QueryTopics(projectUUID string, userUUID string, name string, pageToken string, pageSize int32) ([]QTopic, int32, string, error)
 	QueryDailyTopicMsgCount(projectUUID string, name string, date time.Time) ([]QDailyTopicMsgCount, error)
 	RemoveTopic(projectUUID string, name string) error

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -99,7 +99,7 @@ func NewNamesList() NamesList {
 // FindMetric returns the metric of a specific subscription
 func FindMetric(projectUUID string, name string, store stores.Store) (SubMetrics, error) {
 	result := SubMetrics{MsgNum: 0}
-	subs, _, _, err := store.QuerySubs(projectUUID, name, "", 0)
+	subs, _, _, err := store.QuerySubs(projectUUID, "", name, "", 0)
 
 	// check if sub exists
 	if len(subs) == 0 {
@@ -198,7 +198,7 @@ func (sl *PaginatedSubscriptions) ExportJSON() (string, error) {
 }
 
 // Find searches the store for all subscriptions of a given project or a specific one
-func Find(projectUUID string, name string, pageToken string, pageSize int32, store stores.Store) (PaginatedSubscriptions, error) {
+func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store stores.Store) (PaginatedSubscriptions, error) {
 
 	var err error
 	var qSubs []stores.QSub
@@ -214,7 +214,7 @@ func Find(projectUUID string, name string, pageToken string, pageSize int32, sto
 		return result, err
 	}
 
-	if qSubs, totalSize, nextPageToken, err = store.QuerySubs(projectUUID, name, string(pageTokenBytes), pageSize); err != nil {
+	if qSubs, totalSize, nextPageToken, err = store.QuerySubs(projectUUID, userUUID, name, string(pageTokenBytes), pageSize); err != nil {
 		return result, err
 	}
 
@@ -295,7 +295,7 @@ func CreateSub(projectUUID string, name string, topic string, push string, offse
 		return Subscription{}, errors.New("backend error")
 	}
 
-	results, err := Find(projectUUID, name, "", 0, store)
+	results, err := Find(projectUUID, "", name, "", 0, store)
 	if len(results.Subscriptions) != 1 {
 		return Subscription{}, errors.New("backend error")
 	}
@@ -349,7 +349,7 @@ func RemoveSub(projectUUID string, name string, store stores.Store) error {
 
 // HasSub returns true if project & subscription combination exist
 func HasSub(projectUUID string, name string, store stores.Store) bool {
-	res, err := Find(projectUUID, name, "", 0, store)
+	res, err := Find(projectUUID, "", name, "", 0, store)
 	if len(res.Subscriptions) > 0 && err == nil {
 		return true
 	}

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -84,7 +84,7 @@ func (suite *SubTestSuite) TestGetSubByName() {
 	cfgAPI.LoadStrJSON(suite.cfgStr)
 	store := stores.NewMockStore(cfgAPI.StoreHost, cfgAPI.StoreDB)
 
-	result, _ := Find("argo_uuid", "sub1", "", 0, store)
+	result, _ := Find("argo_uuid", "", "sub1", "", 0, store)
 	expSub := New("argo_uuid", "ARGO", "sub1", "topic1")
 	expSub.PushCfg.RetPol.PolicyType = ""
 	expSub.PushCfg.RetPol.Period = 0
@@ -138,22 +138,35 @@ func (suite *SubTestSuite) TestGetSubsByProject() {
 	expSubs1 = append(expSubs1, expSub3)
 	expSubs1 = append(expSubs1, expSub2)
 	expSubs1 = append(expSubs1, expSub1)
-	result1, _ := Find("argo_uuid", "", "", 0, store)
+	result1, _ := Find("argo_uuid", "", "", "", 0, store)
 
 	// retrieve first two subs
 	expSubs2 := []Subscription{}
 	expSubs2 = append(expSubs2, expSub4)
 	expSubs2 = append(expSubs2, expSub3)
-	result2, _ := Find("argo_uuid", "", "", 2, store)
+	result2, _ := Find("argo_uuid", "", "", "", 2, store)
 
 	//retrieve the next two subs
 	expSubs3 := []Subscription{}
 	expSubs3 = append(expSubs3, expSub2)
 	expSubs3 = append(expSubs3, expSub1)
-	result3, _ := Find("argo_uuid", "", "MQ==", 2, store)
+	result3, _ := Find("argo_uuid", "", "", "MQ==", 2, store)
 
 	// provide an invalid page token
-	_, err := Find("", "", "invalid", 0, store)
+	_, err := Find("", "", "", "invalid", 0, store)
+
+	// retrieve user's subs
+	expSubs4 := []Subscription{}
+	expSubs4 = append(expSubs4, expSub4)
+	expSubs4 = append(expSubs4, expSub3)
+	expSubs4 = append(expSubs4, expSub2)
+	result4, _ := Find("argo_uuid", "uuid1", "", "", 0, store)
+
+	// retrieve user's subs with pagination
+	expSubs5 := []Subscription{}
+	expSubs5 = append(expSubs5, expSub4)
+	expSubs5 = append(expSubs5, expSub3)
+	result5, _ := Find("argo_uuid", "uuid1", "", "", 2, store)
 
 	suite.Equal(expSubs1, result1.Subscriptions)
 	suite.Equal("", result1.NextPageToken)
@@ -168,6 +181,14 @@ func (suite *SubTestSuite) TestGetSubsByProject() {
 	suite.Equal(int32(4), result3.TotalSize)
 
 	suite.Equal("illegal base64 data at input byte 4", err.Error())
+
+	suite.Equal(expSubs4, result4.Subscriptions)
+	suite.Equal("", result4.NextPageToken)
+	suite.Equal(int32(3), result4.TotalSize)
+
+	suite.Equal(expSubs5, result5.Subscriptions)
+	suite.Equal("MQ==", result5.NextPageToken)
+	suite.Equal(int32(3), result5.TotalSize)
 }
 
 func (suite *SubTestSuite) TestLoadFromCfg() {
@@ -175,7 +196,7 @@ func (suite *SubTestSuite) TestLoadFromCfg() {
 	cfgAPI.LoadStrJSON(suite.cfgStr)
 
 	store := stores.NewMockStore(cfgAPI.StoreHost, cfgAPI.StoreDB)
-	results, _ := Find("argo_uuid", "", "", 0, store)
+	results, _ := Find("argo_uuid", "", "", "", 0, store)
 	expSub1 := New("argo_uuid", "ARGO", "sub1", "topic1")
 	expSub1.PushCfg.RetPol.PolicyType = ""
 	expSub1.PushCfg.RetPol.Period = 0
@@ -302,7 +323,7 @@ func (suite *SubTestSuite) TestExportJson() {
 
 	store := stores.NewMockStore(cfgAPI.StoreHost, cfgAPI.StoreDB)
 
-	res, _ := Find("argo_uuid", "sub1", "", 0, store)
+	res, _ := Find("argo_uuid", "", "sub1", "", 0, store)
 
 	outJSON, _ := res.Subscriptions[0].ExportJSON()
 	expJSON := `{
@@ -362,7 +383,7 @@ func (suite *SubTestSuite) TestExportJson() {
    "nextPageToken": "",
    "totalSize": 4
 }`
-	results, _ := Find("argo_uuid", "", "", 0, store)
+	results, _ := Find("argo_uuid", "", "", "", 0, store)
 	outJSON2, _ := results.ExportJSON()
 	suite.Equal(expJSON2, outJSON2)
 


### PR DESCRIPTION
Update the already existing methods that are used to query the subscriptions collection to accept an extra argument, **userUUID**.

Given the route **/projects/{project}/subscriptions**
if the user making the request is not a project or service admin and he has consumer role for the respective project, we load the subscriptions he has access to.