### PR TITLE
ARGO-1684 update status call to handle push enabled false

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -4254,6 +4254,33 @@ func (suite *HandlerTestSuite) TestHealthCheck() {
 	suite.Equal(expResp, w.Body.String())
 }
 
+func (suite *HandlerTestSuite) TestHealthCheckPushDisabled() {
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/status", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{
+ "status": "ok",
+ "push_functionality": "disabled"
+}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	cfgKafka.PushEnabled = false
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	mgr := oldPush.Manager{}
+	pc := new(push.MockClient)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/v1/status", WrapMockAuthConfig(HealthCheck, cfgKafka, &brk, str, &mgr, pc))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
 func (suite *HandlerTestSuite) TestHealthCheckPushWorkerMissing() {
 
 	req, err := http.NewRequest("GET", "http://localhost:8080/v1/status", nil)


### PR DESCRIPTION
Provide a new rpc call **Status** that returns the state of the service.

Also provide a wrapper around the rest of the rpc calls that prevents requests from accessing them, IF the state of the service is erroneous.