### PR TITLE
ARGO-1984 Prohibit duplicate project references in user profiles

### DIFF
--- a/auth/users.go
+++ b/auth/users.go
@@ -446,8 +446,20 @@ func UpdateUser(uuid string, name string, projectList []ProjectRoles, email stri
 
 	validRoles := store.GetAllRoles()
 
+	var duplicates []string
+	// Prep project roles for datastore insert
 	if projectList != nil {
 		for _, item := range projectList {
+
+			// check if project is encountered before by consulting duplicate list
+			for _, dItem := range duplicates {
+				if dItem == item.Project {
+					return User{}, errors.New("duplicate reference of project " + dItem)
+				}
+			}
+
+			duplicates = append(duplicates, item.Project)
+
 			prUUID := projects.GetUUIDByName(item.Project, store)
 			// If project name doesn't reflect a uuid, then is non existent
 			if prUUID == "" {
@@ -492,9 +504,21 @@ func CreateUser(uuid string, name string, projectList []ProjectRoles, token stri
 		return User{}, errors.New("exists")
 	}
 
+	var duplicates []string
 	// Prep project roles for datastore insert
 	prList := []stores.QProjectRoles{}
 	for _, item := range projectList {
+
+		// check if project is encountered before by consulting duplicate list
+		for _, dItem := range duplicates {
+			if dItem == item.Project {
+				return User{}, errors.New("duplicate reference of project " + dItem)
+			}
+		}
+
+		// add project name to duplicate check list
+		duplicates = append(duplicates, item.Project)
+
 		prUUID := projects.GetUUIDByName(item.Project, store)
 		// If project name doesn't reflect a uuid, then is non existent
 		if prUUID == "" {

--- a/handlers.go
+++ b/handlers.go
@@ -627,6 +627,13 @@ func UserUpdate(w http.ResponseWriter, r *http.Request) {
 			respondErr(w, err)
 			return
 		}
+
+		if strings.HasPrefix(err.Error(), "duplicate") {
+			err := APIErrorInvalidData(err.Error())
+			respondErr(w, err)
+			return
+		}
+
 		err := APIErrGenericInternal(err.Error())
 		respondErr(w, err)
 		return
@@ -694,6 +701,13 @@ func UserCreate(w http.ResponseWriter, r *http.Request) {
 			respondErr(w, err)
 			return
 		}
+
+		if strings.HasPrefix(err.Error(), "duplicate") {
+			err := APIErrorInvalidData(err.Error())
+			respondErr(w, err)
+			return
+		}
+
 		err := APIErrGenericInternal(err.Error())
 		respondErr(w, err)
 		return

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -202,6 +202,39 @@ func (suite *HandlerTestSuite) TestUserCreate() {
 	//suite.Equal([]string{"admin", "viewer"}, usrOut.Projects[0].Role)
 }
 
+func (suite *HandlerTestSuite) TestUserCreateDuplicateRef() {
+
+	postJSON := `{
+	"email":"email@foo.com",
+	"projects":[{"project":"ARGO","roles":["admin","viewer"]},{"project":"ARGO","roles":["admin","viewer"]}]
+}`
+
+	req, err := http.NewRequest("POST", "http://localhost:8080/v1/users/USERNEW", bytes.NewBuffer([]byte(postJSON)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expJSON := `{
+   "error": {
+      "code": 400,
+      "message": "duplicate reference of project ARGO",
+      "status": "INVALID_ARGUMENT"
+   }
+}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	mgr := oldPush.Manager{}
+	w := httptest.NewRecorder()
+	router.HandleFunc("/v1/users/{user}", WrapMockAuthConfig(UserCreate, cfgKafka, &brk, str, &mgr, nil))
+	router.ServeHTTP(w, req)
+	suite.Equal(400, w.Code)
+	suite.Equal(expJSON, w.Body.String())
+}
+
 func (suite *HandlerTestSuite) TestRefreshToken() {
 
 	req, err := http.NewRequest("POST", "http://localhost:8080/v1/users/UserZ:refreshToken", nil)
@@ -249,6 +282,39 @@ func (suite *HandlerTestSuite) TestUserUpdate() {
 	suite.Equal("UPDATED_NAME", userOut.Name)
 	suite.Equal([]string{"service_admin"}, userOut.ServiceRoles)
 	suite.Equal("UserA", userOut.CreatedBy)
+
+}
+
+func (suite *HandlerTestSuite) TestUserUpdateDuplicate() {
+	postJSON := `{
+		"email":"email@foo.com",
+		"projects":[{"project":"ARGO","roles":["admin","viewer"]},{"project":"ARGO2","roles":["admin","viewer"]},{"project":"ARGO2","roles":["admin","viewer"]}]
+	}`
+
+	expJSON := `{
+   "error": {
+      "code": 400,
+      "message": "duplicate reference of project ARGO2",
+      "status": "INVALID_ARGUMENT"
+   }
+}`
+
+	req, err := http.NewRequest("PUT", "http://localhost:8080/v1/users/UserZ", bytes.NewBuffer([]byte(postJSON)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	mgr := oldPush.Manager{}
+	w := httptest.NewRecorder()
+	router.HandleFunc("/v1/users/{user}", WrapMockAuthConfig(UserUpdate, cfgKafka, &brk, str, &mgr, nil))
+	router.ServeHTTP(w, req)
+	suite.Equal(400, w.Code)
+	suite.Equal(expJSON, w.Body.String())
 
 }
 


### PR DESCRIPTION
# Issue 
Prohibit duplicate project references in user profiles when creatin a user and when updating a user

# Fix:
- Update `CreateUser` and `UpdateUser` methods in auth package to check for duplicate project references in input structs
- Update unit tests to demonstrate new checks