### PR TITLE
ARGO-2364 Allow project admin to add users to its project

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -706,6 +706,55 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /projects/{PROJECT}/members/{USER}:add:
+    post:
+      summary: Add a user to the project
+      description: |
+        Add a user to the project
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - name: PROJECT
+          in: path
+          description: Name of the project
+          required: true
+          type: string
+        - name: USER
+          in: path
+          description: Name of the user
+          required: true
+          type: string
+        - name: User information
+          in: body
+          description: Extra user information such as roles and email
+          required: false
+          schema:
+           type: object
+           properties:
+             projects:
+               type: array
+               items:
+                 $ref: "#/definitions/ProjectRoles"
+      tags:
+        - Projects
+      responses:
+        200:
+          description: A User object
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        404:
+          $ref: "#/responses/404"
+        409:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
+
+
   /projects/{PROJECT}/members/{USER}:remove:
     post:
       summary: Remove a user from the respective project
@@ -738,8 +787,6 @@ paths:
           $ref: "#/responses/403"
         404:
           $ref: "#/responses/404"
-        409:
-          $ref: "#/responses/409"
         500:
           $ref: "#/responses/500"
   /users:

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -439,6 +439,61 @@ Success Response
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
+### [POST] Add/Invite a user to a project
+
+### Example request
+```
+curl -X POST -H "Content-Type: application/json"
+  -d POSTDATA "https://{URL}/v1/projects/ARGO2/members/NewUser:add?key=S3CR3T"
+```
+
+### Post body:
+
+```json
+{
+  "roles": ["consumer"],
+   "topics": ["topic1"],
+   "subscriptions": ["sub1"]
+}
+```
+
+### Responses  
+If successful, the response contains information about the added user
+
+Success Response
+`200 OK`
+
+```json
+{
+
+       "uuid": "99bfd746-4ebe-11e8-9c2d-fa7ae01bbebw",
+       "projects": [
+          {
+             "project": "ARGO2",
+             "roles": [
+                "consumer"
+             ],
+             "topics": [
+                "topic1"
+             ],
+             "subscriptions": [
+                "sub1"
+             ]
+          }
+       ],
+       "name": "NewUSer",
+       "token": "S3CR3T",
+       "email": "email@test.com",
+       "service_roles": [],
+       "created_on": "2009-11-10T23:00:00Z",
+       "modified_on": "2009-11-10T23:00:00Z"
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+
 ### [POST] Remove a user from the project
 
 ### Example request

--- a/routing.go
+++ b/routing.go
@@ -85,6 +85,7 @@ var defaultRoutes = []APIRoute{
 	{"users:delete", "DELETE", "/users/{user}", UserDelete},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:metrics", "GET", "/projects/{project}:metrics", ProjectMetrics},
+	{"projects:addUser", "POST", "/projects/{project}/members/{user}:add", ProjectUserAdd},
 	{"projects:removeUser", "POST", "/projects/{project}/members/{user}:remove", ProjectUserRemove},
 	{"projects:showUser", "GET", "/projects/{project}/members/{user}", ProjectUserListOne},
 	{"projects:createUser", "POST", "/projects/{project}/members/{user}", ProjectUserCreate},


### PR DESCRIPTION
New api call that allows a project admin to add members/users to its project.

URL: /v1/projects/{{project}}/members/{{user}}:add

body: 
{
  "roles": ["consumer"],
   "topics": ["topic1"],
   "subscriptions": ["sub1"]
}

- The user needs to exist in the AMS
- The user must not already be a user of the project