### PR TITLE
ARGO-2373 New API Call - User register

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -815,6 +815,27 @@ func (suite *AuthTestSuite) TestGetPushWorkerToken() {
 	suite.Equal("push_500", err4.Error())
 }
 
+func (suite *AuthTestSuite) TestRegisterUser() {
+
+	store := stores.NewMockStore("", "")
+
+	ur, err := RegisterUser("ruuid1", "n1", "f1", "l1", "e1", "o1", "d1", "time", "atkn", PendingRegistrationStatus, store)
+	suite.Nil(err)
+	suite.Equal(UserRegistration{
+		UUID:            "ruuid1",
+		Name:            "n1",
+		FirstName:       "f1",
+		LastName:        "l1",
+		Email:           "e1",
+		Organization:    "o1",
+		Description:     "d1",
+		RegisteredAt:    "time",
+		ActivationToken: "atkn",
+		Status:          PendingRegistrationStatus,
+	}, ur)
+
+}
+
 func TestAuthTestSuite(t *testing.T) {
 	suite.Run(t, new(AuthTestSuite))
 }

--- a/auth/users.go
+++ b/auth/users.go
@@ -15,6 +15,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	AcceptedRegistrationStatus = "accepted"
+	PendingRegistrationStatus  = "pending"
+	RejectedRegistrationStatus = "rejected"
+)
+
 // User is the struct that holds user information
 type User struct {
 	UUID         string         `json:"uuid"`
@@ -50,6 +56,20 @@ type PaginatedUsers struct {
 	Users         []User `json:"users"`
 	NextPageToken string `json:"nextPageToken"`
 	TotalSize     int32  `json:"totalSize"`
+}
+
+// UserRegistration holds information about a new user registration
+type UserRegistration struct {
+	UUID            string `json:"uuid"`
+	Name            string `json:"name"`
+	FirstName       string `json:"first_name"`
+	LastName        string `json:"last_name"`
+	Organization    string `json:"organization"`
+	Description     string `json:"description"`
+	Email           string `json:"email"`
+	Status          string `json:"status"`
+	ActivationToken string `json:"activation_token"`
+	RegisteredAt    string `json:"registered_at"`
 }
 
 // ExportJSON exports User to json format
@@ -91,6 +111,28 @@ func GetUserFromJSON(input []byte) (User, error) {
 	u := User{}
 	err := json.Unmarshal([]byte(input), &u)
 	return u, err
+}
+
+// RegisterUser registers a new user to the store
+func RegisterUser(uuid, name, fname, lname, email, org, desc, registeredAt, atkn, status string, str stores.Store) (UserRegistration, error) {
+
+	err := str.RegisterUser(uuid, name, fname, lname, email, org, desc, registeredAt, atkn, status)
+	if err != nil {
+		return UserRegistration{}, err
+	}
+
+	return UserRegistration{
+		UUID:            uuid,
+		Name:            name,
+		FirstName:       fname,
+		LastName:        lname,
+		Email:           email,
+		Organization:    org,
+		Description:     desc,
+		RegisteredAt:    registeredAt,
+		ActivationToken: atkn,
+		Status:          status,
+	}, nil
 }
 
 // NewUser accepts parameters and creates a new user

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -25,7 +25,40 @@ tags:
     description: Projects available in the service
   - name: Schemas
     description: Available schemas under a project for validating published messages payload
+  - name: Registrations
+    description: User registrations
 paths:
+
+  /registrations/{USER}:
+    post:
+      summary: Register a new user
+      description: |
+        Register a new user
+      parameters:
+        - name: USER
+          in: path
+          description: Username
+          required: true
+          type: string
+        - name: User information
+          in: body
+          description: Extra user  information
+          required: true
+          schema:
+            $ref: "#/definitions/UserRegistration"
+      tags:
+        - Registrations
+      responses:
+        200:
+          description: User registration object
+          schema:
+            $ref: '#/definitions/UserRegistration'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/409"
+        500:
+          $ref: "#/responses/500"
 
   /projects/{PROJECT}/schemas:
     get:
@@ -2154,6 +2187,30 @@ responses:
       $ref: '#/definitions/ErrorMsg'
 
 definitions:
+
+  UserRegistration:
+     type: object
+     properties:
+       uuid:
+        type: string
+       name:
+        type: string
+       email:
+        type: string
+       first_name:
+        type: string
+       last_name:
+        type: string
+       organization:
+        type: string
+       description:
+        type: string
+       activation_token:
+        type: string
+       status:
+        type: string
+       registered_at:
+        type: string
 
   SchemaList:
     type: object

--- a/doc/v1/docs/api_registrations.md
+++ b/doc/v1/docs/api_registrations.md
@@ -1,0 +1,53 @@
+#Registrations API Calls
+
+ARGO Messaging Service supports calls for registering users
+
+## [POST] Manage Registrations - New user registration
+This request creates a new registration for a future user
+
+### Request
+```json
+POST "/v1/registrations
+```
+
+### Post body:
+```json
+{
+   "name": "new-register-user",
+  "first_name": "first-name",
+  "last_name": "last-name",
+  "email": "test@example.com",
+  "organization": "org1",
+  "description": "desc1"
+}
+```
+
+
+
+### Example request
+```bash
+curl -X POST -H "Content-Type: application/json"
+"https://{URL}/v1/registrations
+```
+
+### Responses  
+If successful, the response contains the newly registered user
+
+Success Response
+`200 OK`
+
+```json
+{
+   "uuid": "99bfd746-4ebe-11p0-9c2d-fa7ae01bbebc",
+   "name": "new-register-user",
+   "first_name": "first-name",
+   "last_name": "last-name",
+   "organization": "org1",
+   "description": "desc1",
+   "email": "test@example.com",
+   "activation_token": "a-token",
+   "status": "pending",
+   "registered_at": "2009-11-10T23:00:00Z"
+}
+```
+

--- a/doc/v1/docs/index.md
+++ b/doc/v1/docs/index.md
@@ -21,6 +21,7 @@ API Calls
 -   [Metrics](api_metrics.md)
 -   [Schemas](api_schemas.md)
 -   [Version Information](api_version.md)
+-   [Registrations](api_registrations.md)
 
 Frequent Questions
 

--- a/handlers.go
+++ b/handlers.go
@@ -1690,6 +1690,74 @@ func UserDelete(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// RegisterUser(POST) registers a new user
+func RegisterUser(w http.ResponseWriter, r *http.Request) {
+
+	// Init output
+	output := []byte("")
+
+	// Add content type header to the response
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+
+	// Grab context references
+	refStr := gorillaContext.Get(r, "str").(stores.Store)
+
+	// Read POST JSON body
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		err := APIErrorInvalidRequestBody()
+		respondErr(w, err)
+		return
+	}
+
+	// Parse pull options
+	requestBody := auth.UserRegistration{}
+	err = json.Unmarshal(body, &requestBody)
+	if err != nil {
+		err := APIErrorInvalidArgument("User")
+		respondErr(w, err)
+		return
+	}
+
+	// check if a user with that name already exists
+	if auth.ExistsWithName(requestBody.Name, refStr) {
+		err := APIErrorConflict("User")
+		respondErr(w, err)
+		return
+	}
+
+	uuid := uuid.NewV4().String()
+	registered := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	tkn, err := auth.GenToken()
+	if err != nil {
+		err := APIErrGenericInternal("")
+		respondErr(w, err)
+		return
+	}
+
+	ur, err := auth.RegisterUser(uuid, requestBody.Name, requestBody.FirstName, requestBody.LastName, requestBody.Email,
+		requestBody.Organization, requestBody.Description, registered, tkn, auth.PendingRegistrationStatus, refStr)
+
+	if err != nil {
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	output, err = json.MarshalIndent(ur, "", "   ")
+	if err != nil {
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	respondOK(w, output)
+}
+
 // SubAck (GET) one subscription
 func SubAck(w http.ResponseWriter, r *http.Request) {
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1723,6 +1723,93 @@ func (suite *HandlerTestSuite) TestProjectUserListUnprivARGO() {
 
 }
 
+func (suite *HandlerTestSuite) TestRegisterUser() {
+
+	type td struct {
+		postBody           string
+		expectedResponse   string
+		expectedStatusCode int
+		msg                string
+	}
+
+	testData := []td{
+		{
+			postBody: `{
+							"name": "new-register-user",
+							"first_name": "first-name",
+							"last_name": "last-name",
+							"email": "test@example.com",
+							"organization": "org1",
+							"description": "desc1"
+					   }`,
+			expectedResponse: `{
+   "uuid": "{{UUID}}",
+   "name": "new-register-user",
+   "first_name": "first-name",
+   "last_name": "last-name",
+   "organization": "org1",
+   "description": "desc1",
+   "email": "test@example.com",
+   "status": "pending",
+   "activation_token": "{{ATKN}}",
+   "registered_at": "{{REAT}}"
+}`,
+			expectedStatusCode: 200,
+			msg:                "User registration successful",
+		},
+		{
+			postBody: `{
+							"name": "UserA",
+							"first_name": "new-name",
+							"last_name": "last-name",
+							"email": "test@example.com",
+							"organization": "org1",
+							"description": "desc1"
+					   }`,
+			expectedResponse: `{
+   "error": {
+      "code": 409,
+      "message": "User already exists",
+      "status": "ALREADY_EXISTS"
+   }
+}`,
+			expectedStatusCode: 409,
+			msg:                "user already exists",
+		},
+	}
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+	cfgKafka.PushEnabled = true
+	cfgKafka.PushWorkerToken = "push_token"
+	cfgKafka.ResAuth = false
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	mgr := oldPush.Manager{}
+	pc := new(push.MockClient)
+
+	for _, t := range testData {
+
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", "http://localhost:8080/v1/registrations", strings.NewReader(t.postBody))
+		if err != nil {
+			log.Fatal(err)
+		}
+		router.HandleFunc("/v1/registrations", WrapMockAuthConfig(RegisterUser, cfgKafka, &brk, str, &mgr, pc))
+		router.ServeHTTP(w, req)
+		if t.expectedStatusCode == 200 {
+			t.expectedResponse = strings.Replace(t.expectedResponse, "{{UUID}}", str.UserRegistrations[0].UUID, 1)
+			t.expectedResponse = strings.Replace(t.expectedResponse, "{{REAT}}", str.UserRegistrations[0].RegisteredAt, 1)
+			t.expectedResponse = strings.Replace(t.expectedResponse, "{{ATKN}}", str.UserRegistrations[0].ActivationToken, 1)
+
+		}
+		suite.Equal(t.expectedStatusCode, w.Code, t.msg)
+		suite.Equal(t.expectedResponse, w.Body.String(), t.msg)
+	}
+
+}
+
 func (suite *HandlerTestSuite) TestProjectUserCreate() {
 
 	type td struct {

--- a/routing.go
+++ b/routing.go
@@ -83,6 +83,7 @@ var defaultRoutes = []APIRoute{
 	{"users:create", "POST", "/users/{user}", UserCreate},
 	{"users:update", "PUT", "/users/{user}", UserUpdate},
 	{"users:delete", "DELETE", "/users/{user}", UserDelete},
+	{"registrations:newUser", "POST", "/registrations", RegisterUser},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:metrics", "GET", "/projects/{project}:metrics", ProjectMetrics},
 	{"projects:addUser", "POST", "/projects/{project}/members/{user}:add", ProjectUserAdd},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -11,6 +11,7 @@ import (
 type MockStore struct {
 	Server             string
 	Database           string
+	UserRegistrations  []QUserRegister
 	SubList            []QSub
 	TopicList          []QTopic
 	DailyTopicMsgCount []QDailyTopicMsgCount
@@ -79,6 +80,25 @@ func (mk *MockStore) InsertUser(uuid string, projects []QProjectRoles, name stri
 		CreatedBy:    createdBy,
 	}
 	mk.UserList = append(mk.UserList, user)
+	return nil
+}
+
+func (mk *MockStore) RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error {
+
+	ur := QUserRegister{
+		UUID:            uuid,
+		Name:            name,
+		FirstName:       firstName,
+		LastName:        lastName,
+		Email:           email,
+		Organization:    org,
+		Description:     desc,
+		RegisteredAt:    registeredAt,
+		ActivationToken: atkn,
+		Status:          status,
+	}
+
+	mk.UserRegistrations = append(mk.UserRegistrations, ur)
 	return nil
 }
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -148,6 +148,25 @@ func (mong *MongoStore) UpdateProject(projectUUID string, name string, descripti
 
 }
 
+// RegisterUser inserts a new user registration to the database
+func (mong *MongoStore) RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error {
+
+	ur := QUserRegister{
+		UUID:            uuid,
+		Name:            name,
+		FirstName:       firstName,
+		LastName:        lastName,
+		Email:           email,
+		Organization:    org,
+		Description:     desc,
+		RegisteredAt:    registeredAt,
+		ActivationToken: atkn,
+		Status:          status,
+	}
+
+	return mong.InsertResource("user_registrations", ur)
+}
+
 // UpdateUserToken updates user's token
 func (mong *MongoStore) UpdateUserToken(uuid string, token string) error {
 

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -48,6 +48,20 @@ type QProject struct {
 	Description string    `bson:"description"`
 }
 
+// QUserRegister holds information about a UserRegister query
+type QUserRegister struct {
+	UUID            string `bson:"uuid"`
+	Name            string `bson:"name"`
+	FirstName       string `bson:"first_name"`
+	LastName        string `bson:"last_name"`
+	Organization    string `bson:"organization"`
+	Description     string `bson:"description"`
+	Email           string `bson:"email"`
+	ActivationToken string `bson:"activation_token"`
+	Status          string `bson:"status"`
+	RegisteredAt    string `bson:"registered_at"`
+}
+
 // QUser are the results of the QUser query
 type QUser struct {
 	ID           interface{}     `bson:"_id,omitempty"`

--- a/stores/store.go
+++ b/stores/store.go
@@ -1,6 +1,8 @@
 package stores
 
-import "time"
+import (
+	"time"
+)
 
 // Store encapsulates the generic store interface
 type Store interface {
@@ -30,6 +32,7 @@ type Store interface {
 	RemoveProjectSubs(projectUUID string) error
 	QueryDailyProjectMsgCount(projectUUID string) ([]QDailyProjectMsgCount, error)
 	QueryTotalMessagesPerProject(projectUUIDs []string, startDate time.Time, endDate time.Time) ([]QProjectMessageCount, error)
+	RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error
 	InsertUser(uuid string, projects []QProjectRoles, name string, firstName string, lastName string, org string, desc string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertOpMetric(hostname string, cpu float64, mem float64) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -592,6 +592,22 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("", qtd[0].SchemaUUID)
 	suite.Equal([]QSchema{}, expd)
 	suite.Nil(ed)
+
+	// test user registration
+	store.RegisterUser("ruuid1", "n1", "f1", "l1", "e1", "o1", "d1", "time", "atkn", "pending")
+	suite.Equal(1, len(store.UserRegistrations))
+	suite.Equal(QUserRegister{
+		UUID:            "ruuid1",
+		Name:            "n1",
+		FirstName:       "f1",
+		LastName:        "l1",
+		Email:           "e1",
+		Organization:    "o1",
+		Description:     "d1",
+		RegisteredAt:    "time",
+		ActivationToken: "atkn",
+		Status:          "pending",
+	}, store.UserRegistrations[0])
 }
 
 func TestStoresTestSuite(t *testing.T) {


### PR DESCRIPTION
Added a new API Call that will allow users to register for an account in the AMS

URL: POST - /registrations

body: 
{
 "name": "username-1",
  "first_name": "first-name",
  "last_name": "last-name",
  "email": "test@example.com",
  "organization": "org1",
  "description": "desc1"
}

The service will also add two additional fields that will be needed by further API calls which are,

**activation_token** and **status**.