### PR TITLE
ARGO-1787 Add verification_hash and verified fields for push enabled subscriptions

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1610,6 +1610,10 @@ definitions:
         description: endpoint url for endpoint to push messages
       retryPolicy:
         $ref: '#/definitions/RetryPolicy'
+      verification_hash:
+        type: string
+      verified:
+        type: boolean
 
   PushStatus:
     type: object

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -36,6 +36,44 @@ Success Response
 }
 ```
 
+### Push Enabled Subscriptions
+Whenever a subscription is created with a valid push configuration, the service will also generate a unique hash that
+should be later used to validate the ownership of the registered push endpoint, and will mark the subscription as 
+unverified.
+
+## Request to create Push Enabled Subscription
+```json
+{
+ "topic": "projects/BRAND_NEW/topics/monitoring",
+ "ackDeadlineSeconds":10,
+  "pushConfig": {
+    "pushEndpoint": "https://127.0.0.1:5000/receive_here",
+    "retryPolicy": {
+      "type": "linear", 
+      "period": 1000              	
+    }
+   }
+}
+```
+### Response
+```json
+{
+ "name": "projects/BRAND_NEW/subscriptions/alert_engine",
+ "topic": "projects/BRAND_NEW/topics/monitoring",
+ "ackDeadlineSeconds": 10,
+  "pushConfig": {
+    "pushEndpoint": "https://127.0.0.1:5000/receive_here",
+    "retryPolicy": {
+      "type": "linear", 
+      "period": 1000              	
+    },
+    "verification_hash": "9d5189f7f758e380a5f8bc4fdb4fe980c565b67b",
+    "verified": false
+    }    
+}
+```
+
+
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
@@ -347,6 +385,13 @@ curl -X POST -H "Content-Type: application/json"
 
 Success Response
 Code: `200 OK`, Empty response if successful.
+
+Whenever a subscription is created with a valid push configuration, the service will also generate a unique hash that
+should be later used to validate the ownership of the registered push endpoint, and will mark the subscription as 
+unverified.
+
+**NOTE** Changing the push endpoint of a push enabled subscription, or removing the push configuration and then re-applying
+will mark the subscription as unverified and a new verification process should take place.
 
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -407,12 +407,14 @@ func (mk *MockStore) ModAck(projectUUID string, name string, ack int) error {
 }
 
 // ModSubPush modifies the subscription push configuration
-func (mk *MockStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error {
+func (mk *MockStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int, vhash string, verified bool) error {
 	for i, item := range mk.SubList {
 		if item.ProjectUUID == projectUUID && item.Name == name {
 			mk.SubList[i].PushEndpoint = push
 			mk.SubList[i].RetPolicy = rPolicy
 			mk.SubList[i].RetPeriod = rPeriod
+			mk.SubList[i].VerificationHash = vhash
+			mk.SubList[i].Verified = verified
 			return nil
 		}
 	}
@@ -621,10 +623,10 @@ func (mk *MockStore) Initialize() {
 	mk.TopicList = append(mk.TopicList, qtop4)
 
 	// populate Subscriptions
-	qsub1 := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}
-	qsub2 := QSub{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, ""}
-	qsub3 := QSub{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, ""}
-	qsub4 := QSub{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled"}
+	qsub1 := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}
+	qsub2 := QSub{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}
+	qsub3 := QSub{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}
+	qsub4 := QSub{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled", "push-id-1", true}
 	mk.SubList = append(mk.SubList, qsub1)
 	mk.SubList = append(mk.SubList, qsub2)
 	mk.SubList = append(mk.SubList, qsub3)
@@ -770,19 +772,21 @@ func (mk *MockStore) InsertTopic(projectUUID string, name string) error {
 }
 
 // InsertSub inserts a new sub object to the store
-func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
+func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int, vhash string, verified bool) error {
 	sub := QSub{
-		ID:           len(mk.SubList),
-		ProjectUUID:  projectUUID,
-		Name:         name,
-		Topic:        topic,
-		Offset:       offset,
-		Ack:          ack,
-		PushEndpoint: push,
-		RetPolicy:    rPolicy,
-		RetPeriod:    rPeriod,
-		MsgNum:       0,
-		TotalBytes:   0,
+		ID:               len(mk.SubList),
+		ProjectUUID:      projectUUID,
+		Name:             name,
+		Topic:            topic,
+		Offset:           offset,
+		Ack:              ack,
+		PushEndpoint:     push,
+		RetPolicy:        rPolicy,
+		RetPeriod:        rPeriod,
+		VerificationHash: vhash,
+		Verified:         verified,
+		MsgNum:           0,
+		TotalBytes:       0,
 	}
 	mk.SubList = append(mk.SubList, sub)
 	mk.SubsACL[name] = QAcl{}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -851,20 +851,22 @@ func (mong *MongoStore) InsertProject(uuid string, name string, createdOn time.T
 }
 
 // InsertSub inserts a subscription to the store
-func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int) error {
+func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, ack int, push string, rPolicy string, rPeriod int, vhash string, verified bool) error {
 	sub := QSub{
-		ProjectUUID:  projectUUID,
-		Name:         name,
-		Topic:        topic,
-		Offset:       offset,
-		NextOffset:   0,
-		PendingAck:   "",
-		Ack:          ack,
-		PushEndpoint: push,
-		RetPolicy:    rPolicy,
-		RetPeriod:    rPeriod,
-		MsgNum:       0,
-		TotalBytes:   0,
+		ProjectUUID:      projectUUID,
+		Name:             name,
+		Topic:            topic,
+		Offset:           offset,
+		NextOffset:       0,
+		PendingAck:       "",
+		Ack:              ack,
+		PushEndpoint:     push,
+		RetPolicy:        rPolicy,
+		RetPeriod:        rPeriod,
+		VerificationHash: vhash,
+		Verified:         verified,
+		MsgNum:           0,
+		TotalBytes:       0,
 	}
 	return mong.InsertResource("subscriptions", sub)
 }
@@ -1007,7 +1009,7 @@ func (mong *MongoStore) ModAck(projectUUID string, name string, ack int) error {
 }
 
 // ModSubPush modifies the push configuration
-func (mong *MongoStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error {
+func (mong *MongoStore) ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int, vhash string, verified bool) error {
 	db := mong.Session.DB(mong.Database)
 	c := db.C("subscriptions")
 
@@ -1016,9 +1018,11 @@ func (mong *MongoStore) ModSubPush(projectUUID string, name string, push string,
 		"name":         name,
 	},
 		bson.M{"$set": bson.M{
-			"push_endpoint": push,
-			"retry_policy":  rPolicy,
-			"retry_period":  rPeriod,
+			"push_endpoint":     push,
+			"retry_policy":      rPolicy,
+			"retry_period":      rPeriod,
+			"verification_hash": vhash,
+			"verified":          verified,
 		},
 		})
 	return err

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -6,20 +6,22 @@ import (
 
 // QSub are the results of the Qsub query
 type QSub struct {
-	ID           interface{} `bson:"_id,omitempty"`
-	ProjectUUID  string      `bson:"project_uuid"`
-	Name         string      `bson:"name"`
-	Topic        string      `bson:"topic"`
-	Offset       int64       `bson:"offset"`
-	NextOffset   int64       `bson:"next_offset"`
-	PendingAck   string      `bson:"pending_ack"`
-	PushEndpoint string      `bson:"push_endpoint"`
-	Ack          int         `bson:"ack"`
-	RetPolicy    string      `bson:"retry_policy"`
-	RetPeriod    int         `bson:"retry_period"`
-	MsgNum       int64       `bson:"msg_num"`
-	TotalBytes   int64       `bson:"total_bytes"`
-	PushStatus   string      `bson:"push_status,omitempty"`
+	ID               interface{} `bson:"_id,omitempty"`
+	ProjectUUID      string      `bson:"project_uuid"`
+	Name             string      `bson:"name"`
+	Topic            string      `bson:"topic"`
+	Offset           int64       `bson:"offset"`
+	NextOffset       int64       `bson:"next_offset"`
+	PendingAck       string      `bson:"pending_ack"`
+	PushEndpoint     string      `bson:"push_endpoint"`
+	Ack              int         `bson:"ack"`
+	RetPolicy        string      `bson:"retry_policy"`
+	RetPeriod        int         `bson:"retry_period"`
+	MsgNum           int64       `bson:"msg_num"`
+	TotalBytes       int64       `bson:"total_bytes"`
+	PushStatus       string      `bson:"push_status,omitempty"`
+	VerificationHash string      `bson:"verification_hash"`
+	Verified         bool        `bson:"verified"`
 }
 
 // QAcl holds a list of authorized users queried from topic or subscription collections

--- a/stores/store.go
+++ b/stores/store.go
@@ -34,7 +34,7 @@ type Store interface {
 	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubMsgNum(projectUUID string, name string, num int64) error
-	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int) error
+	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, push string, rPolicy string, rPeriod int, vhash string, verified bool) error
 	HasProject(name string) bool
 	HasUsers(projectUUID string, users []string) (bool, []string)
 	QueryOneSub(projectUUID string, name string) (QSub, error)
@@ -46,7 +46,7 @@ type Store interface {
 	UpdateSubOffset(projectUUID string, name string, offset int64)
 	UpdateSubPull(projectUUID string, name string, offset int64, ts string) error
 	UpdateSubOffsetAck(projectUUID string, name string, offset int64, ts string) error
-	ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int) error
+	ModSubPush(projectUUID string, name string, push string, rPolicy string, rPeriod int, vhash string, verified bool) error
 	ModSubPushStatus(projectUUID string, name string, status string) error
 	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
 	ModACL(projectUUID string, resource string, name string, acl []string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -25,10 +25,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{0, "argo_uuid", "topic1", 0, 0}}
 
 	eSubList := []QSub{
-		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled"},
-		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, ""},
-		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, ""},
-		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}}
+		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled", "push-id-1", true},
+		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false},
+		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false},
+		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}}
 
 	// retrieve all topics
 	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
@@ -89,8 +89,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve first 2 subs
 	eSubListFirstPage := []QSub{
-		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled"},
-		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, ""}}
+		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled", "push-id-1", true},
+		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}}
 
 	subList2, ts2, pg2, err2 := store.QuerySubs("argo_uuid", "", "", "", 2)
 	suite.Equal(eSubListFirstPage, subList2)
@@ -99,8 +99,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve next 2 subs
 	eSubListNextPage := []QSub{
-		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, ""},
-		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}}
+		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false},
+		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}}
 
 	subList3, ts3, pg3, err3 := store.QuerySubs("argo_uuid", "", "", "1", 2)
 	suite.Equal(eSubListNextPage, subList3)
@@ -109,7 +109,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve user's subs
 	eSubList4 := []QSub{
-		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "endpoint.foo", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, PushStatus: "push enabled"},
+		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "endpoint.foo", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, PushStatus: "push enabled", VerificationHash: "push-id-1", Verified: true},
 		{ID: 2, ProjectUUID: "argo_uuid", Name: "sub3", Topic: "topic3", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, PushStatus: ""},
 		{ID: 1, ProjectUUID: "argo_uuid", Name: "sub2", Topic: "topic2", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, PushStatus: ""}}
 
@@ -121,7 +121,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve user's subs
 	eSubList5 := []QSub{
-		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "endpoint.foo", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, PushStatus: "push enabled"},
+		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "endpoint.foo", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, PushStatus: "push enabled", VerificationHash: "push-id-1", Verified: true},
 		{ID: 2, ProjectUUID: "argo_uuid", Name: "sub3", Topic: "topic3", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, PushStatus: ""}}
 	subList5, ts5, pg5, err5 := store.QuerySubs("argo_uuid", "uuid1", "", "", 2)
 
@@ -192,7 +192,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
 	store.InsertTopic("argo_uuid", "topicFresh")
-	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, "", "", 0)
+	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, "", "", 0, "", false)
 
 	eTopList2 := []QTopic{
 		{4, "argo_uuid", "topicFresh", 0, 0},
@@ -203,11 +203,11 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 
 	eSubList2 := []QSub{
-		{4, "argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 10, "", 0, 0, 0, ""},
-		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled"},
-		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, ""},
-		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, ""},
-		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}}
+		{4, "argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false},
+		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 10, "linear", 300, 0, 0, "push enabled", "push-id-1", true},
+		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false},
+		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false},
+		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}}
 
 	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList2, tpList)
@@ -231,7 +231,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("not found", err.Error())
 
 	sb, err := store.QueryOneSub("argo_uuid", "sub1")
-	esb := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, ""}
+	esb := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 10, "", 0, 0, 0, "", "", false}
 	suite.Equal(esb, sb)
 
 	// Test modify ack deadline in store
@@ -240,14 +240,16 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(66, subAck.Ack)
 
 	// Test mod push sub
-	e1 := store.ModSubPush("argo_uuid", "sub1", "example.com", "linear", 400)
+	e1 := store.ModSubPush("argo_uuid", "sub1", "example.com", "linear", 400, "hash-1", true)
 	sub1, _ := store.QueryOneSub("argo_uuid", "sub1")
 	suite.Nil(e1)
 	suite.Equal("example.com", sub1.PushEndpoint)
 	suite.Equal("linear", sub1.RetPolicy)
 	suite.Equal(400, sub1.RetPeriod)
+	suite.Equal("hash-1", sub1.VerificationHash)
+	suite.True(sub1.Verified)
 
-	e2 := store.ModSubPush("argo_uuid", "unknown", "", "", 0)
+	e2 := store.ModSubPush("argo_uuid", "unknown", "", "", 0, "", false)
 	suite.Equal("not found", e2.Error())
 
 	// Test mod push sub

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -129,7 +129,12 @@ func (suite *SubTestSuite) TestGetSubsByProject() {
 	expSub4.PushCfg.RetPol.PolicyType = "linear"
 	expSub4.PushCfg.RetPol.Period = 300
 	rp := RetryPolicy{"linear", 300}
-	expSub4.PushCfg = PushConfig{"endpoint.foo", rp}
+	expSub4.PushCfg = PushConfig{
+		Pend:             "endpoint.foo",
+		RetPol:           rp,
+		VerificationHash: "push-id-1",
+		Verified:         true,
+	}
 	expSub4.PushStatus = "push enabled"
 
 	// retrieve all subs
@@ -210,7 +215,12 @@ func (suite *SubTestSuite) TestLoadFromCfg() {
 	expSub4.PushCfg.RetPol.PolicyType = "linear"
 	expSub4.PushCfg.RetPol.Period = 300
 	rp := RetryPolicy{"linear", 300}
-	expSub4.PushCfg = PushConfig{"endpoint.foo", rp}
+	expSub4.PushCfg = PushConfig{
+		Pend:             "endpoint.foo",
+		RetPol:           rp,
+		VerificationHash: "push-id-1",
+		Verified:         true,
+	}
 	expSub4.PushStatus = "push enabled"
 	expSubs := []Subscription{}
 	expSubs = append(expSubs, expSub4)
@@ -243,11 +253,11 @@ func (suite *SubTestSuite) TestCreateSubStore() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	sub, err := CreateSub("argo_uuid", "sub1", "topic1", "", 0, 0, "linear", 300, store)
+	sub, err := CreateSub("argo_uuid", "sub1", "topic1", "", 0, 0, "linear", 300, "", true, store)
 	suite.Equal(Subscription{}, sub)
 	suite.Equal("exists", err.Error())
 
-	sub2, err2 := CreateSub("argo_uuid", "subNew", "topicNew", "", 0, 0, "linear", 300, store)
+	sub2, err2 := CreateSub("argo_uuid", "subNew", "topicNew", "", 0, 0, "linear", 300, "", true, store)
 	expSub := New("argo_uuid", "ARGO", "subNew", "topicNew")
 	suite.Equal(expSub, sub2)
 	suite.Equal(nil, err2)
@@ -282,7 +292,7 @@ func (suite *SubTestSuite) TestModSubPush() {
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
 	// modify push config
-	err1 := ModSubPush("argo_uuid", "sub1", "example.com", "linear", 400, store)
+	err1 := ModSubPush("argo_uuid", "sub1", "example.com", "linear", 400, "hash-1", true, store)
 
 	suite.Nil(err1)
 
@@ -290,9 +300,11 @@ func (suite *SubTestSuite) TestModSubPush() {
 	suite.Equal("example.com", sub1.PushEndpoint)
 	suite.Equal("linear", sub1.RetPolicy)
 	suite.Equal(400, sub1.RetPeriod)
+	suite.Equal("hash-1", sub1.VerificationHash)
+	suite.True(sub1.Verified)
 
 	// test error case
-	err2 := ModSubPush("argo_uuid", "unknown", "", "", 0, store)
+	err2 := ModSubPush("argo_uuid", "unknown", "", "", 0, "", false, store)
 	suite.Equal("not found", err2.Error())
 }
 
@@ -331,7 +343,9 @@ func (suite *SubTestSuite) TestExportJson() {
    "topic": "/projects/ARGO/topics/topic1",
    "pushConfig": {
       "pushEndpoint": "",
-      "retryPolicy": {}
+      "retryPolicy": {},
+      "verification_hash": "",
+      "verified": false
    },
    "ackDeadlineSeconds": 10
 }`
