### PR TITLE
ARGO-2068 New API Call - Retrieve all schemas under a project

### DIFF
--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -5,7 +5,9 @@ import (
 	"strconv"
 
 	"errors"
+	"fmt"
 	"github.com/ARGOeu/argo-messaging/messages"
+	"strings"
 	"time"
 )
 
@@ -96,7 +98,9 @@ func (b *MockBroker) Publish(topic string, msg messages.Message) (string, string
 	b.MsgList = append(b.MsgList, payload)
 	off := b.GetMaxOffset(topic) - 1
 	msgID := strconv.FormatInt(off, 10)
-	return msgID, "argo_uuid.topic1", 0, int64(len(b.MsgList)), nil
+	// split the name that SHOULD come in the form of project_uuid.topic_name
+	s := strings.Split(topic, ".")
+	return msgID, fmt.Sprintf("%s.%s", s[0], s[1]), 0, int64(len(b.MsgList)), nil
 }
 
 // GetOffset returns a current topic's offset

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -27,6 +27,36 @@ tags:
     description: Available schemas under a project for validating published messages payload
 paths:
 
+  /projects/{PROJECT}/schemas:
+    get:
+      summary: Retrieve all schemas under a project
+      description: |
+        Retrieve all schemas under a project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+      tags:
+        - Schemas
+      responses:
+        200:
+          description: A List of schemas
+          schema:
+            $ref: '#/definitions/SchemaList'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/schemas/{SCHEMA}:
     post:
       summary: Create a new schema
@@ -1886,6 +1916,14 @@ responses:
       $ref: '#/definitions/ErrorMsg'
 
 definitions:
+
+  SchemaList:
+    type: object
+    properties:
+      schemas:
+        type: array
+        items:
+          $ref: '#/definitions/Schema'
 
   Schema:
     type: object

--- a/doc/v1/docs/api_schemas.md
+++ b/doc/v1/docs/api_schemas.md
@@ -58,6 +58,91 @@ Success Response
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+## [GET] Manage Schemas - Retrieve All Schemas
+This request retrieves all schemas under the given project.
+
+### Request
+```json
+GET "/v1/projects/{project_name}/schemas"
+```
+
+### Where
+- project_name: Name of the project in which the schema will belong
+
+### Example request
+```json
+curl -X GET -H "Content-Type: application/json"
+ " https://{URL}/v1/projects/project-1/schemas?key=S3CR3T"
+```
+
+### Responses  
+
+If successful, the response contains all the schemas of the given project.
+
+Success Response
+`200 OK`
+```json
+{
+  "schemas": [
+  {
+    "uuid": "50811bd1-c94c-4ad7-8f55-a561c6270b50",
+    "name": "projects/project-1/schemas/schema-1",
+    "type": "json",
+    "schema": {
+        "properties": {
+            "address": {
+                "type": "string"
+            },
+            "email": {
+                "type": "string"
+            },
+            "name": {
+                "type": "string"
+            },
+            "telephone": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "name",
+            "email"
+        ],
+        "type": "object"
+    }
+  },
+  {
+    "uuid": "50811bd1-c94c-4ad7-8f55-a561c6270b55",
+    "name": "projects/project-1/schemas/schema-2",
+    "type": "json",
+    "schema": {
+        "properties": {
+            "address": {
+                "type": "string"
+            },
+            "email": {
+                "type": "string"
+            },
+            "name": {
+                "type": "string"
+            },
+            "telephone": {
+                "type": "string"
+            }
+        },
+        "required": [
+            "name",
+            "email"
+        ],
+        "type": "object"
+    }
+  }
+ ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
 ## [POST] Manage Schemas - Create new Schema
 This request creates a new schema
 

--- a/handlers.go
+++ b/handlers.go
@@ -3507,6 +3507,30 @@ func SchemaListOne(w http.ResponseWriter, r *http.Request) {
 	respondOK(w, output)
 }
 
+// SchemaLisAll(GET) retrieves all the schemas under the given project
+func SchemaListAll(w http.ResponseWriter, r *http.Request) {
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab context references
+	refStr := gorillaContext.Get(r, "str").(stores.Store)
+
+	// Get project UUID First to use as reference
+	projectUUID := gorillaContext.Get(r, "auth_project_uuid").(string)
+	schemasList, err := schemas.Find(projectUUID, "", "", refStr)
+	if err != nil {
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	output, _ := json.MarshalIndent(schemasList, "", " ")
+	respondOK(w, output)
+}
+
 // SchemaUpdate(PUT) updates the given schema
 func SchemaUpdate(w http.ResponseWriter, r *http.Request) {
 

--- a/routing.go
+++ b/routing.go
@@ -116,6 +116,7 @@ var defaultRoutes = []APIRoute{
 	{"topics:modifyAcl", "POST", "/projects/{project}/topics/{topic}:modifyAcl", TopicModACL},
 	{"schemas:create", "POST", "/projects/{project}/schemas/{schema}", SchemaCreate},
 	{"schemas:show", "GET", "/projects/{project}/schemas/{schema}", SchemaListOne},
+	{"schemas:list", "GET", "/projects/{project}/schemas", SchemaListAll},
 	{"schemas:update", "PUT", "/projects/{project}/schemas/{schema}", SchemaUpdate},
 	{"schemas:delete", "DELETE", "/projects/{project}/schemas/{schema}", SchemaDelete},
 }


### PR DESCRIPTION
- Added a new http handler **SchemaLIstAll** that returns all the schemas under the provided project.

- url: **/projects/{project}/schemas**

- Utilized the already existing **schemas.Find()** function that returns all schemas if the only argument is the **project_uuid**.