### PR TITLE
ARGO-1792 API Call - Verify Push Endpoint

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1077,6 +1077,41 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:verifyPushEndpoint:
+    post:
+      summary: Verify the ownership of the push endpoint
+      description: |
+        The service will execute a request against the registered push endpoint in order to retrieve the verification_hash that it was generated
+      parameters:
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SUBSCRIPTION
+          in: path
+          description: Name of the subscription
+          required: true
+          type: string
+      tags:
+        - Subscriptions
+      responses:
+        200:
+          description: Empty response if successful
+          schema:
+            type: string
+            default: ""
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409_action_conflict"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/subscriptions/{SUBSCRIPTION}:modifyPushStatus:
     post:
       summary: Modify the push status of th subscription
@@ -1493,6 +1528,10 @@ responses:
       $ref: '#/definitions/ErrorMsg'
   409:
     description: Item already exists!
+    schema:
+      $ref: '#/definitions/ErrorMsg'
+  409_action_conflict:
+    description: A conflict occurred due to the user's action!
     schema:
       $ref: '#/definitions/ErrorMsg'
 

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -77,6 +77,44 @@ unverified.
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+
+## [POST] Manage Subscriptions - Verify ownership of a push endpoint
+This request triggers the process of verifying the ownership of a registered push endpoint 
+
+### Request
+`PUT /v1/projects/{project_name}/subscriptions/{subscription_name}:verifyPushEndpoint`
+
+### Where
+- Project_name: Name of the project
+- subscription_name: The subscription name
+
+### Example request
+```json
+curl -X POST "https://{URL}/v1/projects/BRAND_NEW/subscriptions/alert_engine:verifyPushEndpoint?key=S3CR3T"`
+```
+
+### Push Enabled Subscriptions
+Whenever a subscription is created with a valid push configuration, the service will also generate a unique hash that
+should be later used to validate the ownership of the registered push endpoint, and will mark the subscription as 
+unverified.
+
+The owner of the push endpoint needs to execute the following steps in order to verify the ownership of the
+registered endpoint.
+
+- Open an api call with a path of `/ams_verification_hash`. The service will try to access this path using the `host:port`
+of the push endpoint. For example, if the push endpoint is `https://example.com:8443/receive_here`, the  push endpoint should also
+support the api route of `https://example.com:8443/ams_verification_hash`.
+
+- The api route of `https://example.com:8443/ams_verification_hash` should support the http `GET` method.
+
+- A `GET` request to `https://example.com:8443/ams_verification_hash` should return a response body 
+with only the `verification_hash`
+that is found inside the subscriptions push configuration, 
+a `status code` of `200` and the header `Content-type: plain/text`.
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [GET] Manage Subscriptions - List All Subscriptions under a specific Topic
 
 This request lists all available subscriptions under a specific topic in the service.

--- a/examples/flask_receive_endpoint/receiver.py
+++ b/examples/flask_receive_endpoint/receiver.py
@@ -16,9 +16,9 @@
 
 from flask import Flask
 from flask import request
+from flask import Response
 import argparse
 import json
-import base64
 from logging.config import dictConfig
 import ssl
 import flask_cors
@@ -49,6 +49,7 @@ dictConfig({
     }
 })
 
+VERIFICATION_HASH = ""
 
 app = Flask(__name__)
 
@@ -81,6 +82,11 @@ def receive_msg():
         return e.message, 400
 
 
+@app.route('/ams_verification_hash', methods=['GET'])
+def return_verification_hash():
+    return Response(response=VERIFICATION_HASH, status=200, content_type="plain/text")
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Simple flask endpoint for push subscriptions")
@@ -97,11 +103,17 @@ if __name__ == "__main__":
         "-port", "--port", metavar="INTEGER", help="Bind port",
         default=5000, type=int, dest="port")
 
+    parser.add_argument(
+        "-vh", "--verification-hash", metavar="STRING", help="Verification hash for the push endpoint",
+        required=True, dest="vhash")
+
     args = parser.parse_args()
 
     flask_cors.CORS(app=app, methods=["OPTIONS", "HEAD", "POST"], allow_headers=["X-Requested-With", "Content-Type"])
 
     context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
     context.load_cert_chain(args.cert, args.key)
+
+    VERIFICATION_HASH = args.vhash
 
     app.run(host='0.0.0.0', port=args.port, ssl_context=context, threaded=True, debug=True)

--- a/routing.go
+++ b/routing.go
@@ -97,6 +97,7 @@ var defaultRoutes = []APIRoute{
 	{"subscriptions:delete", "DELETE", "/projects/{project}/subscriptions/{subscription}", SubDelete},
 	{"subscriptions:pull", "POST", "/projects/{project}/subscriptions/{subscription}:pull", SubPull},
 	{"subscriptions:acknowledge", "POST", "/projects/{project}/subscriptions/{subscription}:acknowledge", SubAck},
+	{"subscriptions:verifyPushEndpoint", "POST", "/projects/{project}/subscriptions/{subscription}:verifyPushEndpoint", SubVerifyPushEndpoint},
 	{"subscriptions:modifyAckDeadline", "POST", "/projects/{project}/subscriptions/{subscription}:modifyAckDeadline", SubModAck},
 	{"subscriptions:modifyPushConfig", "POST", "/projects/{project}/subscriptions/{subscription}:modifyPushConfig", SubModPush},
 	{"subscriptions:modifyPushStatus", "POST", "/projects/{project}/subscriptions/{subscription}:modifyPushStatus", SubModPushStatus},


### PR DESCRIPTION
- Add a new Http handler, **SubVerifyPushEndpoint**
- Add a new function, VerifyPushEndpoint in the subscriptions package that handles the logic behind verifying the ownership of a push endpoint
- Add a new method to the subscription struct that extracts the host:port from the registered push endpoint
- Extended the flask endpoint to provide an api call for verifying push endpoints