### PR TITLE
ARGO-2086 Idea for argo-messaging: add validate action to schema resource

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -57,6 +57,53 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}/schemas/{SCHEMA}:validate:
+    post:
+      summary: Validate a specific message against the provided schema
+      description: |
+        Validate explicitily a message against the provided schema.This API call is to be used to test
+        that the registered schema and the messages that are expected to be published to the resepctive topic later on,
+        work as expected.
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: SCHEMA
+          in: path
+          description: Name of the schema
+          required: true
+          type: string
+        - name: Message
+          in: body
+          description: Schema information
+          required: true
+          schema:
+           type: object
+      tags:
+        - Schemas
+      responses:
+        200:
+          description: Message is succesfully validated
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                default: "Message validated successfully"
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/schemas/{SCHEMA}:
     post:
       summary: Create a new schema

--- a/doc/v1/docs/api_schemas.md
+++ b/doc/v1/docs/api_schemas.md
@@ -323,3 +323,50 @@ Success Response
 
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+## [POST] Manage Schemas - Validate Message 
+This request is used whenever we want to test a message against a schema.
+The process to check that your schema and messages are working as expected is to create
+a new topic that needs to be associated with the schema, then create the message in bas64 encoding and
+publish it to the topic.Instead of creating all this pipeline in order to check your schema and messages
+we can explicitly do it on this API call.
+
+### Request
+```json
+POST "/v1/projects/{project_name}/schemas/{schema_name}:validate"
+```
+
+### Where
+- project_name: Name of the project under which the schema belongs
+- schema_name: Name of the schema to be updated
+
+### Example request
+```json
+curl -X POST -H "Content-Type: application/json -d POSTDATA"
+ " https://{URL}/v1/projects/project-1/schemas/schema-1:validate?key=S3CR3T"
+```
+
+### Post body:
+
+```json
+{
+  "name": "name1",
+  "email": "e1@example.com",
+  "address": "address1",
+  "telephone": "6980574421"
+}
+```
+
+### Responses  
+
+
+Success Response
+`200 OK`
+```json
+{
+    "message": "Message validated successfully"
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/routing.go
+++ b/routing.go
@@ -115,6 +115,7 @@ var defaultRoutes = []APIRoute{
 	{"topics:delete", "DELETE", "/projects/{project}/topics/{topic}", TopicDelete},
 	{"topics:publish", "POST", "/projects/{project}/topics/{topic}:publish", TopicPublish},
 	{"topics:modifyAcl", "POST", "/projects/{project}/topics/{topic}:modifyAcl", TopicModACL},
+	{"schemas:validateMessage", "POST", "/projects/{project}/schemas/{schema}:validate", SchemaValidateMessage},
 	{"schemas:create", "POST", "/projects/{project}/schemas/{schema}", SchemaCreate},
 	{"schemas:show", "GET", "/projects/{project}/schemas/{schema}", SchemaListOne},
 	{"schemas:list", "GET", "/projects/{project}/schemas", SchemaListAll},

--- a/schemas/schema.go
+++ b/schemas/schema.go
@@ -19,7 +19,7 @@ const (
 	GenericError           = "Could not load schema for topic"
 )
 
-// schema holds information regarding a schema that will be used to validate a topic's published messages
+// Schema holds information regarding a schema that will be used to validate a topic's published messages
 type Schema struct {
 	ProjectUUID string                 `json:"-"`
 	UUID        string                 `json:"uuid"`


### PR DESCRIPTION
- Add a new API call to explicitly validate a message against a registered schema
  route: (POST) **/projects/{project}/schemas/{schema}:validate**
 The post body of the request should be the message it self.
 e.g. { "email": "email1", "name": "n1"}
- Added a new http handler **SchemaValidateMessage** that converts the message to an internal
  **messages.MsgList** in order to use the already existing **schemas.ValidateMessages**
- Updated swagger,mkdocs and tests.
