### PR TITLE
ARGO-2705 Add extra topic field created_on

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -2619,6 +2619,9 @@ definitions:
       name:
         type: string
         description: Name of the topic
+      created_on:
+        type: string
+        description: creation date
 
   Topics:
     type: object

--- a/doc/v1/docs/api_topics.md
+++ b/doc/v1/docs/api_topics.md
@@ -37,7 +37,8 @@ Success Response
 `200 OK`
 ```json
 {
- "name": "projects/BRAND_NEW/topics/monitoring"
+ "name": "projects/BRAND_NEW/topics/monitoring",
+ "created_on": "2020-11-21T00:00:00Z"
 }
 ```
 
@@ -98,7 +99,9 @@ Success Response
 `200 OK`
 ```json
 {
- "name": "projects/BRAND_NEW/topics/monitoring"
+ "name": "projects/BRAND_NEW/topics/monitoring",
+ "created_on": "2020-11-21T00:00:00Z"
+
 }
 ```
 
@@ -149,10 +152,12 @@ Success Response
 {
   "topics": [
     {
-      "name":"/project/BRAND_NEW/topics/monitoring"
+      "name":"/project/BRAND_NEW/topics/monitoring",
+      "created_on": "2020-11-21T00:00:00Z"
     },
     {
-      "name":"/project/BRAND_NEW/topics/accounting"
+      "name":"/project/BRAND_NEW/topics/accounting",
+      "created_on": "2020-11-21T00:00:00Z"
     }
  ],
   "nextPageToken": "",
@@ -183,7 +188,8 @@ Success Response
 {
   "topics": [
     {
-      "name":"/project/BRAND_NEW/topics/monitoring"
+      "name":"/project/BRAND_NEW/topics/monitoring",
+      "created_on": "2020-11-21T00:00:00Z"
     }
  ],
   "nextPageToken": "some_token",
@@ -214,7 +220,8 @@ Success Response
 {
   "topics": [
     {
-      "name":"/project/BRAND_NEW/topics/accounting"
+      "name":"/project/BRAND_NEW/topics/accounting",
+      "created_on": "2020-11-21T00:00:00Z"
     }
  ],
   "nextPageToken": "",

--- a/handlers/topics.go
+++ b/handlers/topics.go
@@ -194,8 +194,11 @@ func TopicCreate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	created := time.Now().UTC()
+
 	// Get Result Object
-	res, err := topics.CreateTopic(projectUUID, urlVars["topic"], schemaUUID, refStr)
+	res, err := topics.CreateTopic(projectUUID, urlVars["topic"], schemaUUID, created, refStr)
 	if err != nil {
 		if err.Error() == "exists" {
 			err := APIErrorConflict("Topic")

--- a/handlers/topics_test.go
+++ b/handlers/topics_test.go
@@ -77,7 +77,8 @@ func (suite *TopicsHandlersTestSuite) TestTopicCreate() {
 	}
 
 	expResp := `{
-   "name": "/projects/ARGO/topics/topicNew"
+   "name": "/projects/ARGO/topics/topicNew",
+   "created_on": "{{CON}}"
 }`
 
 	cfgKafka := config.NewAPICfg()
@@ -87,11 +88,13 @@ func (suite *TopicsHandlersTestSuite) TestTopicCreate() {
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
 	mgr := oldPush.Manager{}
-
 	router.HandleFunc("/v1/projects/{project}/topics/{topic}", WrapMockAuthConfig(TopicCreate, cfgKafka, &brk, str, &mgr, nil))
 	router.ServeHTTP(w, req)
+	tp, _, _, _ := str.QueryTopics("argo_uuid", "", "topicNew", "", 1)
+	expResp = strings.Replace(expResp, "{{CON}}", tp[0].CreatedOn.Format("2006-01-02T15:04:05Z"), 1)
 	suite.Equal(200, w.Code)
 	suite.Equal(expResp, w.Body.String())
+
 }
 
 func (suite *TopicsHandlersTestSuite) TestTopicCreateExists() {
@@ -130,7 +133,8 @@ func (suite *TopicsHandlersTestSuite) TestTopicListOne() {
 	}
 
 	expResp := `{
-   "name": "/projects/ARGO/topics/topic1"
+   "name": "/projects/ARGO/topics/topic1",
+   "created_on": "2020-11-22T00:00:00Z"
 }`
 
 	cfgKafka := config.NewAPICfg()
@@ -328,18 +332,22 @@ func (suite *TopicsHandlersTestSuite) TestTopicListAll() {
 	expResp := `{
    "topics": [
       {
-         "name": "/projects/ARGO/topics/topic4"
+         "name": "/projects/ARGO/topics/topic4",
+         "created_on": "2020-11-19T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/topics/topic3",
-         "schema": "projects/ARGO/schemas/schema-3"
+         "schema": "projects/ARGO/schemas/schema-3",
+         "created_on": "2020-11-20T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/topics/topic2",
-         "schema": "projects/ARGO/schemas/schema-1"
+         "schema": "projects/ARGO/schemas/schema-1",
+         "created_on": "2020-11-21T00:00:00Z"
       },
       {
-         "name": "/projects/ARGO/topics/topic1"
+         "name": "/projects/ARGO/topics/topic1",
+         "created_on": "2020-11-22T00:00:00Z"
       }
    ],
    "nextPageToken": "",
@@ -371,10 +379,12 @@ func (suite *TopicsHandlersTestSuite) TestTopicListAllPublisher() {
    "topics": [
       {
          "name": "/projects/ARGO/topics/topic2",
-         "schema": "projects/ARGO/schemas/schema-1"
+         "schema": "projects/ARGO/schemas/schema-1",
+         "created_on": "2020-11-21T00:00:00Z"
       },
       {
-         "name": "/projects/ARGO/topics/topic1"
+         "name": "/projects/ARGO/topics/topic1",
+         "created_on": "2020-11-22T00:00:00Z"
       }
    ],
    "nextPageToken": "",
@@ -405,7 +415,8 @@ func (suite *TopicsHandlersTestSuite) TestTopicListAllPublisherWithPagination() 
    "topics": [
       {
          "name": "/projects/ARGO/topics/topic2",
-         "schema": "projects/ARGO/schemas/schema-1"
+         "schema": "projects/ARGO/schemas/schema-1",
+         "created_on": "2020-11-21T00:00:00Z"
       }
    ],
    "nextPageToken": "MA==",
@@ -629,11 +640,13 @@ func (suite *TopicsHandlersTestSuite) TestTopicListAllFirstPage() {
 	expResp := `{
    "topics": [
       {
-         "name": "/projects/ARGO/topics/topic4"
+         "name": "/projects/ARGO/topics/topic4",
+         "created_on": "2020-11-19T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/topics/topic3",
-         "schema": "projects/ARGO/schemas/schema-3"
+         "schema": "projects/ARGO/schemas/schema-3",
+         "created_on": "2020-11-20T00:00:00Z"
       }
    ],
    "nextPageToken": "MQ==",
@@ -664,7 +677,8 @@ func (suite *TopicsHandlersTestSuite) TestTopicListAllNextPage() {
 	expResp := `{
    "topics": [
       {
-         "name": "/projects/ARGO/topics/topic1"
+         "name": "/projects/ARGO/topics/topic1",
+         "created_on": "2020-11-22T00:00:00Z"
       }
    ],
    "nextPageToken": "",
@@ -987,7 +1001,8 @@ func (suite *TopicsHandlersTestSuite) TestValidationInTopics() {
 	str := stores.NewMockStore("whatever", "argo_mgs")
 
 	okResp := `{
-   "name": "/projects/ARGO/topics/topic1"
+   "name": "/projects/ARGO/topics/topic1",
+   "created_on": "2020-11-22T00:00:00Z"
 }`
 	invProject := `{
    "error": {

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -767,10 +767,10 @@ func (mk *MockStore) Initialize() {
 	mk.OpMetrics = make(map[string]QopMetric)
 
 	// populate topics
-	qtop4 := QTopic{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, ""}
-	qtop3 := QTopic{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3"}
-	qtop2 := QTopic{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1"}
-	qtop1 := QTopic{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""}
+	qtop4 := QTopic{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, "", time.Date(2020, 11, 19, 0, 0, 0, 0, time.Local)}
+	qtop3 := QTopic{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3", time.Date(2020, 11, 20, 0, 0, 0, 0, time.Local)}
+	qtop2 := QTopic{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.Local)}
+	qtop1 := QTopic{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.Local)}
 	mk.TopicList = append(mk.TopicList, qtop1)
 	mk.TopicList = append(mk.TopicList, qtop2)
 	mk.TopicList = append(mk.TopicList, qtop3)
@@ -1023,7 +1023,7 @@ func (mk *MockStore) HasProject(name string) bool {
 }
 
 // InsertTopic inserts a new topic object to the store
-func (mk *MockStore) InsertTopic(projectUUID string, name string, schemaUUID string) error {
+func (mk *MockStore) InsertTopic(projectUUID string, name string, schemaUUID string, createdOn time.Time) error {
 	topic := QTopic{
 		ID:            len(mk.TopicList),
 		ProjectUUID:   projectUUID,
@@ -1033,6 +1033,7 @@ func (mk *MockStore) InsertTopic(projectUUID string, name string, schemaUUID str
 		LatestPublish: time.Time{},
 		PublishRate:   0,
 		SchemaUUID:    schemaUUID,
+		CreatedOn:     createdOn,
 	}
 	mk.TopicList = append(mk.TopicList, topic)
 	return nil

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -1208,7 +1208,7 @@ func (mong *MongoStore) HasProject(name string) bool {
 }
 
 // InsertTopic inserts a topic to the store
-func (mong *MongoStore) InsertTopic(projectUUID string, name string, schemaUUID string) error {
+func (mong *MongoStore) InsertTopic(projectUUID string, name string, schemaUUID string, createdOn time.Time) error {
 
 	topic := QTopic{
 		ProjectUUID:   projectUUID,
@@ -1218,6 +1218,7 @@ func (mong *MongoStore) InsertTopic(projectUUID string, name string, schemaUUID 
 		LatestPublish: time.Time{},
 		PublishRate:   0,
 		SchemaUUID:    schemaUUID,
+		CreatedOn:     createdOn,
 	}
 
 	return mong.InsertResource("topics", topic)

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -106,6 +106,7 @@ type QTopic struct {
 	LatestPublish time.Time   `bson:"latest_publish"`
 	PublishRate   float64     `bson:"publish_rate"`
 	SchemaUUID    string      `bson:"schema_uuid"`
+	CreatedOn     time.Time   `bson:"created_on"`
 }
 
 // QDailyTopicMsgCount holds information about the daily number of messages published to a topic

--- a/stores/store.go
+++ b/stores/store.go
@@ -38,7 +38,7 @@ type Store interface {
 	InsertUser(uuid string, projects []QProjectRoles, name string, firstName string, lastName string, org string, desc string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
 	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
 	InsertOpMetric(hostname string, cpu float64, mem float64) error
-	InsertTopic(projectUUID string, name string, schemaUUID string) error
+	InsertTopic(projectUUID string, name string, schemaUUID string, createdOn time.Time) error
 	IncrementTopicMsgNum(projectUUID string, name string, num int64) error
 	IncrementDailyTopicMsgCount(projectUUID string, topicName string, num int64, date time.Time) error
 	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -19,10 +19,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("mockbase", store.Database)
 
 	eTopList := []QTopic{
-		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, ""},
-		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3"},
-		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1"},
-		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""},
+		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, "", time.Date(2020, 11, 19, 0, 0, 0, 0, time.Local)},
+		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3", time.Date(2020, 11, 20, 0, 0, 0, 0, time.Local)},
+		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.Local)},
+		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.Local)},
 	}
 
 	eSubList := []QSub{
@@ -39,8 +39,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve first 2
 	eTopList1st2 := []QTopic{
-		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, ""},
-		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3"},
+		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, "", time.Date(2020, 11, 19, 0, 0, 0, 0, time.Local)},
+		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3", time.Date(2020, 11, 20, 0, 0, 0, 0, time.Local)},
 	}
 	tpList2, ts2, pg2, _ := store.QueryTopics("argo_uuid", "", "", "", 2)
 	suite.Equal(eTopList1st2, tpList2)
@@ -49,7 +49,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve the last one
 	eTopList3 := []QTopic{
-		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""},
+		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.Local)},
 	}
 	tpList3, ts3, pg3, _ := store.QueryTopics("argo_uuid", "", "", "0", 1)
 	suite.Equal(eTopList3, tpList3)
@@ -58,7 +58,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve a single topic
 	eTopList4 := []QTopic{
-		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""},
+		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.Local)},
 	}
 	tpList4, ts4, pg4, _ := store.QueryTopics("argo_uuid", "", "topic1", "", 0)
 	suite.Equal(eTopList4, tpList4)
@@ -67,8 +67,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve user's topics
 	eTopList5 := []QTopic{
-		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1"},
-		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""},
+		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.Local)},
+		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.Local)},
 	}
 	tpList5, ts5, pg5, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 0)
 	suite.Equal(eTopList5, tpList5)
@@ -77,7 +77,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve use's topic with pagination
 	eTopList6 := []QTopic{
-		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1"},
+		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.Local)},
 	}
 
 	tpList6, ts6, pg6, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 1)