@@ -347,7 +361,9 @@ func (suite *SubTestSuite) TestExportJson() {
             "retryPolicy": {
                "type": "linear",
                "period": 300
-            }
+            },
+            "verification_hash": "push-id-1",
+            "verified": true
          },
          "ackDeadlineSeconds": 10,
          "push_status": "push enabled"
@@ -357,7 +373,9 @@ func (suite *SubTestSuite) TestExportJson() {
          "topic": "/projects/ARGO/topics/topic3",
          "pushConfig": {
             "pushEndpoint": "",
-            "retryPolicy": {}
+            "retryPolicy": {},
+            "verification_hash": "",
+            "verified": false
          },
          "ackDeadlineSeconds": 10
       },
@@ -366,7 +384,9 @@ func (suite *SubTestSuite) TestExportJson() {
          "topic": "/projects/ARGO/topics/topic2",
          "pushConfig": {
             "pushEndpoint": "",
-            "retryPolicy": {}
+            "retryPolicy": {},
+            "verification_hash": "",
+            "verified": false
          },
          "ackDeadlineSeconds": 10
       },
@@ -375,7 +395,9 @@ func (suite *SubTestSuite) TestExportJson() {
          "topic": "/projects/ARGO/topics/topic1",
          "pushConfig": {
             "pushEndpoint": "",
-            "retryPolicy": {}
+            "retryPolicy": {},
+            "verification_hash": "",
+            "verified": false
          },
          "ackDeadlineSeconds": 10
       }


### PR DESCRIPTION
Add to new field to the push configuration struct, **verification_hash** and **verified**, to help the verification process of the registered push endpoint.

Modified the SubCreate and the ModSubPush handlers to take care of these new fields.