### PR TITLE
ARGO-1880 List user members of a project

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/ARGOeu/argo-messaging/projects"
 	"github.com/ARGOeu/argo-messaging/stores"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 // User is the struct that holds user information
@@ -19,7 +20,7 @@ type User struct {
 	UUID         string         `json:"uuid"`
 	Projects     []ProjectRoles `json:"projects"`
 	Name         string         `json:"name"`
-	Token        string         `json:"token"`
+	Token        string         `json:"token,omitempty"`
 	Email        string         `json:"email"`
 	ServiceRoles []string       `json:"service_roles"`
 	CreatedOn    string         `json:"created_on,omitempty"`
@@ -94,6 +95,7 @@ func NewUser(uuid string, projects []ProjectRoles, name string, token string, em
 	return User{UUID: uuid, Projects: projects, Name: name, Token: token, Email: email, ServiceRoles: serviceRoles, CreatedOn: createdOn.Format(zuluForm), ModifiedOn: modifiedOn.Format(zuluForm), CreatedBy: createdBy}
 }
 
+// GetPushWorker returns a push worker user by token
 func GetPushWorker(pwToken string, store stores.Store) (User, error) {
 
 	pw, err := GetUserByToken(pwToken, store)
@@ -151,7 +153,7 @@ func GetUserByToken(token string, store stores.Store) (User, error) {
 }
 
 // FindUsers returns a specific user or a list of all available users belonging to a  project in the datastore.
-func FindUsers(projectUUID string, uuid string, name string, store stores.Store) (Users, error) {
+func FindUsers(projectUUID string, uuid string, name string, priviledged bool, store stores.Store) (Users, error) {
 	result := Users{}
 
 	users, err := store.QueryUsers(projectUUID, uuid, name)
@@ -160,17 +162,31 @@ func FindUsers(projectUUID string, uuid string, name string, store stores.Store)
 
 		// Get Username from user uuid
 
+		// Get Username from user uuid
+		serviceRoles := []string{}
+		token := ""
 		usernameC := ""
-		if item.CreatedBy != "" {
-			usr, err := store.QueryUsers("", item.CreatedBy, "")
-			if err == nil && len(usr) > 0 {
-				usernameC = usr[0].Name
 
+		// if call made by priviledged user (superuser), show service roles, token and user creator info
+		if priviledged {
+			if item.CreatedBy != "" {
+				usr, err := store.QueryUsers("", item.CreatedBy, "")
+				if err == nil && len(usr) > 0 {
+					usernameC = usr[0].Name
+
+				}
 			}
+			token = item.Token
+			serviceRoles = item.ServiceRoles
 		}
 
 		pRoles := []ProjectRoles{}
 		for _, pItem := range item.Projects {
+			// if user not priviledged (not superuser) and queried projectUUID doesn't
+			// match current role item's project UUID, skip the item
+			if !priviledged && pItem.ProjectUUID != projectUUID {
+				continue
+			}
 			prName := projects.GetNameByUUID(pItem.ProjectUUID, store)
 			// Get User topics and subscriptions
 
@@ -188,7 +204,7 @@ func FindUsers(projectUUID string, uuid string, name string, store stores.Store)
 			pRoles = append(pRoles, ProjectRoles{Project: prName, Roles: pItem.Roles, Topics: topicNames, Subs: subNames})
 		}
 
-		curUser := NewUser(item.UUID, pRoles, item.Name, item.Token, item.Email, item.ServiceRoles, item.CreatedOn.UTC(), item.ModifiedOn.UTC(), usernameC)
+		curUser := NewUser(item.UUID, pRoles, item.Name, token, item.Email, serviceRoles, item.CreatedOn.UTC(), item.ModifiedOn.UTC(), usernameC)
 
 		result.List = append(result.List, curUser)
 	}
@@ -201,7 +217,7 @@ func FindUsers(projectUUID string, uuid string, name string, store stores.Store)
 }
 
 // PaginatedFindUsers returns a page of users
-func PaginatedFindUsers(pageToken string, pageSize int32, store stores.Store) (PaginatedUsers, error) {
+func PaginatedFindUsers(pageToken string, pageSize int32, projectUUID string, priviledged bool, store stores.Store) (PaginatedUsers, error) {
 
 	var totalSize int32
 	var nextPageToken string
@@ -217,28 +233,39 @@ func PaginatedFindUsers(pageToken string, pageSize int32, store stores.Store) (P
 
 	result := PaginatedUsers{Users: []User{}}
 
-	if users, totalSize, nextPageToken, err = store.PaginatedQueryUsers(string(pageTokenBytes), pageSize); err != nil {
+	if users, totalSize, nextPageToken, err = store.PaginatedQueryUsers(string(pageTokenBytes), pageSize, projectUUID); err != nil {
 		return result, err
 	}
 
 	for _, item := range users {
 
 		// Get Username from user uuid
-
+		serviceRoles := []string{}
+		token := ""
 		usernameC := ""
-		if item.CreatedBy != "" {
-			usr, err := store.QueryUsers("", item.CreatedBy, "")
-			if err == nil && len(usr) > 0 {
-				usernameC = usr[0].Name
+		// if call made by priviledged user (superuser), show service roles, token and user creator info
+		if priviledged {
+			if item.CreatedBy != "" {
+				usr, err := store.QueryUsers("", item.CreatedBy, "")
+				if err == nil && len(usr) > 0 {
+					usernameC = usr[0].Name
 
+				}
 			}
+			token = item.Token
+			serviceRoles = item.ServiceRoles
 		}
 
 		pRoles := []ProjectRoles{}
 		for _, pItem := range item.Projects {
+			// if user not priviledged (not superuser) and queried projectUUID doesn't
+			// match current role item's project UUID, skip the item
+			if !priviledged && pItem.ProjectUUID != projectUUID {
+				continue
+			}
 			prName := projects.GetNameByUUID(pItem.ProjectUUID, store)
-			// Get User topics and subscriptions
 
+			// Get User topics and subscriptions
 			topicList, _ := store.QueryTopicsByACL(pItem.ProjectUUID, item.UUID)
 			topicNames := []string{}
 			for _, tpItem := range topicList {
@@ -253,7 +280,7 @@ func PaginatedFindUsers(pageToken string, pageSize int32, store stores.Store) (P
 			pRoles = append(pRoles, ProjectRoles{Project: prName, Roles: pItem.Roles, Topics: topicNames, Subs: subNames})
 		}
 
-		curUser := NewUser(item.UUID, pRoles, item.Name, item.Token, item.Email, item.ServiceRoles, item.CreatedOn.UTC(), item.ModifiedOn.UTC(), usernameC)
+		curUser := NewUser(item.UUID, pRoles, item.Name, token, item.Email, serviceRoles, item.CreatedOn.UTC(), item.ModifiedOn.UTC(), usernameC)
 
 		result.Users = append(result.Users, curUser)
 	}
@@ -307,6 +334,7 @@ func GetNameByUUID(uuid string, store stores.Store) string {
 	return result
 }
 
+// GetUserByUUID returns user information by UUID
 func GetUserByUUID(uuid string, store stores.Store) (User, error) {
 
 	var result User
@@ -383,7 +411,7 @@ func UpdateUserToken(uuid string, token string, store stores.Store) (User, error
 		return User{}, err
 	}
 	// reflect stored object
-	stored, err := FindUsers("", uuid, "", store)
+	stored, err := FindUsers("", uuid, "", true, store)
 	return stored.One(), err
 }
 
@@ -453,7 +481,7 @@ func UpdateUser(uuid string, name string, projectList []ProjectRoles, email stri
 	}
 
 	// reflect stored object
-	stored, err := FindUsers("", uuid, "", store)
+	stored, err := FindUsers("", uuid, "", true, store)
 	return stored.One(), err
 }
 
@@ -488,7 +516,7 @@ func CreateUser(uuid string, name string, projectList []ProjectRoles, token stri
 	}
 
 	// reflect stored object
-	stored, err := FindUsers("", "", name, store)
+	stored, err := FindUsers("", "", name, true, store)
 	return stored.One(), err
 }
 
@@ -600,8 +628,8 @@ func PerResource(project string, resType string, resName string, userUUID string
 	if resType == "topics" || resType == "subscriptions" {
 		err := store.ExistsInACL(project, resType, resName, userUUID)
 		if err != nil {
-			return false
 			log.Errorln(err.Error())
+			return false
 		}
 
 		return true

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -271,6 +271,75 @@ paths:
           $ref: "#/responses/404"
         500:
           $ref: "#/responses/500"
+  
+  /projects/{PROJECT}/members:
+    get:
+      summary: List users that are members of the project
+      description: |
+        List all user members of the specific project. This call is can be used only by project admins or service admins
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - $ref: '#/parameters/PageToken'
+        - $ref: '#/parameters/PageSize'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+      tags:
+        - Projects
+      responses:
+        200:
+          description: An array of Users
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Users'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
+  /projects/{PROJECT}/members/{USER}:
+    get:
+      summary: Show info on a specific user member of the project
+      description: |
+        Shows information on a specific user member of the project. This call is can be used only by project admins or service admins
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: USER
+          in: path
+          description: Name of the user
+          required: true
+          type: string
+      tags:
+        - Projects
+      responses:
+        200:
+          description: A User object
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
 
 
   /users:

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -210,6 +210,128 @@ Code: `200 OK`, Empty response if successful.
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+### [GET] List all users that are members of a specific project
+
+### Example request
+```
+curl -X GET -H "Content-Type: application/json"
+  "https://{URL}/v1/projects/ARGO2/members?key=S3CR3T"
+```
+
+### Responses  
+If successful, the response contains a list of all available users in the specific project
+
+Success Response
+`200 OK`
+
+```json
+{
+ "users": [
+    {
+       "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
+       "projects": [
+          {
+             "project": "ARGO2",
+             "roles": [
+                "consumer",
+                "publisher"
+             ],
+             "topics": [],
+             "subscriptions": []
+          }
+       ],
+       "name": "Test",
+       "token": "S3CR3T",
+       "email": "Test@test.com",
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
+    }
+ ],
+ "nextPageToken": "",
+ "totalSize": 1
+}
+```
+
+### Unpriviledge mode (non service_admin user)
+When a user is project_admin instead of service_admin and lists a project's users the results
+returned remove user information such as `token`, `service_roles` and `created_by` For example:
+
+```json
+{
+ "users": [
+    {
+       "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
+       "projects": [
+          {
+             "project": "ARGO2",
+             "roles": [
+                "consumer",
+                "publisher"
+             ],
+             "topics": [],
+             "subscriptions": []
+          }
+       ],
+       "name": "Test",
+       "token": "",
+       "email": "Test@test.com",
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
+    }
+ ],
+ "nextPageToken": "",
+ "totalSize": 1
+}
+```
+
+### [GET] Show a specific member user of the specific project
+
+### Example request
+```
+curl -X GET -H "Content-Type: application/json"
+  "https://{URL}/v1/projects/ARGO2/members/Test?key=S3CR3T"
+```
+
+### Responses  
+If successful, the response contains information of the specific user Test
+
+Success Response
+`200 OK`
+
+```json
+{
+ "users": [
+    {
+       "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
+       "projects": [
+          {
+             "project": "ARGO2",
+             "roles": [
+                "consumer",
+                "publisher"
+             ],
+             "topics": [],
+             "subscriptions": []
+          }
+       ],
+       "name": "Test",
+       "token": "S3CR3T",
+       "email": "Test@test.com",
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
+    }
+ ],
+ "nextPageToken": "",
+ "totalSize": 1
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [GET] Project Metrics
 The following request returns related metrics for the specific project: eg. the number of topics
 
@@ -228,6 +350,8 @@ GET "/v1/projects/{project_name}:metrics"
 curl  -H "Content-Type: application/json"
 "https://{URL}/v1/projects/BRAND_NEW:metrics?key=S3CR3T"
 ```
+
+
 
 ### Responses  
 If successful it returns projects related metrics (number of topics, number of subscriptions).

--- a/doc/v1/docs/api_users.md
+++ b/doc/v1/docs/api_users.md
@@ -46,7 +46,7 @@ Success Response
        "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
        "projects": [
           {
-             "project": "ARGO",
+             "project": "ARGO2",
              "roles": [
                 "consumer",
                 "publisher"
@@ -195,7 +195,7 @@ Success Response
        "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
        "projects": [
           {
-             "project": "ARGO",
+             "project": "ARGO2",
              "roles": [
                 "consumer",
                 "publisher"
@@ -346,6 +346,49 @@ Success Response
 }
 ```
 
+### Paginated Request that returns all users that are members of a specific project
+
+### Example request
+```
+curl -X GET -H "Content-Type: application/json"
+  "https://{URL}/v1/users?key=S3CR3T&project=ARGO2"
+```
+
+### Responses  
+If successful, the response contains a list of all available users that are members in the project ARGO2
+
+Success Response
+`200 OK`
+
+```json
+{
+ "users": [
+    {
+       "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
+       "projects": [
+          {
+             "project": "ARGO2",
+             "roles": [
+                "consumer",
+                "publisher"
+             ],
+             "topics": [],
+             "subscriptions": []
+          }
+       ],
+       "name": "Test",
+       "token": "S3CR3T",
+       "email": "Test@test.com",
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
+    }
+ ],
+ "nextPageToken": "",
+ "totalSize": 1
+}
+```
+
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
@@ -402,6 +445,9 @@ Success Response
    "modified_on": "2009-11-10T23:00:00Z"
 }
 ```
+
+
+
 
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/projects/project.go
+++ b/projects/project.go
@@ -91,6 +91,7 @@ func Find(uuid string, name string, store stores.Store) (Projects, error) {
 // GetNameByUUID queries projects by UUID and returns the project name. If not found, returns an empty string
 func GetNameByUUID(uuid string, store stores.Store) string {
 	result := ""
+
 	// if project string empty, returns all projects
 	projects, err := store.QueryProjects(uuid, "")
 

--- a/routing.go
+++ b/routing.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ARGOeu/argo-messaging/brokers"
 	"github.com/ARGOeu/argo-messaging/config"
 	oldPush "github.com/ARGOeu/argo-messaging/push"
-	"github.com/ARGOeu/argo-messaging/push/grpc/client"
+	push "github.com/ARGOeu/argo-messaging/push/grpc/client"
 	"github.com/ARGOeu/argo-messaging/stores"
 	gorillaContext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
@@ -83,6 +83,8 @@ var defaultRoutes = []APIRoute{
 	{"users:delete", "DELETE", "/users/{user}", UserDelete},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:metrics", "GET", "/projects/{project}:metrics", ProjectMetrics},
+	{"projects:showUser", "GET", "/projects/{project}/members/{user}", ProjectUserListOne},
+	{"projects:listUsers", "GET", "/projects/{project}/members", ProjectListUsers},
 	{"projects:show", "GET", "/projects/{project}", ProjectListOne},
 	{"projects:create", "POST", "/projects/{project}", ProjectCreate},
 	{"projects:update", "PUT", "/projects/{project}", ProjectUpdate},

--- a/stores/store.go
+++ b/stores/store.go
@@ -17,7 +17,7 @@ type Store interface {
 	UpdateSubConsumeRate(projectUUID string, name string, rate float64) error
 	RemoveTopic(projectUUID string, name string) error
 	RemoveSub(projectUUID string, name string) error
-	PaginatedQueryUsers(pageToken string, pageSize int32) ([]QUser, int32, string, error)
+	PaginatedQueryUsers(pageToken string, pageSize int32, projectUUID string) ([]QUser, int32, string, error)
 	QueryUsers(projectUUID string, uuid string, name string) ([]QUser, error)
 	UpdateUser(uuid string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error
 	AppendToUserProjects(userUUID string, projectUUID string, pRoles ...string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -311,46 +311,46 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(errors.New("not found"), err08)
 
 	// test mod acl
-	eModAcl1 := store.ModACL("argo_uuid", "topics", "topic1", []string{"u1", "u2"})
-	suite.Nil(eModAcl1)
+	eModACL1 := store.ModACL("argo_uuid", "topics", "topic1", []string{"u1", "u2"})
+	suite.Nil(eModACL1)
 	tACL := store.TopicsACL["topic1"].ACL
 	suite.Equal([]string{"u1", "u2"}, tACL)
 
-	eModAcl2 := store.ModACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u2"})
-	suite.Nil(eModAcl2)
+	eModACL2 := store.ModACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u2"})
+	suite.Nil(eModACL2)
 	sACL := store.SubsACL["sub1"].ACL
 	suite.Equal([]string{"u1", "u2"}, sACL)
 
-	eModAcl3 := store.ModACL("argo_uuid", "mistype", "sub1", []string{"u1", "u2"})
-	suite.Equal("wrong resource type", eModAcl3.Error())
+	eModACL3 := store.ModACL("argo_uuid", "mistype", "sub1", []string{"u1", "u2"})
+	suite.Equal("wrong resource type", eModACL3.Error())
 
 	// test append acl
-	eAppAcl1 := store.AppendToACL("argo_uuid", "topics", "topic1", []string{"u3", "u4", "u4"})
-	suite.Nil(eAppAcl1)
+	eAppACL1 := store.AppendToACL("argo_uuid", "topics", "topic1", []string{"u3", "u4", "u4"})
+	suite.Nil(eAppACL1)
 	tACLapp := store.TopicsACL["topic1"].ACL
 	suite.Equal([]string{"u1", "u2", "u3", "u4"}, tACLapp)
 
-	eAppAcl2 := store.AppendToACL("argo_uuid", "subscriptions", "sub1", []string{"u3", "u4", "u4"})
-	suite.Nil(eAppAcl2)
+	eAppACL2 := store.AppendToACL("argo_uuid", "subscriptions", "sub1", []string{"u3", "u4", "u4"})
+	suite.Nil(eAppACL2)
 	sACLapp := store.SubsACL["sub1"].ACL
 	suite.Equal([]string{"u1", "u2", "u3", "u4"}, sACLapp)
 
-	eAppAcl3 := store.AppendToACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
-	suite.Equal("wrong resource type", eAppAcl3.Error())
+	eAppACL3 := store.AppendToACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
+	suite.Equal("wrong resource type", eAppACL3.Error())
 
 	// test remove acl
-	eRemAcl1 := store.RemoveFromACL("argo_uuid", "topics", "topic1", []string{"u1", "u4", "u5"})
-	suite.Nil(eRemAcl1)
+	eRemACL1 := store.RemoveFromACL("argo_uuid", "topics", "topic1", []string{"u1", "u4", "u5"})
+	suite.Nil(eRemACL1)
 	tACLRem := store.TopicsACL["topic1"].ACL
 	suite.Equal([]string{"u2", "u3"}, tACLRem)
 
-	eRemAcl2 := store.RemoveFromACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u4", "u5"})
-	suite.Nil(eRemAcl2)
+	eRemACL2 := store.RemoveFromACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u4", "u5"})
+	suite.Nil(eRemACL2)
 	sACLRem := store.SubsACL["sub1"].ACL
 	suite.Equal([]string{"u2", "u3"}, sACLRem)
 
-	eRemAcl3 := store.RemoveFromACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
-	suite.Equal("wrong resource type", eRemAcl3.Error())
+	eRemACL3 := store.RemoveFromACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
+	suite.Equal("wrong resource type", eRemACL3.Error())
 
 	//Check has users
 	allFound, notFound := store.HasUsers("argo_uuid", []string{"UserA", "UserB", "FooUser"})
@@ -495,27 +495,27 @@ func (suite *StoreTestSuite) TestMockStore() {
 	store2 := NewMockStore("", "")
 
 	// return all users in one page
-	qUsers1, ts1, pg1, _ := store2.PaginatedQueryUsers("", 0)
+	qUsers1, ts1, pg1, _ := store2.PaginatedQueryUsers("", 0, "")
 
 	// return a page with the first 2
-	qUsers2, ts2, pg2, _ := store2.PaginatedQueryUsers("", 2)
+	qUsers2, ts2, pg2, _ := store2.PaginatedQueryUsers("", 2, "")
 
 	// empty store
 	store3 := NewMockStore("", "")
 	store3.UserList = []QUser{}
-	qUsers3, ts3, pg3, _ := store3.PaginatedQueryUsers("", 0)
+	qUsers3, ts3, pg3, _ := store3.PaginatedQueryUsers("", 0, "")
 
 	// use page token "5" to grab another 2 results
-	qUsers4, ts4, pg4, _ := store2.PaginatedQueryUsers("4", 2)
+	qUsers4, ts4, pg4, _ := store2.PaginatedQueryUsers("4", 2, "")
 
 	suite.Equal(store2.UserList, qUsers1)
 	suite.Equal("", pg1)
-	suite.Equal(int32(8), ts1)
+	suite.Equal(int32(9), ts1)
 
-	suite.Equal(7, qUsers2[0].ID)
-	suite.Equal(6, qUsers2[1].ID)
-	suite.Equal("5", pg2)
-	suite.Equal(int32(8), ts2)
+	suite.Equal(8, qUsers2[0].ID)
+	suite.Equal(7, qUsers2[1].ID)
+	suite.Equal("6", pg2)
+	suite.Equal(int32(9), ts2)
 
 	suite.Equal(0, len(qUsers3))
 	suite.Equal("", pg3)
@@ -524,7 +524,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(4, qUsers4[0].ID)
 	suite.Equal(3, qUsers4[1].ID)
 	suite.Equal("2", pg4)
-	suite.Equal(int32(8), ts4)
+	suite.Equal(int32(9), ts4)
 
 	// test update topic latest publish time
 	e1ulp := store2.UpdateTopicLatestPublish("argo_uuid", "topic1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.Local))


### PR DESCRIPTION
## Goal
Allow to list user members of a specific project (project_admins and service_admins allowed to do this)

### Task
Allow listing users per project. When this call is used by service_admins all user information is available. When this call is used by project admins the following user fields are ommited: `token`, `service_roles`, `created_by` as well info on roles that the user might have on other projects. 

The listing of users per projects is implemented in three api requests and supports pagination: 
- **existing one:** `/v1/users` by using and additional urlParam `project={project_name}`
  This api call is available only to service admins that could list all users using pagination but now can also filter by project
- **a new one:** `v1/projects/{project_name}/members`
 This api call is available to both service_admins and project_admins and allows to quickly list user members of a specific project. When the call is made by service_admins all user info is displayed. When the call is made by project_admins critical info is hidden (see above) 
- **a new one:** `v1/projects/{project_name}/members/{user_name}`
 This api call is available to both service_admins and project_admins and allows to quickly show information on a specific user member of a specific project. When the call is made by service_admins all user info is displayed. When the call is made by project_admins critical info is hidden (see above) 

### Implementation 
- Leverage method `stores.PaginatedQueryUsers` to allow the optional usage of `projectUUID` argument. If `projectUUID` is empty method queries all users, else queries only users that have any role in the specific project with uuid: `projectUUID`
- Leverage method `auth.PaginatedFindUsers` to allow the optional usage of `projectUUID` argument as well as `priviledged` boolean argument to hide user info when queries are init from `project_admin` users. 
- Update `UserListAll` handler method to use accordingly the refactored query functions 
- Create new handler method `ProjectListUsers` that allows list users per project using the routing pattern `/v1/projects/{project_name}/members`
- Create new handler method `ProjectListOneUser` that allows to get info on a specific user member of a project using  the routing pattern `/v1/projects/{project_name}/members/{username}`
- Update unit tests
- Update mkdocs
- Update swagger definition 

