### PR TITLE
ARGO-2090 Add version info in argo-messaging binary

### DIFF
--- a/argo-messaging.spec
+++ b/argo-messaging.spec
@@ -29,7 +29,9 @@ export GOPATH=$PWD
 export PATH=$PATH:$GOPATH/bin
 
 cd src/github.com/ARGOeu/argo-messaging/
-go install
+export GIT_COMMIT=$(git rev-list -1 HEAD)
+export BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+go install -ldflags "-X github.com/ARGOeu/argo-messaging/version.Commit=$GIT_COMMIT -X github.com/ARGOeu/argo-messaging/version.BuildTime=$BUILD_TIME"
 
 %install
 %{__rm} -rf %{buildroot}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1823,6 +1823,21 @@ paths:
           $ref: "#/responses/404"
         500:
           $ref: "#/responses/500"
+  
+  /version:
+    get:
+      summary: "List API Version information"
+      description: "List api version information such as release version, commit hash etc"
+      tags:
+        - Version
+      produces:
+        - "application/json"
+        - "application/xml"
+      responses:
+        200:
+          description: "Successful retrieval of version info"
+          schema:
+            $ref: "#/definitions/Version"
 
 parameters:
   ApiKey:
@@ -1994,22 +2009,9 @@ definitions:
         type: string
       value:
         type: string
+        
+  
 
-  SubMetrics:
-    type: object
-    properties:
-      mumber_of_messages:
-        type: integer
-      total_bytes:
-        type: integer
-
-  TopicMetrics:
-    type: object
-    properties:
-      mumber_of_messages:
-        type: integer
-      total_bytes:
-        type: integer
 
   AuthUsers:
     type: object
@@ -2107,8 +2109,6 @@ definitions:
       current:
        type: integer
        description: current offset
-
-
 
   RetryPolicy:
     type: object
@@ -2321,3 +2321,21 @@ definitions:
           status:
             type: string
             description: status of the error
+            
+  Version:
+    type: object
+    properties:
+      release:
+        type: string
+      commit: 
+        type: string        
+      build_time: 
+        type: string
+      golang:
+        type: string
+      compiler: 
+        type: string
+      os: 
+        type: string
+      architecture:
+          type: string

--- a/doc/v1/docs/api_version.md
+++ b/doc/v1/docs/api_version.md
@@ -1,0 +1,35 @@
+# List API Version Information
+
+This method can be used to retrieve api version information
+
+## Input
+
+```
+GET /v1/version
+```
+
+### Request headers
+
+```
+Accept: application/json
+```
+
+## Response
+
+Headers: `Status: 200 OK`
+
+## Response Body
+
+Json Response
+
+```json
+{
+    "release": "1.0.5",
+    "commit": "f9f2e8c5f02lbcc94fe76b0d3cfa5d20d9365444",
+    "build_time": "2019-11-01T12:51:04Z",
+    "golang": "go1.11.5",
+    "compiler": "gc",
+    "os": "linux",
+    "architecture": "amd64"
+}
+```

--- a/doc/v1/docs/index.md
+++ b/doc/v1/docs/index.md
@@ -20,6 +20,7 @@ API Calls
 -   [Subscriptions](api_subs.md)
 -   [Metrics](api_metrics.md)
 -   [Schemas](api_schemas.md)
+-   [Version Information](api_version.md)
 
 Frequent Questions
 

--- a/handlers.go
+++ b/handlers.go
@@ -22,11 +22,13 @@ import (
 	"github.com/ARGOeu/argo-messaging/metrics"
 	"github.com/ARGOeu/argo-messaging/projects"
 	oldPush "github.com/ARGOeu/argo-messaging/push"
-	"github.com/ARGOeu/argo-messaging/push/grpc/client"
+	push "github.com/ARGOeu/argo-messaging/push/grpc/client"
 	"github.com/ARGOeu/argo-messaging/schemas"
 	"github.com/ARGOeu/argo-messaging/stores"
 	"github.com/ARGOeu/argo-messaging/subscriptions"
 	"github.com/ARGOeu/argo-messaging/topics"
+	"github.com/ARGOeu/argo-messaging/version"
+
 	gorillaContext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	"github.com/twinj/uuid"
@@ -3643,6 +3645,34 @@ func SchemaDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondOK(w, nil)
+}
+
+// ListVersion displays version information about the service
+func ListVersion(w http.ResponseWriter, r *http.Request) {
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	v := version.Model{
+		Release:   version.Release,
+		Commit:    version.Commit,
+		BuildTime: version.BuildTime,
+		GO:        version.GO,
+		Compiler:  version.Compiler,
+		OS:        version.OS,
+		Arch:      version.Arch,
+	}
+
+	output, err := json.MarshalIndent(v, "", " ")
+	if err != nil {
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+	respondOK(w, output)
+
 }
 
 // Respond utility functions

--- a/main.go
+++ b/main.go
@@ -8,8 +8,9 @@ import (
 	"github.com/ARGOeu/argo-messaging/brokers"
 	"github.com/ARGOeu/argo-messaging/config"
 	oldPush "github.com/ARGOeu/argo-messaging/push"
-	"github.com/ARGOeu/argo-messaging/push/grpc/client"
+	push "github.com/ARGOeu/argo-messaging/push/grpc/client"
 	"github.com/ARGOeu/argo-messaging/stores"
+	"github.com/ARGOeu/argo-messaging/version"
 	"github.com/gorilla/handlers"
 	log "github.com/sirupsen/logrus"
 )
@@ -21,9 +22,14 @@ func init() {
 			FullTimestamp: true,
 			DisableColors: true},
 	)
