### PR TITLE
ARGO-2374 New API Call - Accept a user's registration

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -836,6 +836,57 @@ func (suite *AuthTestSuite) TestRegisterUser() {
 
 }
 
+func (suite *AuthTestSuite) TestFindUserRegistration() {
+
+	store := stores.NewMockStore("", "")
+
+	ur1, e1 := FindUserRegistration("ur-uuid1", "pending", store)
+	expur1 := UserRegistration{
+		UUID:            "ur-uuid1",
+		Name:            "urname",
+		FirstName:       "urfname",
+		LastName:        "urlname",
+		Organization:    "urorg",
+		Description:     "urdesc",
+		Email:           "uremail",
+		ActivationToken: "uratkn-1",
+		Status:          "pending",
+		RegisteredAt:    "2019-05-12T22:26:58Z",
+		ModifiedBy:      "UserA",
+		ModifiedAt:      "2020-05-15T22:26:58Z",
+	}
+	suite.Nil(e1)
+	suite.Equal(expur1, ur1)
+
+	// not found
+	_, e2 := FindUserRegistration("unknown", "pending", store)
+	suite.Equal(errors.New("not found"), e2)
+}
+
+func (suite *AuthTestSuite) TestUpdateUserRegistration() {
+
+	store := stores.NewMockStore("", "")
+	m := time.Date(2020, 8, 5, 11, 33, 45, 0, time.UTC)
+	e1 := UpdateUserRegistration("ur-uuid1", AcceptedRegistrationStatus, "uuid1", m, store)
+	ur1, _ := FindUserRegistration("ur-uuid1", "accepted", store)
+	expur1 := UserRegistration{
+		UUID:            "ur-uuid1",
+		Name:            "urname",
+		FirstName:       "urfname",
+		LastName:        "urlname",
+		Organization:    "urorg",
+		Description:     "urdesc",
+		Email:           "uremail",
+		ActivationToken: "",
+		Status:          "accepted",
+		RegisteredAt:    "2019-05-12T22:26:58Z",
+		ModifiedBy:      "UserA",
+		ModifiedAt:      "2020-08-05T11:33:45Z",
+	}
+	suite.Nil(e1)
+	suite.Equal(expur1, ur1)
+}
+
 func TestAuthTestSuite(t *testing.T) {
 	suite.Run(t, new(AuthTestSuite))
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -60,6 +60,31 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /registrations/{UUID}:accept:
+    post:
+      summary: Accepts the registration for a new user
+      description: |
+        Register a new user
+      parameters:
+        - name: UUID
+          in: path
+          description: UUID of the registration
+          required: true
+          type: string
+      tags:
+        - Registrations
+      responses:
+        200:
+          description: Newly created user object
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/404"
+        500:
+          $ref: "#/responses/500"
+
   /projects/{PROJECT}/schemas:
     get:
       summary: Retrieve all schemas under a project
@@ -2210,6 +2235,10 @@ definitions:
        status:
         type: string
        registered_at:
+        type: string
+       modified_at:
+        type: string
+       modified_by:
         type: string
 
   SchemaList:

--- a/doc/v1/docs/api_registrations.md
+++ b/doc/v1/docs/api_registrations.md
@@ -47,7 +47,51 @@ Success Response
    "email": "test@example.com",
    "activation_token": "a-token",
    "status": "pending",
-   "registered_at": "2009-11-10T23:00:00Z"
+   "registered_at": "2009-11-10T23:00:00Z",
+   "modified_at": "2009-11-10T23:00:00Z",
+   "modified_by": "UserA"
 }
 ```
 
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+## [POST] Manage Registrations - Accept a User's Registration
+This request accepts a user's registration 
+and as a result it creates a new user with the provided information.
+
+### Request
+```json
+POST "/v1/registrations/{uuid}:accept"
+```
+
+### Example request
+```bash
+curl -X POST -H "Content-Type: application/json"
+"https://{URL}/v1/registrations/uuid1:accept"
+```
+
+### Responses  
+If successful, the response contains the newly created user
+
+Success Response
+`200 OK`
+
+```json
+{
+    "uuid": "1d0aa54e-44b8-4d2a-8cf7-d4cb2e350c61",
+    "projects": [],
+    "name": "user-acc-344",
+    "first_name": "fname",
+    "last_name": "lname",
+    "organization": "grnet",
+    "description": "simple user",
+    "token": "bb0ad3da48f69372e38e55e423324b7366e32804",
+    "email": "test@example.com",
+    "service_roles": [],
+    "created_on": "2020-05-17T22:27:09Z",
+    "modified_on": "2020-05-17T22:27:09Z"
+}
+```
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/handlers.go
+++ b/handlers.go
@@ -1758,6 +1758,72 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	respondOK(w, output)
 }
 
+// AcceptUserRegister (POST) accepts a user registration and creates the respective user
+func AcceptRegisterUser(w http.ResponseWriter, r *http.Request) {
+
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab url path variables
+	urlVars := mux.Vars(r)
+	regUUID := urlVars["uuid"]
+
+	// Grab context references
+	refStr := gorillaContext.Get(r, "str").(stores.Store)
+	refUserUUID := gorillaContext.Get(r, "auth_user_uuid").(string)
+
+	ru, err := auth.FindUserRegistration(regUUID, auth.PendingRegistrationStatus, refStr)
+	if err != nil {
+
+		if err.Error() == "not found" {
+			err := APIErrorNotFound("User registration")
+			respondErr(w, err)
+			return
+		}
+
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	userUUID := uuid.NewV4().String() // generate a new userUUID to attach to the new project
+	token, err := auth.GenToken()     // generate a new user token
+	created := time.Now().UTC()
+	// Get Result Object
+	res, err := auth.CreateUser(userUUID, ru.Name, ru.FirstName, ru.LastName, ru.Organization, ru.Description,
+		[]auth.ProjectRoles{}, token, ru.Email, []string{}, created, refUserUUID, refStr)
+
+	if err != nil {
+		if err.Error() == "exists" {
+			err := APIErrorConflict("User")
+			respondErr(w, err)
+			return
+		}
+
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	// update the registration
+	err = auth.UpdateUserRegistration(regUUID, auth.AcceptedRegistrationStatus, refUserUUID, created, refStr)
+	if err != nil {
+		log.Errorf("Could not update registration, %v", err.Error())
+	}
+
+	// Output result to JSON
+	resJSON, err := res.ExportJSON()
+	if err != nil {
+		err := APIErrExportJSON()
+		respondErr(w, err)
+		return
+	}
+
+	// Write response
+	respondOK(w, []byte(resJSON))
+}
+
 // SubAck (GET) one subscription
 func SubAck(w http.ResponseWriter, r *http.Request) {
 

--- a/routing.go
+++ b/routing.go
@@ -84,6 +84,7 @@ var defaultRoutes = []APIRoute{
 	{"users:update", "PUT", "/users/{user}", UserUpdate},
 	{"users:delete", "DELETE", "/users/{user}", UserDelete},
 	{"registrations:newUser", "POST", "/registrations", RegisterUser},
+	{"registrations:acceptNewUser", "POST", "/registrations/{uuid}:accept", AcceptRegisterUser},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:metrics", "GET", "/projects/{project}:metrics", ProjectMetrics},
 	{"projects:addUser", "POST", "/projects/{project}/members/{user}:add", ProjectUserAdd},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -11,7 +11,7 @@ import (
 type MockStore struct {
 	Server             string
 	Database           string
-	UserRegistrations  []QUserRegister
+	UserRegistrations  []QUserRegistration
 	SubList            []QSub
 	TopicList          []QTopic
 	DailyTopicMsgCount []QDailyTopicMsgCount
@@ -85,7 +85,7 @@ func (mk *MockStore) InsertUser(uuid string, projects []QProjectRoles, name stri
 
 func (mk *MockStore) RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error {
 
-	ur := QUserRegister{
+	ur := QUserRegistration{
 		UUID:            uuid,
 		Name:            name,
 		FirstName:       firstName,
@@ -99,6 +99,31 @@ func (mk *MockStore) RegisterUser(uuid, name, firstName, lastName, email, org, d
 	}
 
 	mk.UserRegistrations = append(mk.UserRegistrations, ur)
+	return nil
+}
+
+func (mk *MockStore) QueryRegistrations(regUUID, status string) ([]QUserRegistration, error) {
+
+	for idx, ur := range mk.UserRegistrations {
+		if ur.UUID == regUUID && ur.Status == status {
+			return []QUserRegistration{mk.UserRegistrations[idx]}, nil
+		}
+	}
+
+	return []QUserRegistration{}, nil
+}
+
+func (mk *MockStore) UpdateRegistration(regUUID, status, modifiedBy, modifiedAt string) error {
+
+	for idx, ur := range mk.UserRegistrations {
+		if ur.UUID == regUUID {
+			mk.UserRegistrations[idx].Status = status
+			mk.UserRegistrations[idx].ModifiedBy = modifiedBy
+			mk.UserRegistrations[idx].ModifiedAt = modifiedAt
+			mk.UserRegistrations[idx].ActivationToken = ""
+		}
+	}
+
 	return nil
 }
 
@@ -770,6 +795,23 @@ func (mk *MockStore) Initialize() {
 	mk.SubsACL["sub3"] = qSubACL03
 	mk.SubsACL["sub4"] = qSubACL04
 
+	// Populate user registrations
+	ur1 := QUserRegistration{
+		UUID:            "ur-uuid1",
+		Name:            "urname",
+		FirstName:       "urfname",
+		LastName:        "urlname",
+		Organization:    "urorg",
+		Description:     "urdesc",
+		Email:           "uremail",
+		ActivationToken: "uratkn-1",
+		Status:          "pending",
+		RegisteredAt:    "2019-05-12T22:26:58Z",
+		ModifiedBy:      "uuid1",
+		ModifiedAt:      "2020-05-15T22:26:58Z",
+	}
+
+	mk.UserRegistrations = append(mk.UserRegistrations, ur1)
 }
 
 func (mk *MockStore) QueryTotalMessagesPerProject(projectUUIDs []string, startDate time.Time, endDate time.Time) ([]QProjectMessageCount, error) {

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -151,7 +151,7 @@ func (mong *MongoStore) UpdateProject(projectUUID string, name string, descripti
 // RegisterUser inserts a new user registration to the database
 func (mong *MongoStore) RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error {
 
-	ur := QUserRegister{
+	ur := QUserRegistration{
 		UUID:            uuid,
 		Name:            name,
 		FirstName:       firstName,
@@ -165,6 +165,42 @@ func (mong *MongoStore) RegisterUser(uuid, name, firstName, lastName, email, org
 	}
 
 	return mong.InsertResource("user_registrations", ur)
+}
+
+func (mong *MongoStore) QueryRegistrations(regUUID, status string) ([]QUserRegistration, error) {
+
+	query := bson.M{
+		"uuid":   regUUID,
+		"status": status,
+	}
+
+	qur := []QUserRegistration{}
+
+	db := mong.Session.DB(mong.Database)
+	c := db.C("user_registrations")
+	err := c.Find(query).All(&qur)
+	if err != nil {
+		return qur, err
+	}
+
+	return qur, nil
+}
+
+func (mong *MongoStore) UpdateRegistration(regUUID, status, modifiedBy, modifiedAt string) error {
+
+	db := mong.Session.DB(mong.Database)
+	c := db.C("user_registrations")
+
+	ur := bson.M{"uuid": regUUID}
+	change := bson.M{
+		"$set": bson.M{
+			"status":           status,
+			"modified_by":      modifiedBy,
+			"modified_at":      modifiedAt,
+			"activation_token": "",
+		},
+	}
+	return c.Update(ur, change)
 }
 
 // UpdateUserToken updates user's token

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -48,8 +48,8 @@ type QProject struct {
 	Description string    `bson:"description"`
 }
 
-// QUserRegister holds information about a UserRegister query
-type QUserRegister struct {
+// QUserRegistration holds information about a UserRegister query
+type QUserRegistration struct {
 	UUID            string `bson:"uuid"`
 	Name            string `bson:"name"`
 	FirstName       string `bson:"first_name"`
@@ -60,6 +60,8 @@ type QUserRegister struct {
 	ActivationToken string `bson:"activation_token"`
 	Status          string `bson:"status"`
 	RegisteredAt    string `bson:"registered_at"`
+	ModifiedBy      string `bson:"modified_by"`
+	ModifiedAt      string `bson:"modified_at"`
 }
 
 // QUser are the results of the QUser query

--- a/stores/store.go
+++ b/stores/store.go
@@ -33,6 +33,8 @@ type Store interface {
 	QueryDailyProjectMsgCount(projectUUID string) ([]QDailyProjectMsgCount, error)
 	QueryTotalMessagesPerProject(projectUUIDs []string, startDate time.Time, endDate time.Time) ([]QProjectMessageCount, error)
 	RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error
+	QueryRegistrations(regUUID, status string) ([]QUserRegistration, error)
+	UpdateRegistration(regUUID, status, modifiedBy, modifiedAt string) error
 	InsertUser(uuid string, projects []QProjectRoles, name string, firstName string, lastName string, org string, desc string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertOpMetric(hostname string, cpu float64, mem float64) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -595,8 +595,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// test user registration
 	store.RegisterUser("ruuid1", "n1", "f1", "l1", "e1", "o1", "d1", "time", "atkn", "pending")
-	suite.Equal(1, len(store.UserRegistrations))
-	suite.Equal(QUserRegister{
+	expur1 := []QUserRegistration{{
 		UUID:            "ruuid1",
 		Name:            "n1",
 		FirstName:       "f1",
@@ -607,7 +606,29 @@ func (suite *StoreTestSuite) TestMockStore() {
 		RegisteredAt:    "time",
 		ActivationToken: "atkn",
 		Status:          "pending",
-	}, store.UserRegistrations[0])
+	}}
+
+	ur1, _ := store.QueryRegistrations("ruuid1", "pending")
+	suite.Equal(expur1, ur1)
+
+	expur2 := []QUserRegistration{{
+		UUID:            "ur-uuid1",
+		Name:            "urname",
+		FirstName:       "urfname",
+		LastName:        "urlname",
+		Organization:    "urorg",
+		Description:     "urdesc",
+		Email:           "uremail",
+		ActivationToken: "",
+		Status:          "accepted",
+		RegisteredAt:    "2019-05-12T22:26:58Z",
+		ModifiedBy:      "uuid1",
+		ModifiedAt:      "2020-05-17T22:26:58Z",
+	}}
+	store.UpdateRegistration("ur-uuid1", "accepted", "uuid1", "2020-05-17T22:26:58Z")
+	ur2, _ := store.QueryRegistrations("ur-uuid1", "accepted")
+	suite.Equal(expur2, ur2)
+
 }
 
 func TestStoresTestSuite(t *testing.T) {


### PR DESCRIPTION
Added a new API Call that will allow a service admin to accept a user's registration.
URL: POST - /registrations/{uuid}: accept

By accepting a user's registration, the service will also create the respective user with the information provided by the registration.

The registration itself will be updated with an accepted status, and the modified_at and modified_by will contain the timestamp of the action, and the service_Admin that performed it respectively.