### PR TITLE
ARGO-2381 New API Call - List all registrations

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -887,6 +887,38 @@ func (suite *AuthTestSuite) TestUpdateUserRegistration() {
 	suite.Equal(expur1, ur1)
 }
 
+func (suite *AuthTestSuite) TestFindUserRegistrations() {
+
+	store := stores.NewMockStore("", "")
+
+	r1, e1 := FindUserRegistrations("", "", "", "", "", store)
+	expur1 := UserRegistrationsList{
+		UserRegistrations: []UserRegistration{{
+			UUID:            "ur-uuid1",
+			Name:            "urname",
+			FirstName:       "urfname",
+			LastName:        "urlname",
+			Organization:    "urorg",
+			Description:     "urdesc",
+			Email:           "uremail",
+			ActivationToken: "uratkn-1",
+			Status:          "pending",
+			RegisteredAt:    "2019-05-12T22:26:58Z",
+			ModifiedBy:      "UserA",
+			ModifiedAt:      "2020-05-15T22:26:58Z",
+		},
+		},
+	}
+
+	suite.Nil(e1)
+	suite.Equal(expur1, r1)
+
+	r2, e2 := FindUserRegistrations("pending", "uratkn-1", "urname", "uremail", "urorg", store)
+	suite.Nil(e2)
+	suite.Equal(expur1, r2)
+
+}
+
 func TestAuthTestSuite(t *testing.T) {
 	suite.Run(t, new(AuthTestSuite))
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -35,6 +35,7 @@ paths:
       description: |
         Register a new user
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: User information
           in: body
           description: Extra user  information
@@ -58,6 +59,31 @@ paths:
           $ref: "#/responses/409"
         500:
           $ref: "#/responses/500"
+    get:
+      summary: Retrive all registrations in the service
+      description: |
+        Retrieve all registrations the service with or without any filters applied
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - $ref: '#/parameters/RegistrationStatus'
+        - $ref: '#/parameters/RegistrationActivationToken'
+        - $ref: '#/parameters/RegistrationName'
+        - $ref: '#/parameters/RegistrationEmail'
+        - $ref: '#/parameters/RegistrationOrganization'
+      tags:
+        - Registrations
+      responses:
+        200:
+          description: User registration list
+          schema:
+            $ref: '#/definitions/UserRegistrationList'
+        401:
+          $ref: "#/responses/409"
+        403:
+          $ref: "#/responses/403"
+        500:
+          $ref: "#/responses/500"
+
 
   /registrations/{UUID}:accept:
     post:
@@ -65,6 +91,7 @@ paths:
       description: |
         Register a new user
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: UUID
           in: path
           description: UUID of the registration
@@ -94,6 +121,7 @@ paths:
       description: |
         Decline a new user
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: UUID
           in: path
           description: UUID of the registration
@@ -123,6 +151,7 @@ paths:
       description: |
         Retrieves a user's registration
       parameters:
+        - $ref: '#/parameters/ApiKey'
         - name: UUID
           in: path
           description: UUID of the registration
@@ -2187,6 +2216,41 @@ parameters:
     required: true
     type: string
     default: SecretKey123
+  RegistrationStatus:
+    name: status
+    in: query
+    description: Filter registrations based on the provided status
+    required: false
+    type: string
+    default: ""
+  RegistrationActivationToken:
+    name: activation_token
+    in: query
+    description: Filter registrations based on the provided activation token
+    required: false
+    type: string
+    default: ""
+  RegistrationName:
+    name: name
+    in: query
+    description: Filter registrations based on the provided name
+    required: false
+    type: string
+    default: ""
+  RegistrationEmail:
+    name: email
+    in: query
+    description: Filter registrations based on the provided email
+    required: false
+    type: string
+    default: ""
+  RegistrationOrganization:
+    name: organization
+    in: query
+    description: Filter registrations based on the provided organization
+    required: false
+    type: string
+    default: ""
   PageToken:
     name: pageToken
     in: query
@@ -2299,6 +2363,14 @@ definitions:
         type: string
        modified_by:
         type: string
+
+  UserRegistrationList:
+    type: object
+    properties:
+      user_registrations:
+        type: array
+        items:
+          $ref: '#/definitions/UserRegistration'
 
   UserRegistrationPost:
      type: object

--- a/doc/v1/docs/api_registrations.md
+++ b/doc/v1/docs/api_registrations.md
@@ -160,3 +160,54 @@ Success Response
 ```
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+## [GET] Manage Registrations - Retrieve all registrations
+This request retrieves all registration in the service
+
+### Request
+```json
+GET "/v1/registrations"
+```
+
+### Optional Filters
+
+- status
+- activation_token
+- email
+- organization
+- name
+
+### Example request
+```bash
+curl -X GET -H "Content-Type: application/json"
+"https://{URL}/v1/registrations"
+```
+
+### Responses  
+If successful, the response contains all registrations
+
+Success Response
+`200 OK`
+
+```json
+{
+   "user_registrations": [
+   {
+      "uuid": "ur-uuid1",
+      "name": "urname",
+      "first_name": "urfname",
+      "last_name": "urlname",
+      "organization": "urorg",
+      "description": "urdesc",
+      "email": "uremail",
+      "status": "pending",
+      "activation_token": "uratkn-1",
+      "registered_at": "2019-05-12T22:26:58Z",
+      "modified_by": "UserA",
+      "modified_at": "2020-05-15T22:26:58Z"
+   }
+  ]
+}
+```
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/handlers.go
+++ b/handlers.go
@@ -1901,6 +1901,40 @@ func ListOneRegistration(w http.ResponseWriter, r *http.Request) {
 	respondOK(w, urb)
 }
 
+// ListAllRegistrations(GET) retrieves information about all the registrations in the service
+func ListAllRegistrations(w http.ResponseWriter, r *http.Request) {
+
+	contentType := "application/json"
+	charset := "utf-8"
+	w.Header().Add("Content-Type", fmt.Sprintf("%s; charset=%s", contentType, charset))
+
+	// Grab context references
+	refStr := gorillaContext.Get(r, "str").(stores.Store)
+
+	name := r.URL.Query().Get("name")
+	status := r.URL.Query().Get("status")
+	email := r.URL.Query().Get("email")
+	org := r.URL.Query().Get("organization")
+	activationToken := r.URL.Query().Get("activation_token")
+
+	ur, err := auth.FindUserRegistrations(status, activationToken, name, email, org, refStr)
+	if err != nil {
+
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	urb, err := json.MarshalIndent(ur, "", "   ")
+	if err != nil {
+		err := APIErrGenericInternal(err.Error())
+		respondErr(w, err)
+		return
+	}
+
+	respondOK(w, urb)
+}
+
 // SubAck (GET) one subscription
 func SubAck(w http.ResponseWriter, r *http.Request) {
 

--- a/routing.go
+++ b/routing.go
@@ -87,6 +87,7 @@ var defaultRoutes = []APIRoute{
 	{"registrations:acceptNewUser", "POST", "/registrations/{uuid}:accept", AcceptRegisterUser},
 	{"registrations:declineNewUser", "POST", "/registrations/{uuid}:decline", DeclineRegisterUser},
 	{"registrations:show", "GET", "/registrations/{uuid}", ListOneRegistration},
+	{"registrations:list", "GET", "/registrations", ListAllRegistrations},
 	{"projects:list", "GET", "/projects", ProjectListAll},
 	{"projects:metrics", "GET", "/projects/{project}:metrics", ProjectMetrics},
 	{"projects:addUser", "POST", "/projects/{project}/members/{user}:add", ProjectUserAdd},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -102,23 +102,76 @@ func (mk *MockStore) RegisterUser(uuid, name, firstName, lastName, email, org, d
 	return nil
 }
 
-func (mk *MockStore) QueryRegistrations(regUUID, status string) ([]QUserRegistration, error) {
+func (mk *MockStore) QueryRegistrations(regUUID, status, activationToken, name, email, org string) ([]QUserRegistration, error) {
 
-	if status != "" {
-		for idx, ur := range mk.UserRegistrations {
-			if ur.UUID == regUUID && ur.Status == status {
-				return []QUserRegistration{mk.UserRegistrations[idx]}, nil
+	if regUUID == "" && status == "" && activationToken == "" && name == "" && email == "" && org == "" {
+		return mk.UserRegistrations, nil
+	}
+
+	reqs := []QUserRegistration{}
+
+	if regUUID != "" {
+		for idx, req := range mk.UserRegistrations {
+			if req.UUID == regUUID {
+				reqs = append(reqs, mk.UserRegistrations[idx])
+				continue
 			}
 		}
 	} else {
-		for idx, ur := range mk.UserRegistrations {
-			if ur.UUID == regUUID {
-				return []QUserRegistration{mk.UserRegistrations[idx]}, nil
-			}
-		}
+		reqs = mk.UserRegistrations
 	}
 
-	return []QUserRegistration{}, nil
+	if status != "" {
+		tempReqs := []QUserRegistration{}
+		for idx, req := range reqs {
+			if req.Status == status {
+				tempReqs = append(tempReqs, reqs[idx])
+			}
+		}
+		reqs = tempReqs
+	}
+
+	if activationToken != "" {
+		tempReqs := []QUserRegistration{}
+		for idx, req := range reqs {
+			if req.ActivationToken == activationToken {
+				tempReqs = append(tempReqs, reqs[idx])
+			}
+		}
+		reqs = tempReqs
+	}
+
+	if name != "" {
+		tempReqs := []QUserRegistration{}
+		for idx, req := range reqs {
+			if req.Name == name {
+				tempReqs = append(tempReqs, reqs[idx])
+			}
+		}
+		reqs = tempReqs
+	}
+
+	if email != "" {
+		tempReqs := []QUserRegistration{}
+		for idx, req := range reqs {
+			if req.Email == email {
+				tempReqs = append(tempReqs, reqs[idx])
+			}
+		}
+		reqs = tempReqs
+	}
+
+	if org != "" {
+		tempReqs := []QUserRegistration{}
+		for idx, req := range reqs {
+			if req.Organization == org {
+				tempReqs = append(tempReqs, reqs[idx])
+			}
+		}
+		reqs = tempReqs
+	}
+
+	return reqs, nil
 }
 
 func (mk *MockStore) UpdateRegistration(regUUID, status, modifiedBy, modifiedAt string) error {

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -167,14 +167,32 @@ func (mong *MongoStore) RegisterUser(uuid, name, firstName, lastName, email, org
 	return mong.InsertResource("user_registrations", ur)
 }
 
-func (mong *MongoStore) QueryRegistrations(regUUID, status string) ([]QUserRegistration, error) {
+func (mong *MongoStore) QueryRegistrations(regUUID, status, activationToken, name, email, org string) ([]QUserRegistration, error) {
 
-	query := bson.M{
-		"uuid": regUUID,
+	query := bson.M{}
+
+	if regUUID != "" {
+		query["uuid"] = regUUID
 	}
 
 	if status != "" {
 		query["status"] = status
+	}
+
+	if activationToken != "" {
+		query["activation_token"] = activationToken
+	}
+
+	if name != "" {
+		query["name"] = name
+	}
+
+	if email != "" {
+		query["email"] = email
+	}
+
+	if org != "" {
+		query["organization"] = org
 	}
 
 	qur := []QUserRegistration{}

--- a/stores/store.go
+++ b/stores/store.go
@@ -33,7 +33,7 @@ type Store interface {
 	QueryDailyProjectMsgCount(projectUUID string) ([]QDailyProjectMsgCount, error)
 	QueryTotalMessagesPerProject(projectUUIDs []string, startDate time.Time, endDate time.Time) ([]QProjectMessageCount, error)
 	RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error
-	QueryRegistrations(regUUID, status string) ([]QUserRegistration, error)
+	QueryRegistrations(regUUID, status, activationToken, name, email, org string) ([]QUserRegistration, error)
 	UpdateRegistration(regUUID, status, modifiedBy, modifiedAt string) error
 	InsertUser(uuid string, projects []QProjectRoles, name string, firstName string, lastName string, org string, desc string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -608,10 +608,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 		Status:          "pending",
 	}}
 
-	ur1, _ := store.QueryRegistrations("ruuid1", "pending")
+	ur1, _ := store.QueryRegistrations("ruuid1", "pending", "atkn", "n1", "e1", "o1")
 	suite.Equal(expur1, ur1)
 
-	ur12, _ := store.QueryRegistrations("ruuid1", "")
+	ur12, _ := store.QueryRegistrations("ruuid1", "", "", "", "", "")
 	suite.Equal(expur1, ur12)
 
 	expur2 := []QUserRegistration{{
@@ -629,7 +629,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		ModifiedAt:      "2020-05-17T22:26:58Z",
 	}}
 	store.UpdateRegistration("ur-uuid1", "accepted", "uuid1", "2020-05-17T22:26:58Z")
-	ur2, _ := store.QueryRegistrations("ur-uuid1", "accepted")
+	ur2, _ := store.QueryRegistrations("ur-uuid1", "accepted", "", "", "", "")
 	suite.Equal(expur2, ur2)
 
 }


### PR DESCRIPTION
Added a new API Call that will retrieve all registrations in the service
URL: GET - /registrations

available optional filters:
- status
- activation_token
- name
- email
- organization

Response: {
"user_registrations": [
{
"uuid": "ur-uuid1",
"name": "urname",
"first_name": "urfname",
"last_name": "urlname",
"organization": "urorg",
"description": "urdesc",
"email": "uremail",
"status": "pending",
"activation_token": "uratkn-1",
"registered_at": "2019-05-12T22:26:58Z",
"modified_by": "UserA",
"modified_at": "2020-05-15T22:26:58Z"
}
]
}