+
+	// display binary version information during start up
+	version.LogInfo()
+
 }
 
 func main() {
+
 	// create and load configuration object
 	cfg := config.NewAPICfg("LOAD")
 

--- a/routing.go
+++ b/routing.go
@@ -47,7 +47,7 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *o
 		handler = WrapLog(handler, route.Name)
 
 		// skip authentication/authorization for the health status and profile api calls
-		if route.Name != "ams:healthStatus" && "users:profile" != route.Name {
+		if route.Name != "ams:healthStatus" && "users:profile" != route.Name && route.Name != "version:list" {
 			handler = WrapAuthorize(handler, route.Name)
 			handler = WrapAuthenticate(handler)
 		}
@@ -70,6 +70,7 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *o
 
 // Global list populated with default routes
 var defaultRoutes = []APIRoute{
+
 	{"ams:metrics", "GET", "/metrics", OpMetrics},
 	{"ams:healthStatus", "GET", "/status", HealthCheck},
 	{"ams:dailyMessageAverage", "GET", "/metrics/daily-message-average", DailyMessageAverage},
@@ -119,4 +120,5 @@ var defaultRoutes = []APIRoute{
 	{"schemas:list", "GET", "/projects/{project}/schemas", SchemaListAll},
 	{"schemas:update", "PUT", "/projects/{project}/schemas/{schema}", SchemaUpdate},
 	{"schemas:delete", "DELETE", "/projects/{project}/schemas/{schema}", SchemaDelete},
+	{"version:list", "GET", "/version", ListVersion},
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,52 @@
+package version
+
+import (
+	"runtime"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// Release version of the service. Bump it up during new version release
+	Release = "1.0.5"
+	// Commit hash provided during build
+	Commit = "Unknown"
+	// BuildTime provided during build
+	BuildTime = "Unknown"
+	// GO provides golang version
+	GO = runtime.Version()
+	// Compiler info
+	Compiler = runtime.Compiler
+	// OS Info
+	OS = runtime.GOOS
+	// Arch info
+	Arch = runtime.GOARCH
+)
+
+// LogInfo can be used to log version information during startup or termination etc...
+func LogInfo() {
+
+	log.WithFields(
+		log.Fields{
+			"type":         "service_log",
+			"release":      Release,
+			"commit":       Commit,
+			"build_time":   BuildTime,
+			"go":           GO,
+			"compiler":     Compiler,
+			"os":           OS,
+			"architecture": "Arch",
+		},
+	).Infof("Running Argo Messaging v%s (%s/%s)", Release, OS, Arch)
+}
+
+// Model struct holds version information about the binary build
+type Model struct {
+	Release   string `xml:"release" json:"release"`
+	Commit    string `xml:"commit" json:"commit"`
+	BuildTime string `xml:"build_time" json:"build_time"`
+	GO        string `xml:"golang" json:"golang"`
+	Compiler  string `xml:"compiler" json:"compiler"`
+	OS        string `xml:"os" json:"os"`
+	Arch      string `xml:"architecture" json:"architecture"`
+}


### PR DESCRIPTION
Add version information in argo-messaging binary (in the same way as in argo-web-api https://github.com/ARGOeu/argo-web-api/pull/299)

## Goal 
Add version information to binary
Allow to use `/v1/version` to get version information in following format 
```
{
    "release": "1.0.5",
    "commit": "115745ad92cc2495c03dd91d724740ddda1a47c6",
    "build_time": "2019-11-21T12:51:04Z",
    "golang": "go1.11.5",
    "compiler": "gc",
    "os": "linux",
    "architecture": "amd64"
}
```
## Implementation
- [x] Add simple version pacakge with version related vars
- [x] Use ldflags during build time to inject commit hash and build in binary
- [x] Add api routing and handler to display version information
- [x] Display version information in log during start-up
- [x] Change build section in spec file
- [x] Update docs
- [x] Update swagger