### PR TITLE
DEVOPS-54 Execute each stage on different container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,14 @@
 pipeline {
-    agent { 
-        docker { 
-            image 'argo.registry:5000/epel-7-mgo' 
+    agent {
+        docker {
+            image 'argo.registry:5000/epel-7-mgo'
             args '-u jenkins:jenkins'
         }
     }
-    options { checkoutToSubdirectory('argo-messaging') }
+    options {
+        checkoutToSubdirectory('argo-messaging')
+        newContainerPerStage()
+    }
     environment {
         PROJECT_DIR="argo-messaging"
         GOPATH="${WORKSPACE}/go"


### PR DESCRIPTION
By adding newContainerPerStage() option we force jenkins to execute in a freshly spawned container for each stage. The container that it will be used is the one specified at the top level if there isn't specified any stage specific image. 