### PR TITLE
ARGO-1669 Allow only push worker user to pull from push enabled subscription

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -116,6 +116,11 @@ func (suite *AuthTestSuite) TestAuth() {
 	suite.Equal(true, IsServiceAdmin([]string{"service_admin"}))
 	suite.Equal(true, IsServiceAdmin([]string{"service_admin", "publisher"}))
 	suite.Equal(false, IsServiceAdmin([]string{"publisher"}))
+
+	suite.Equal(true, IsPushWorker([]string{"push_worker"}))
+	suite.Equal(true, IsPushWorker([]string{"push_worker", "publisher"}))
+	suite.Equal(false, IsPushWorker([]string{"publisher"}))
+
 	// Check ValidUsers mechanism
 	v, err := AreValidUsers("ARGO", []string{"UserA", "foo", "bar"}, store)
 	suite.Equal(false, v)

--- a/auth/users.go
+++ b/auth/users.go
@@ -524,6 +524,17 @@ func IsConsumer(roles []string) bool {
 	return false
 }
 
+// IsPushWorker Checks if a user is a push worker
+func IsPushWorker(roles []string) bool {
+	for _, role := range roles {
+		if role == "push_worker" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsProjectAdmin checks if the user is a project admin
 func IsProjectAdmin(roles []string) bool {
 	for _, role := range roles {

--- a/handlers.go
+++ b/handlers.go
@@ -2683,6 +2683,13 @@ func SubPull(w http.ResponseWriter, r *http.Request) {
 	retImm := true
 	max := 1
 
+	// if the subscription is push enabled, allow only push worker and service_admin users to pull from it
+	if targetSub.PushCfg != (subscriptions.PushConfig{}) && !auth.IsPushWorker(refRoles) && !auth.IsServiceAdmin(refRoles) {
+		err := APIErrorForbidden()
+		respondErr(w, err)
+		return
+	}
+
 	// Check Authorization per subscription
 	// - if enabled in config
 	// - if user has only consumer role

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -138,7 +138,7 @@ func (suite *MetricsTestSuite) TestGetTopics() {
 	APIcfg.LoadStrJSON(suite.cfgStr)
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 	n, _ := GetProjectTopics("argo_uuid", store)
-	suite.Equal(int64(3), n)
+	suite.Equal(int64(4), n)
 
 }
 func (suite *MetricsTestSuite) TestGetTopicsACL() {

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -614,9 +614,11 @@ func (mk *MockStore) Initialize() {
 	qtop1 := QTopic{0, "argo_uuid", "topic1", 0, 0}
 	qtop2 := QTopic{1, "argo_uuid", "topic2", 0, 0}
 	qtop3 := QTopic{2, "argo_uuid", "topic3", 0, 0}
+	qtop4 := QTopic{3, "argo_uuid", "topic4", 0, 0}
 	mk.TopicList = append(mk.TopicList, qtop1)
 	mk.TopicList = append(mk.TopicList, qtop2)
 	mk.TopicList = append(mk.TopicList, qtop3)
+	mk.TopicList = append(mk.TopicList, qtop4)
 
 	// populate Subscriptions
 	qsub1 := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -19,6 +19,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("mockbase", store.Database)
 
 	eTopList := []QTopic{
+		{3, "argo_uuid", "topic4", 0, 0},
 		{2, "argo_uuid", "topic3", 0, 0},
 		{1, "argo_uuid", "topic2", 0, 0},
 		{0, "argo_uuid", "topic1", 0, 0}}
@@ -32,24 +33,24 @@ func (suite *StoreTestSuite) TestMockStore() {
 	// retrieve all topics
 	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList, tpList)
-	suite.Equal(int32(3), ts1)
+	suite.Equal(int32(4), ts1)
 	suite.Equal("", pg1)
 
 	// retrieve first 2
 	eTopList1st2 := []QTopic{
-		{2, "argo_uuid", "topic3", 0, 0},
-		{1, "argo_uuid", "topic2", 0, 0}}
+		{3, "argo_uuid", "topic4", 0, 0},
+		{2, "argo_uuid", "topic3", 0, 0}}
 	tpList2, ts2, pg2, _ := store.QueryTopics("argo_uuid", "", "", "", 2)
 	suite.Equal(eTopList1st2, tpList2)
-	suite.Equal(int32(3), ts2)
-	suite.Equal("0", pg2)
+	suite.Equal(int32(4), ts2)
+	suite.Equal("1", pg2)
 
 	// retrieve the last one
 	eTopList3 := []QTopic{
 		{0, "argo_uuid", "topic1", 0, 0}}
 	tpList3, ts3, pg3, _ := store.QueryTopics("argo_uuid", "", "", "0", 1)
 	suite.Equal(eTopList3, tpList3)
-	suite.Equal(int32(3), ts3)
+	suite.Equal(int32(4), ts3)
 	suite.Equal("", pg3)
 
 	// retrieve a single topic
@@ -194,7 +195,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, "", "", 0)
 
 	eTopList2 := []QTopic{
-		{3, "argo_uuid", "topicFresh", 0, 0},
+		{4, "argo_uuid", "topicFresh", 0, 0},
+		{3, "argo_uuid", "topic4", 0, 0},
 		{2, "argo_uuid", "topic3", 0, 0},
 		{1, "argo_uuid", "topic2", 0, 0},
 		{0, "argo_uuid", "topic1", 0, 0},

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -47,23 +47,24 @@ func (suite *TopicTestSuite) TestGetPaginatedTopics() {
 
 	// retrieve all topics
 	expPt1 := PaginatedTopics{Topics: []Topic{
+		{"argo_uuid", "topic4", "/projects/ARGO/topics/topic4"},
 		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3"},
 		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2"},
 		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1"}},
-		NextPageToken: "", TotalSize: 3}
+		NextPageToken: "", TotalSize: 4}
 	pgTopics1, err1 := Find("argo_uuid", "", "", "", 0, store)
 
 	// retrieve first 2 topics
 	expPt2 := PaginatedTopics{Topics: []Topic{
-		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3"},
-		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2"}},
-		NextPageToken: "MA==", TotalSize: 3}
+		{"argo_uuid", "topic4", "/projects/ARGO/topics/topic4"},
+		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3"}},
+		NextPageToken: "MQ==", TotalSize: 4}
 	pgTopics2, err2 := Find("argo_uuid", "", "", "", 2, store)
 
 	// retrieve the next topic
 	expPt3 := PaginatedTopics{Topics: []Topic{
 		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1"}},
-		NextPageToken: "", TotalSize: 3}
+		NextPageToken: "", TotalSize: 4}
 	pgTopics3, err3 := Find("argo_uuid", "", "", "MA==", 1, store)
 
 	// invalid page token
@@ -170,6 +171,9 @@ func (suite *TopicTestSuite) TestExportJson() {
 	expJSON2 := `{
    "topics": [
       {
+         "name": "/projects/ARGO/topics/topic4"
+      },
+      {
          "name": "/projects/ARGO/topics/topic3"
       },
       {
@@ -180,7 +184,7 @@ func (suite *TopicTestSuite) TestExportJson() {
       }
    ],
    "nextPageToken": "",
-   "totalSize": 3
+   "totalSize": 4
 }`
 	topics2, _ := Find("argo_uuid", "", "", "", 0, store)
 	outJSON2, _ := topics2.ExportJSON()


### PR DESCRIPTION
Update the **SubPull** handler to check whether or not the given subscription is push enabled.
If it is push enabled, allow only users with a service role of push_worker or service_admin to pull, otherwise return a 403 forbidden error.