@@ -199,15 +199,15 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"publisher"}))
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
-	store.InsertTopic("argo_uuid", "topicFresh", "")
+	store.InsertTopic("argo_uuid", "topicFresh", "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.Local))
 	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 10, "", "", 0, "", false)
 
 	eTopList2 := []QTopic{
-		{4, "argo_uuid", "topicFresh", 0, 0, time.Time{}, 0, ""},
-		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, ""},
-		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3"},
-		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1"},
-		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""},
+		{4, "argo_uuid", "topicFresh", 0, 0, time.Time{}, 0, "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.Local)},
+		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, "", time.Date(2020, 11, 19, 0, 0, 0, 0, time.Local)},
+		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "schema_uuid_3", time.Date(2020, 11, 20, 0, 0, 0, 0, time.Local)},
+		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.Local)},
+		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.Local)},
 	}
 
 	eSubList2 := []QSub{

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -20,6 +20,7 @@ type Topic struct {
 	LatestPublish time.Time `json:"-"`
 	PublishRate   float64   `json:"-"`
 	Schema        string    `json:"schema,omitempty"`
+	CreatedOn     string    `json:"created_on"`
 }
 
 type TopicMetrics struct {
@@ -110,6 +111,7 @@ func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store s
 		curTop := New(item.ProjectUUID, projectName, item.Name)
 		curTop.LatestPublish = item.LatestPublish
 		curTop.PublishRate = item.PublishRate
+		curTop.CreatedOn = item.CreatedOn.Format("2006-01-02T15:04:05Z")
 
 		if item.SchemaUUID != "" {
 			sl, err := schemas.Find(projectUUID, item.SchemaUUID, "", store)
@@ -159,13 +161,13 @@ func (tl *PaginatedTopics) ExportJSON() (string, error) {
 }
 
 // CreateTopic creates a new topic
-func CreateTopic(projectUUID string, name string, schemaUUID string, store stores.Store) (Topic, error) {
+func CreateTopic(projectUUID string, name string, schemaUUID string, createdOn time.Time, store stores.Store) (Topic, error) {
 
 	if HasTopic(projectUUID, name, store) {
 		return Topic{}, errors.New("exists")
 	}
 
-	err := store.InsertTopic(projectUUID, name, schemaUUID)
+	err := store.InsertTopic(projectUUID, name, schemaUUID, createdOn)
 	if err != nil {
 		return Topic{}, errors.New("backend error")
 	}

--- a/topics/topic_test.go
+++ b/topics/topic_test.go
@@ -41,6 +41,7 @@ func (suite *TopicTestSuite) TestGetTopicByName() {
 	expTopic := New("argo_uuid", "ARGO", "topic1")
 	expTopic.PublishRate = 10
 	expTopic.LatestPublish = time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local)
+	expTopic.CreatedOn = "2020-11-22T00:00:00Z"
 	suite.Equal(expTopic, myTopics.Topics[0])
 }
 
@@ -50,23 +51,23 @@ func (suite *TopicTestSuite) TestGetPaginatedTopics() {
 
 	// retrieve all topics
 	expPt1 := PaginatedTopics{Topics: []Topic{
-		{"argo_uuid", "topic4", "/projects/ARGO/topics/topic4", time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, ""},
-		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3", time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "projects/ARGO/schemas/schema-3"},
-		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2", time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "projects/ARGO/schemas/schema-1"},
-		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1", time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""}},
+		{"argo_uuid", "topic4", "/projects/ARGO/topics/topic4", time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, "", "2020-11-19T00:00:00Z"},
+		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3", time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "projects/ARGO/schemas/schema-3", "2020-11-20T00:00:00Z"},
+		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2", time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "projects/ARGO/schemas/schema-1", "2020-11-21T00:00:00Z"},
+		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1", time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", "2020-11-22T00:00:00Z"}},
 		NextPageToken: "", TotalSize: 4}
 	pgTopics1, err1 := Find("argo_uuid", "", "", "", 0, store)
 
 	// retrieve first 2 topics
 	expPt2 := PaginatedTopics{Topics: []Topic{
-		{"argo_uuid", "topic4", "/projects/ARGO/topics/topic4", time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, ""},
-		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3", time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "projects/ARGO/schemas/schema-3"}},
+		{"argo_uuid", "topic4", "/projects/ARGO/topics/topic4", time.Date(0, 0, 0, 0, 0, 0, 0, time.Local), 0, "", "2020-11-19T00:00:00Z"},
+		{"argo_uuid", "topic3", "/projects/ARGO/topics/topic3", time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), 8.99, "projects/ARGO/schemas/schema-3", "2020-11-20T00:00:00Z"}},
 		NextPageToken: "MQ==", TotalSize: 4}
 	pgTopics2, err2 := Find("argo_uuid", "", "", "", 2, store)
 
 	// retrieve the next topic
 	expPt3 := PaginatedTopics{Topics: []Topic{
-		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1", time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""}},
+		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1", time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", "2020-11-22T00:00:00Z"}},
 		NextPageToken: "", TotalSize: 4}
 	pgTopics3, err3 := Find("argo_uuid", "", "", "MA==", 1, store)
 
@@ -75,14 +76,14 @@ func (suite *TopicTestSuite) TestGetPaginatedTopics() {
 
 	// retrieve topics for a specific user
 	expPt5 := PaginatedTopics{Topics: []Topic{
-		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2", time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "projects/ARGO/schemas/schema-1"},
-		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1", time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, ""}},
+		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2", time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "projects/ARGO/schemas/schema-1", "2020-11-21T00:00:00Z"},
+		{"argo_uuid", "topic1", "/projects/ARGO/topics/topic1", time.Date(2019, 5, 6, 0, 0, 0, 0, time.Local), 10, "", "2020-11-22T00:00:00Z"}},
 		NextPageToken: "", TotalSize: 2}
 	pgTopics5, err5 := Find("argo_uuid", "uuid1", "", "", 2, store)
 
 	// retrieve topics for a specific user with pagination
 	expPt6 := PaginatedTopics{Topics: []Topic{
-		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2", time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "projects/ARGO/schemas/schema-1"}},
+		{"argo_uuid", "topic2", "/projects/ARGO/topics/topic2", time.Date(2019, 5, 8, 0, 0, 0, 0, time.Local), 5.45, "projects/ARGO/schemas/schema-1", "2020-11-21T00:00:00Z"}},
 		NextPageToken: "MA==", TotalSize: 2}
 	pgTopics6, err6 := Find("argo_uuid", "uuid1", "", "", 1, store)
 
@@ -129,13 +130,14 @@ func (suite *TopicTestSuite) TestCreateTopicStore() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	tp, err := CreateTopic("argo_uuid", "topic1", "", store)
+	tp, err := CreateTopic("argo_uuid", "topic1", "", time.Time{}, store)
 	suite.Equal(Topic{}, tp)
 	suite.Equal("exists", err.Error())
 
-	tp2, err2 := CreateTopic("argo_uuid", "topicNew", "schema_uuid_1", store)
+	tp2, err2 := CreateTopic("argo_uuid", "topicNew", "schema_uuid_1", time.Date(2019, 5, 7, 0, 0, 0, 0, time.Local), store)
 	expTopic := New("argo_uuid", "ARGO", "topicNew")
 	expTopic.Schema = "projects/ARGO/schemas/schema-1"
+	expTopic.CreatedOn = "2019-05-07T00:00:00Z"
 	suite.Equal(expTopic, tp2)
 	suite.Equal(nil, err2)
 }
@@ -172,25 +174,30 @@ func (suite *TopicTestSuite) TestExportJson() {
 	topics, _ := Find("argo_uuid", "", "topic1", "", 0, store)
 	outJSON, _ := topics.Topics[0].ExportJSON()
 	expJSON := `{
-   "name": "/projects/ARGO/topics/topic1"
+   "name": "/projects/ARGO/topics/topic1",
+   "created_on": "2020-11-22T00:00:00Z"
 }`
 	suite.Equal(expJSON, outJSON)
 
 	expJSON2 := `{
    "topics": [
       {
-         "name": "/projects/ARGO/topics/topic4"
+         "name": "/projects/ARGO/topics/topic4",
+         "created_on": "2020-11-19T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/topics/topic3",
-         "schema": "projects/ARGO/schemas/schema-3"
+         "schema": "projects/ARGO/schemas/schema-3",
+         "created_on": "2020-11-20T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/topics/topic2",
-         "schema": "projects/ARGO/schemas/schema-1"
+         "schema": "projects/ARGO/schemas/schema-1",
+         "created_on": "2020-11-21T00:00:00Z"
       },
       {
-         "name": "/projects/ARGO/topics/topic1"
+         "name": "/projects/ARGO/topics/topic1",
+         "created_on": "2020-11-22T00:00:00Z"
       }
    ],
    "nextPageToken": "",


### PR DESCRIPTION
Add a new field to the topic struct, **created_on**.

The field is assigned a value whenever the create topic handler gets called.

Updated tests,docs and swagger.