### PR TITLE
ARGO-2649 Extend the health API Call to include push server connectivity errors

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -121,6 +121,10 @@ func (suite *AuthTestSuite) TestAuth() {
 	suite.Equal(true, IsPushWorker([]string{"push_worker", "publisher"}))
 	suite.Equal(false, IsPushWorker([]string{"publisher"}))
 
+	suite.Equal(true, IsAdminViewer([]string{"admin_viewer"}))
+	suite.Equal(true, IsAdminViewer([]string{"admin_viewer", "service_admin"}))
+	suite.Equal(false, IsAdminViewer([]string{"publisher"}))
+
 	// Check ValidUsers mechanism
 	v, err := AreValidUsers("ARGO", []string{"UserA", "foo", "bar"}, store)
 	suite.Equal(false, v)

--- a/auth/users.go
+++ b/auth/users.go
@@ -458,9 +458,7 @@ func PaginatedFindUsers(pageToken string, pageSize int32, projectUUID string, pr
 
 // Authenticate based on token
 func Authenticate(projectUUID string, token string, store stores.Store) ([]string, string) {
-	roles, user := store.GetUserRoles(projectUUID, token)
-
-	return roles, user
+	return store.GetUserRoles(projectUUID, token)
 }
 
 // ExistsWithName returns true if a user with name exists
@@ -794,6 +792,17 @@ func IsProjectAdmin(roles []string) bool {
 func IsServiceAdmin(roles []string) bool {
 	for _, role := range roles {
 		if role == "service_admin" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsAdminViewer checks if the user is an admon viewer
+func IsAdminViewer(roles []string) bool {
+	for _, role := range roles {
+		if role == "admin_viewer" {
 			return true
 		}
 	}

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -227,7 +227,7 @@ paths:
           description: Schema information
           required: true
           schema:
-           type: object
+            type: object
       tags:
         - Schemas
       responses:
@@ -272,12 +272,12 @@ paths:
           description: Schema information
           required: true
           schema:
-           type: object
-           properties:
-             schema:
-               type: object
-             type:
-               type: string
+            type: object
+            properties:
+              schema:
+                type: object
+              type:
+                type: string
       tags:
         - Schemas
       responses:
@@ -351,14 +351,14 @@ paths:
           description: Update one or all of the fields of a schema
           required: true
           schema:
-           type: object
-           properties:
-             schema:
-               type: object
-             name:
-              type: string
-             type:
-               type: string
+            type: object
+            properties:
+              schema:
+                type: object
+              name:
+                type: string
+              type:
+                type: string
       tags:
         - Schemas
       responses:
@@ -444,11 +444,14 @@ paths:
 
   /status:
     get:
-      summary: List operational metrics of the ams service
+      summary: List the health status for ams and push server
       description: |
-        list operational metrics
+        list health status
+      parameters:
+        - $ref: '#/parameters/Details'
+        - $ref: '#/parameters/ApiKeyDetails'
       tags:
-        - Operational Metrics
+        - Health Check
       responses:
         200:
           description: Returns the health status
@@ -561,10 +564,10 @@ paths:
           description: Extra project information such as description
           required: true
           schema:
-           type: object
-           properties:
-             description:
-               type: string
+            type: object
+            properties:
+              description:
+                type: string
 
       tags:
         - Projects
@@ -600,12 +603,12 @@ paths:
           description: Extra project information such as description
           required: true
           schema:
-           type: object
-           properties:
-             name:
-               type: string
-             description:
-               type: string
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
       tags:
         - Projects
       responses:
@@ -778,14 +781,14 @@ paths:
           description: Extra user information such as roles and email
           required: false
           schema:
-           type: object
-           properties:
-             projects:
-               type: array
-               items:
-                 $ref: "#/definitions/ProjectRoles"
-             email:
-               type: string
+            type: object
+            properties:
+              projects:
+                type: array
+                items:
+                  $ref: "#/definitions/ProjectRoles"
+              email:
+                type: string
       tags:
         - Projects
       responses:
@@ -826,12 +829,12 @@ paths:
           description: Extra user information such as roles and email
           required: false
           schema:
-           type: object
-           properties:
-             projects:
-               type: array
-               items:
-                 $ref: "#/definitions/ProjectRoles"
+            type: object
+            properties:
+              projects:
+                type: array
+                items:
+                  $ref: "#/definitions/ProjectRoles"
       tags:
         - Projects
       responses:
@@ -874,12 +877,12 @@ paths:
           description: Extra user information such as roles and email
           required: false
           schema:
-           type: object
-           properties:
-             projects:
-               type: array
-               items:
-                 $ref: "#/definitions/ProjectRoles"
+            type: object
+            properties:
+              projects:
+                type: array
+                items:
+                  $ref: "#/definitions/ProjectRoles"
       tags:
         - Projects
       responses:
@@ -1010,18 +1013,18 @@ paths:
           description: Extra user information such as roles and email
           required: false
           schema:
-           type: object
-           properties:
-             projects:
-               type: array
-               items:
-                 $ref: "#/definitions/ProjectRoles"
-             email:
-               type: string
-             service_roles:
-               type: array
-               items:
-                 type: string
+            type: object
+            properties:
+              projects:
+                type: array
+                items:
+                  $ref: "#/definitions/ProjectRoles"
+              email:
+                type: string
+              service_roles:
+                type: array
+                items:
+                  type: string
       tags:
         - Users
       responses:
@@ -1056,26 +1059,26 @@ paths:
           description: Extra user information such as roles and email
           required: false
           schema:
-           type: object
-           properties:
-             projects:
-               type: array
-               items:
-                 $ref: "#/definitions/ProjectRoles"
-             first_name:
-               type: string
-             last_name:
-               type: string
-             description:
-               type: string
-             organization:
-               type: string
-             email:
-               type: string
-             service_roles:
-               type: array
-               items:
-                 type: string
+            type: object
+            properties:
+              projects:
+                type: array
+                items:
+                  $ref: "#/definitions/ProjectRoles"
+              first_name:
+                type: string
+              last_name:
+                type: string
+              description:
+                type: string
+              organization:
+                type: string
+              email:
+                type: string
+              service_roles:
+                type: array
+                items:
+                  type: string
       tags:
         - Users
       responses:
@@ -1359,7 +1362,7 @@ paths:
           description: Parameters of the new subscription object
           required: true
           schema:
-           $ref: '#/definitions/SubParameters'
+            $ref: '#/definitions/SubParameters'
       tags:
         - Subscriptions
       responses:
@@ -1475,7 +1478,7 @@ paths:
           description: List of authorized users
           required: true
           schema:
-           $ref: '#/definitions/AuthUsers'
+            $ref: '#/definitions/AuthUsers'
       tags:
         - Subscriptions
       responses:
@@ -1518,7 +1521,7 @@ paths:
           description: Offset
           required: true
           schema:
-           $ref: '#/definitions/Offset'
+            $ref: '#/definitions/Offset'
       tags:
         - Subscriptions
       responses:
@@ -1560,7 +1563,7 @@ paths:
           description: AckDeadline
           required: true
           schema:
-           $ref: '#/definitions/AckDeadline'
+            $ref: '#/definitions/AckDeadline'
       tags:
         - Subscriptions
       responses:
@@ -1681,7 +1684,7 @@ paths:
           description: Parameters to be used during pull
           required: true
           schema:
-           $ref: '#/definitions/PullOptions'
+            $ref: '#/definitions/PullOptions'
       tags:
         - Subscriptions
       responses:
@@ -1723,7 +1726,7 @@ paths:
           description: Parameters to be used during acknowledgement
           required: true
           schema:
-           $ref: '#/definitions/AckIDs'
+            $ref: '#/definitions/AckIDs'
       tags:
         - Subscriptions
       responses:
@@ -1765,7 +1768,7 @@ paths:
           description: Parameters to be used during acknowledgement
           required: true
           schema:
-           $ref: '#/definitions/PushConfigRef'
+            $ref: '#/definitions/PushConfigRef'
       tags:
         - Subscriptions
       responses:
@@ -1843,7 +1846,7 @@ paths:
           description: push status
           required: true
           schema:
-           $ref: '#/definitions/PushStatus'
+            $ref: '#/definitions/PushStatus'
       tags:
         - Subscriptions
       responses:
@@ -1985,10 +1988,10 @@ paths:
           description: The name of the schema to be linked with the topic.All published messages will be validated against the linked schema.
           required: false
           schema:
-           type: object
-           properties:
-             schema:
-               type: string
+            type: object
+            properties:
+              schema:
+                type: string
       tags:
         - Topics
       responses:
@@ -2071,7 +2074,7 @@ paths:
           description: Message JSON representation
           required: true
           schema:
-           $ref: '#/definitions/Messages'
+            $ref: '#/definitions/Messages'
       tags:
         - Topics
       responses:
@@ -2182,7 +2185,7 @@ paths:
           description: List of authorized users
           required: true
           schema:
-           $ref: '#/definitions/AuthUsers'
+            $ref: '#/definitions/AuthUsers'
       tags:
         - Topics
       responses:
@@ -2224,6 +2227,20 @@ parameters:
     required: true
     type: string
     default: SecretKey123
+  ApiKeyDetails:
+    name: key
+    in: query
+    description: user key token for authentication when accesing the url parameter details
+    required: false
+    type: string
+    default: ""
+  Details:
+    name: details
+    in: query
+    description: report detailed error for ams push server
+    required: false
+    type: boolean
+    default: false
   RegistrationStatus:
     name: status
     in: query
@@ -2328,14 +2345,14 @@ responses:
       $ref: '#/definitions/ErrorMsg'
 
   409_no_topic:
-      description: Subscription's topic doesn't exist
-      schema:
-        $ref: '#/definitions/ErrorMsg'
+    description: Subscription's topic doesn't exist
+    schema:
+      $ref: '#/definitions/ErrorMsg'
 
   409_no_offset_for_time:
-      description: Timestamp is out of bounds for the subscription's topic/partition
-      schema:
-        $ref: '#/definitions/ErrorMsg'
+    description: Timestamp is out of bounds for the subscription's topic/partition
+    schema:
+      $ref: '#/definitions/ErrorMsg'
 
   500:
     description: Internal Error
@@ -2345,31 +2362,31 @@ responses:
 definitions:
 
   UserRegistration:
-     type: object
-     properties:
-       uuid:
+    type: object
+    properties:
+      uuid:
         type: string
-       name:
+      name:
         type: string
-       email:
+      email:
         type: string
-       first_name:
+      first_name:
         type: string
-       last_name:
+      last_name:
         type: string
-       organization:
+      organization:
         type: string
-       description:
+      description:
         type: string
-       activation_token:
+      activation_token:
         type: string
-       status:
+      status:
         type: string
-       registered_at:
+      registered_at:
         type: string
-       modified_at:
+      modified_at:
         type: string
-       modified_by:
+      modified_by:
         type: string
 
   UserRegistrationList:
@@ -2381,19 +2398,19 @@ definitions:
           $ref: '#/definitions/UserRegistration'
 
   UserRegistrationPost:
-     type: object
-     properties:
-       name:
+    type: object
+    properties:
+      name:
         type: string
-       email:
+      email:
         type: string
-       first_name:
+      first_name:
         type: string
-       last_name:
+      last_name:
         type: string
-       organization:
+      organization:
         type: string
-       description:
+      description:
         type: string
 
   SchemaList:
@@ -2439,12 +2456,12 @@ definitions:
         type: integer
 
   Metrics:
-   type: object
-   properties:
-     metrics:
-       type: array
-       items:
-         $ref: '#/definitions/Metric'
+    type: object
+    properties:
+      metrics:
+        type: array
+        items:
+          $ref: '#/definitions/Metric'
 
   Metric:
     type: object
@@ -2473,8 +2490,8 @@ definitions:
         type: string
       value:
         type: string
-        
-  
+
+
 
 
   AuthUsers:
@@ -2483,7 +2500,7 @@ definitions:
       authorized_users:
         type: array
         items:
-         type: string
+          type: string
 
   PullOptions:
     type: object
@@ -2515,7 +2532,7 @@ definitions:
         type: string
         description: Name of the topic
       pushConfig:
-            $ref: '#/definitions/PushConfig'
+        $ref: '#/definitions/PushConfig'
       ackDeadlineSeconds:
         type: integer
         description: maximum wait time in seconds for Acknowledgement
@@ -2523,7 +2540,7 @@ definitions:
     type: object
     properties:
       pushConfig:
-         $ref: '#/definitions/PushConfig'
+        $ref: '#/definitions/PushConfig'
   PushConfig:
     type: object
     properties:
@@ -2551,38 +2568,38 @@ definitions:
     type: object
     properties:
       ackDeadlineSeconds:
-       type: integer
-       description: deadline to acknowledge a pulled message (in seconds)
+        type: integer
+        description: deadline to acknowledge a pulled message (in seconds)
 
   Offset:
     type: object
     properties:
       offset:
-       type: integer
-       description: offset number of current subscriptions
+        type: integer
+        description: offset number of current subscriptions
 
   Offsets:
     type: object
     properties:
       min:
-       type: integer
-       description: minimum offset
+        type: integer
+        description: minimum offset
       max:
-       type: integer
-       description: max offset
+        type: integer
+        description: max offset
       current:
-       type: integer
-       description: current offset
+        type: integer
+        description: current offset
 
   RetryPolicy:
     type: object
     properties:
-     type:
-       type: string
-       description: type of the retry policy used (Only linear policy supported)
-     period:
-       type: integer
-       description: period of retry policy in milliseconds
+      type:
+        type: string
+        description: type of the retry policy used (Only linear policy supported)
+      period:
+        type: integer
+        description: period of retry policy in milliseconds
 
   Topic:
     type: object
@@ -2667,17 +2684,17 @@ definitions:
           $ref: '#/definitions/Project'
 
   Project:
-     type: object
-     properties:
-       name:
+    type: object
+    properties:
+      name:
         type: string
-       created_on:
+      created_on:
         type: string
-       modified_on:
+      modified_on:
         type: string
-       created_by:
+      created_by:
         type: string
-       description:
+      description:
         type: string
 
   Users:
@@ -2693,64 +2710,64 @@ definitions:
         type: integer
 
   User:
-     type: object
-     properties:
-       uuid:
+    type: object
+    properties:
+      uuid:
         type: string
-       name:
+      name:
         type: string
-       first_name:
+      first_name:
         type: string
-       last_name:
+      last_name:
         type: string
-       organization:
+      organization:
         type: string
-       description:
+      description:
         type: string
-       projects:
+      projects:
         type: array
         items:
-           $ref: '#/definitions/ProjectRoles'
-       token:
+          $ref: '#/definitions/ProjectRoles'
+      token:
         type: string
-       email:
+      email:
         type: string
-       service_roles:
+      service_roles:
         type: array
         items:
           type: string
-       created_on:
+      created_on:
         type: string
-       modified_on:
+      modified_on:
         type: string
-       created_by:
+      created_by:
         type: string
 
   ProjectRoles:
-      type: object
-      properties:
-        project:
+    type: object
+    properties:
+      project:
+        type: string
+      roles:
+        type: array
+        items:
           type: string
-        roles:
-          type: array
-          items:
-            type: string
 
   MessageIDs:
-     type: object
-     properties:
-       messageIds:
-         type: array
-         items:
-           type: string
+    type: object
+    properties:
+      messageIds:
+        type: array
+        items:
+          type: string
 
   AckIDs:
-     type: object
-     properties:
-       ackIds:
-         type: array
-         items:
-           type: string
+    type: object
+    properties:
+      ackIds:
+        type: array
+        items:
+          type: string
 
   HealthCheck:
     type: object
@@ -2793,21 +2810,21 @@ definitions:
           status:
             type: string
             description: status of the error
-            
+
   Version:
     type: object
     properties:
       release:
         type: string
-      commit: 
-        type: string        
-      build_time: 
+      commit:
+        type: string
+      build_time:
         type: string
       golang:
         type: string
-      compiler: 
+      compiler:
         type: string
-      os: 
+      os:
         type: string
       architecture:
-          type: string
+        type: string

--- a/doc/v1/docs/api_health.md
+++ b/doc/v1/docs/api_health.md
@@ -1,0 +1,45 @@
+# Service health check for ams and push server
+
+This method can be used to retrieve api information regarding the proper functionality
+of the ams service and the push server
+
+## [GET] Get Health status
+
+### Request
+```
+GET "/v1/status"
+```
+
+### Example request
+
+- `details=(true|false)` indicates if we need detailed
+information about errors regarding the push server.
+
+- A user token corresponding to a `service_admin` or `admin_viewer`
+has to be provided when using the `details` parameter.
+
+```
+curl -H "Content-Type: application/json"
+ "https://{URL}/v1/status?details=true&key=token"
+```
+
+### Responses
+If successful, the response returns the health status of the service
+
+Success Response
+`200 OK`
+
+```json
+{
+  "status": "ok",
+  "push_servers": [
+    {
+      "endpoint": "localhost:5555",
+      "status": "Success: SERVING"
+    }
+  ]
+}
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/doc/v1/docs/api_metrics.md
+++ b/doc/v1/docs/api_metrics.md
@@ -62,41 +62,6 @@ Success Response
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
-## [GET] Get Health status
-
-### Request
-```
-GET "/v1/status"
-```
-
-### Example request
-
-```
-curl -H "Content-Type: application/json"
- "https://{URL}/v1/status"
-```
-
-### Responses
-If successful, the response returns the health status of the service
-
-Success Response
-`200 OK`
-
-```json
-{
-  "status": "ok",
-  "push_servers": [
-    {
-      "endpoint": "localhost:5555",
-      "status": "Success: SERVING"
-    }
-  ]
-}
-```
-
-### Errors
-Please refer to section [Errors](api_errors.md) to see all possible Errors
-
 ## [GET] Get Daily Message Average
 
 This request returns the total amount of messages per project for the given time window.The number of messages

--- a/doc/v1/docs/index.md
+++ b/doc/v1/docs/index.md
@@ -21,6 +21,7 @@ API Calls
 -   [Metrics](api_metrics.md)
 -   [Schemas](api_schemas.md)
 -   [Version Information](api_version.md)
+-   [Health Status](api_health.md)
 -   [Registrations](api_registrations.md)
 
 Frequent Questions

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -5030,11 +5030,11 @@ func (suite *HandlerTestSuite) TestProjectMessageCount() {
   {
    "project": "ARGO",
    "message_count": 30,
-   "average_daily_messages": 10
+   "average_daily_messages": 7
   }
  ],
  "total_message_count": 30,
- "average_daily_messages": 10
+ "average_daily_messages": 7
 }`
 
 	cfgKafka := config.NewAPICfg()

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -189,10 +189,14 @@ func (suite *ProjectsTestSuite) TestGetProjectsMessageCount() {
 	// test total message count per project
 	expectedTmpc := TotalProjectsMessageCount{
 		Projects: []ProjectMessageCount{
-			{Project: "ARGO", MessageCount: 60, AverageDailyMessages: 20},
+			{
+				Project:              "ARGO",
+				MessageCount:         60,
+				AverageDailyMessages: 15,
+			},
 		},
 		TotalCount:           60,
-		AverageDailyMessages: 20,
+		AverageDailyMessages: 15,
 	}
 
 	tmpc, tmpcerr := GetProjectsMessageCount(

--- a/push/grpc/client/client.go
+++ b/push/grpc/client/client.go
@@ -30,7 +30,7 @@ type GrpcClientStatus struct {
 }
 
 // Result prints the result of an grpc request
-func (st *GrpcClientStatus) Result() string {
+func (st *GrpcClientStatus) Result(details bool) string {
 
 	grpcStatus := status.Convert(st.err)
 
@@ -45,7 +45,11 @@ func (st *GrpcClientStatus) Result() string {
 				"backend_service": "ams-push-server",
 			},
 		).Error(grpcStatus.Message())
-		return "Push server is currently unavailable"
+		if details {
+			return grpcStatus.Message()
+		} else {
+			return "Push server is currently unavailable"
+		}
 	}
 
 	return fmt.Sprintf("Error: %v", grpcStatus.Message())

--- a/push/grpc/client/client_test.go
+++ b/push/grpc/client/client_test.go
@@ -18,7 +18,7 @@ func (suite *ClientTestSuite) TestResult() {
 		err:     nil,
 		message: "ok message",
 	}
-	suite.Equal("ok message", grpcStatus.Result())
+	suite.Equal("ok message", grpcStatus.Result(false))
 
 	// error status
 	grpcStatus2 := GrpcClientStatus{
@@ -26,7 +26,23 @@ func (suite *ClientTestSuite) TestResult() {
 		message: "",
 	}
 
-	suite.Equal("Error: invalid argument", grpcStatus2.Result())
+	suite.Equal("Error: invalid argument", grpcStatus2.Result(false))
+
+	// unavailable error status
+	grpcStatus3 := GrpcClientStatus{
+		err:     status.Error(codes.Unavailable, "connection refused"),
+		message: "",
+	}
+
+	suite.Equal("Push server is currently unavailable", grpcStatus3.Result(false))
+
+	// unavailable detailed status
+	grpcStatus4 := GrpcClientStatus{
+		err:     status.Error(codes.Unavailable, "connection refused"),
+		message: "",
+	}
+
+	suite.Equal("connection refused", grpcStatus4.Result(true))
 }
 
 func TestClientTestSuite(t *testing.T) {

--- a/push/grpc/client/mock.go
+++ b/push/grpc/client/mock.go
@@ -77,6 +77,6 @@ type MockClientStatus struct {
 	Status string
 }
 
-func (m *MockClientStatus) Result() string {
+func (m *MockClientStatus) Result(details bool) string {
 	return m.Status
 }

--- a/push/grpc/client/pushclient.go
+++ b/push/grpc/client/pushclient.go
@@ -26,5 +26,5 @@ type Client interface {
 // ClientStatus represents responses from a push backend
 type ClientStatus interface {
 	// Result returns the string representation for the response from a push backend
-	Result() string
+	Result(details bool) string
 }

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -904,6 +904,9 @@ func (mk *MockStore) QueryTotalMessagesPerProject(projectUUIDs []string, startDa
 	days := int64(1)
 	if !endDate.Equal(startDate) {
 		days = int64(endDate.Sub(startDate).Hours() / 24)
+		// add an extra day to compensate for the fact that we need the starting day included as well
+		// e.g. Aug 1 to Aug 31 should be calculated as 31 days and not as 30
+		days += 1
 	}
 
 	if len(projectUUIDs) == 0 {

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -1320,6 +1320,9 @@ func (mong *MongoStore) QueryTotalMessagesPerProject(projectUUIDs []string, star
 	days := 1
 	if !endDate.Equal(startDate) {
 		days = int(endDate.Sub(startDate).Hours() / 24)
+		// add an extra day to compensate for the fact that we need the starting day included as well
+		// e.g. Aug 1 to Aug 31 should be calculated as 31 days and not as 30
+		days += 1
 	}
 
 	condQuery := []bson.M{
@@ -1381,8 +1384,6 @@ func (mong *MongoStore) QueryTotalMessagesPerProject(projectUUIDs []string, star
 			},
 		).Fatal(err.Error())
 	}
-
-	fmt.Printf("%+v\n", qdp)
 
 	return qdp, err
 }

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -543,7 +543,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// test QueryTotalMessagesPerProject
 	expectedQpmc := []QProjectMessageCount{
-		{ProjectUUID: "argo_uuid", NumberOfMessages: 30, AverageDailyMessages: 10},
+		{ProjectUUID: "argo_uuid", NumberOfMessages: 30, AverageDailyMessages: 7},
 	}
 	qpmc, qpmcerr1 := store2.QueryTotalMessagesPerProject([]string{"argo_uuid"}, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC), time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC))
 	suite.Equal(expectedQpmc, qpmc)


### PR DESCRIPTION
Add an extra url parameter, details that will indicate whether or not ams should return the detailed status from an erroneous connection with the push server.

When accessing the details URL parameter the user should also provide an API token key that corresponds to an admin_viewer or service_admin user.