### PR TITLE
DEVOPS-57 Add downstream job build at post build steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,4 +81,13 @@ pipeline {
             }
         } 
     }
+    post{
+        success {
+            script{
+                if ( env.BRANCH_NAME == 'devel' ) {
+                    build job: '../../argo_swagger_docs', propagate: false
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR contains the trigger of the swagger doc generation job in case of a successful build at the devel branch.