### PR TITLE
ARGO-2707 Create a new metrics API Call

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -465,9 +465,9 @@ paths:
           $ref: "#/responses/500"
 
 
-  /metrics/daily-message-average:
+  /metrics/va_metrics:
     get:
-      summary: List of projects and their message count for the given time window
+      summary: List of projects and their message count, users, topics, subs for the given time window
       description: |
         list operational metrics
       parameters:
@@ -479,9 +479,9 @@ paths:
         - Operational Metrics
       responses:
         200:
-          description: Returns the message count metrics per project
+          description: Returns the message count metrics per project, and overall users, subs and topics
           schema:
-            $ref: '#/definitions/TotalProjectMessageCount'
+            $ref: '#/definitions/VAMetrics'
         401:
           $ref: "#/responses/401"
         403:
@@ -2433,6 +2433,19 @@ definitions:
       schema:
         type: object
 
+  VAMetrics:
+    type: object
+    properties:
+      projects_metrics:
+        type: object
+        $ref: '#/definitions/TotalProjectMessageCount'
+      users_count:
+        type: integer
+      topics_count:
+        type: integer
+      subscriptions_count:
+        type: integer
+
   TotalProjectMessageCount:
     type: object
     properties:
@@ -2490,9 +2503,6 @@ definitions:
         type: string
       value:
         type: string
-
-
-
 
   AuthUsers:
     type: object

--- a/doc/v1/docs/api_metrics.md
+++ b/doc/v1/docs/api_metrics.md
@@ -62,14 +62,16 @@ Success Response
 ### Errors
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
-## [GET] Get Daily Message Average
+## [GET] Get VA Metrics
 
 This request returns the total amount of messages per project for the given time window.The number of messages
 is calculated using the `daily message count` for each one of the project's topics.
+It also returns the amount of created `users`, `topics` and `subscriptions`
+within the given time window.
 
 ### Request
 ```
-GET "/v1/metrics/daily-message-average"
+GET "/v1/metrics/va_metrics"
 
 ```
 ### URL parameters
@@ -81,24 +83,26 @@ GET "/v1/metrics/daily-message-average"
 
 ```
 curl -H "Content-Type: application/json"
- "https://{URL}/v1/metrics/daily-message-average"
+ "https://{URL}/v1/metrics/va_metrics"
 ```
 
 ### Example request with URL parameters
 
 ```
 curl -H "Content-Type: application/json"
- "https://{URL}/v1/metrics/daily-message-average?start_date=2019-03-01&end_date=2019-07-24&projects=ARGO,ARGO-2"
+ "https://{URL}/v1/metrics/va_metrics?start_date=2019-03-01&end_date=2019-07-24&projects=ARGO,ARGO-2"
 ```
 
 ### Responses
-If successful, the response returns the total amount of messages per project for the given time window
+If successful, the response returns the total amount of messages per project,
+users,topics and subscriptions for the given time window
 
 Success Response
 `200 OK`
 
 ```json
 {
+  "projects_metrics": {
     "projects": [
         {
             "project": "ARGO-2",
@@ -113,6 +117,10 @@ Success Response
     ],
     "total_message_count": 25677,
     "average_daily_messages": 122
+  },
+  "users_count": 44,
+  "topics_count": 33,
+  "subscriptions_counter": 100 
 }
 ```
 ### Errors

--- a/handlers/metrics.go
+++ b/handlers/metrics.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/ARGOeu/argo-messaging/auth"
 	"github.com/ARGOeu/argo-messaging/metrics"
-	"github.com/ARGOeu/argo-messaging/projects"
 	"github.com/ARGOeu/argo-messaging/stores"
 	"github.com/ARGOeu/argo-messaging/subscriptions"
 	"github.com/ARGOeu/argo-messaging/topics"
@@ -53,8 +52,8 @@ func OpMetrics(w http.ResponseWriter, r *http.Request) {
 	respondOK(w, output)
 }
 
-// DailyMessageAverage (GET) retrieves the average amount of published messages per day
-func DailyMessageAverage(w http.ResponseWriter, r *http.Request) {
+// VaMetrics (GET) retrieves metrics regrading projects, users, subscriptions, topics
+func VaMetrics(w http.ResponseWriter, r *http.Request) {
 
 	// Add content type header to the response
 	contentType := "application/json"
@@ -104,14 +103,14 @@ func DailyMessageAverage(w http.ResponseWriter, r *http.Request) {
 		projectsList = strings.Split(projectsUrlValue, ",")
 	}
 
-	cc, err := projects.GetProjectsMessageCount(projectsList, startDate, endDate, refStr)
+	vr, err := metrics.GetVAReport(projectsList, startDate, endDate, refStr)
 	if err != nil {
 		err := APIErrorNotFound(err.Error())
 		respondErr(w, err)
 		return
 	}
 
-	output, err := json.MarshalIndent(cc, "", " ")
+	output, err := json.MarshalIndent(vr, "", " ")
 	if err != nil {
 		err := APIErrExportJSON()
 		respondErr(w, err)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ARGOeu/argo-messaging/config"
 	"github.com/ARGOeu/argo-messaging/stores"
@@ -346,6 +347,71 @@ func (suite *MetricsTestSuite) TestAggrProjectUserTopicsTest() {
 
 	suite.Equal(expJSON, outJSON)
 
+}
+
+func (suite *MetricsTestSuite) TestGetProjectsMessageCount() {
+
+	store := stores.NewMockStore("", "")
+	store.Initialize()
+
+	// test total message count per project
+	expectedTmpc := TotalProjectsMessageCount{
+		Projects: []ProjectMessageCount{
+			{
+				Project:              "ARGO",
+				MessageCount:         60,
+				AverageDailyMessages: 15,
+			},
+		},
+		TotalCount:           60,
+		AverageDailyMessages: 15,
+	}
+
+	tmpc, tmpcerr := GetProjectsMessageCount(
+		[]string{"ARGO"},
+		time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC),
+		store,
+	)
+
+	suite.Equal(expectedTmpc, tmpc)
+	suite.Nil(tmpcerr)
+}
+
+func (suite *MetricsTestSuite) TestGetVAReport() {
+
+	store := stores.NewMockStore("", "")
+	store.Initialize()
+
+	// test total message count per project
+	expectedTmpc := TotalProjectsMessageCount{
+		Projects: []ProjectMessageCount{
+			{
+				Project:              "ARGO",
+				MessageCount:         280,
+				AverageDailyMessages: 0,
+			},
+		},
+		TotalCount:           280,
+		AverageDailyMessages: 0,
+	}
+
+	va, tmpcerr := GetVAReport(
+		[]string{"ARGO"},
+		time.Date(2007, 10, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2020, 20, 4, 0, 0, 0, 0, time.UTC),
+		store,
+	)
+
+	expectedVA := VAReport{
+		ProjectsMetrics:    expectedTmpc,
+		UsersCount:         18,
+		TopicsCount:        8,
+		SubscriptionsCount: 8,
+	}
+
+	suite.Equal(expectedVA, va)
+	suite.Nil(tmpcerr)
 }
 
 func TestMetricsTestSuite(t *testing.T) {

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -53,6 +53,25 @@ type Metric struct {
 	Description  string      `json:"description"`
 }
 
+type ProjectMessageCount struct {
+	Project              string  `json:"project"`
+	MessageCount         int64   `json:"message_count"`
+	AverageDailyMessages float64 `json:"average_daily_messages"`
+}
+
+type TotalProjectsMessageCount struct {
+	Projects             []ProjectMessageCount `json:"projects"`
+	TotalCount           int64                 `json:"total_message_count"`
+	AverageDailyMessages float64               `json:"average_daily_messages"`
+}
+
+type VAReport struct {
+	ProjectsMetrics    TotalProjectsMessageCount `json:"projects_metrics"`
+	UsersCount         int                       `json:"users_count"`
+	TopicsCount        int                       `json:"topics_count"`
+	SubscriptionsCount int                       `json:"subscriptions_count"`
+}
+
 type Timepoint struct {
 	Timestamp string      `json:"timestamp"`
 	Value     interface{} `json:"value"`

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -1,7 +1,10 @@
 package metrics
 
 import (
+	"fmt"
+	amsProjects "github.com/ARGOeu/argo-messaging/projects"
 	"github.com/ARGOeu/argo-messaging/stores"
+	"math"
 	"time"
 )
 
@@ -105,4 +108,101 @@ func AggrProjectUserTopics(projectUUID string, store stores.Store) (MetricList, 
 
 	}
 	return ml, err
+}
+
+// GetVAReport returns a VAReport populated with the needed metrics
+func GetVAReport(projects []string, startDate time.Time, endDate time.Time, str stores.Store) (VAReport, error) {
+
+	vaReport := VAReport{}
+
+	tpm, err := GetProjectsMessageCount(projects, startDate, endDate, str)
+	if err != nil {
+		return vaReport, err
+	}
+
+	// for the counters we need to include the ones created up to the end of the end date
+	// if some gives 2020-15-01 we need to get all counters up to 2020-15-01T23:59:59
+	endDate = time.Date(endDate.Year(), endDate.Month(), endDate.Day(), 23, 59, 59, 0, endDate.Location())
+	uc, err := str.UsersCount(startDate, endDate)
+	if err != nil {
+		return vaReport, err
+	}
+
+	tc, err := str.TopicsCount(startDate, endDate)
+	if err != nil {
+		return vaReport, err
+	}
+
+	sc, err := str.SubscriptionsCount(startDate, endDate)
+	if err != nil {
+		return vaReport, err
+	}
+
+	vaReport.ProjectsMetrics = tpm
+	vaReport.UsersCount = uc
+	vaReport.TopicsCount = tc
+	vaReport.SubscriptionsCount = sc
+
+	return vaReport, nil
+}
+
+// GetProjectsMessageCount returns the total amount of messages per project for the given time window
+func GetProjectsMessageCount(projects []string, startDate time.Time, endDate time.Time, str stores.Store) (TotalProjectsMessageCount, error) {
+
+	tpj := TotalProjectsMessageCount{
+		Projects:   []ProjectMessageCount{},
+		TotalCount: 0,
+	}
+
+	var qtpj []stores.QProjectMessageCount
+	var err error
+
+	// since we want to present the end result using project names and not uuids
+	// we need to hold the mapping of UUID to NAME
+	projectsUUIDNames := make(map[string]string)
+
+	// check that all project UUIDs are correct
+	// translate the project NAMES to their respective UUIDs
+	projectUUIDs := make([]string, 0)
+	for _, prj := range projects {
+		projectUUID := amsProjects.GetUUIDByName(prj, str)
+		if projectUUID == "" {
+			return TotalProjectsMessageCount{}, fmt.Errorf("Project %v", prj)
+		}
+		projectUUIDs = append(projectUUIDs, projectUUID)
+		projectsUUIDNames[projectUUID] = prj
+	}
+
+	qtpj, err = str.QueryTotalMessagesPerProject(projectUUIDs, startDate, endDate)
+	if err != nil {
+		return TotalProjectsMessageCount{}, err
+	}
+
+	for _, prj := range qtpj {
+
+		projectName := ""
+
+		// if no project names were provided we have to do the mapping between name and uuid
+		if len(projects) == 0 {
+			projectName = amsProjects.GetNameByUUID(prj.ProjectUUID, str)
+		} else {
+			projectName = projectsUUIDNames[prj.ProjectUUID]
+		}
+
+		avg := math.Ceil(prj.AverageDailyMessages*100) / 100
+
+		pc := ProjectMessageCount{
+			Project:              projectName,
+			MessageCount:         prj.NumberOfMessages,
+			AverageDailyMessages: avg,
+		}
+
+		tpj.Projects = append(tpj.Projects, pc)
+
+		tpj.TotalCount += prj.NumberOfMessages
+
+		tpj.AverageDailyMessages += avg
+	}
+
+	return tpj, nil
 }

--- a/projects/project_test.go
+++ b/projects/project_test.go
@@ -181,35 +181,6 @@ func (suite *ProjectsTestSuite) TestProjects() {
 	suite.Equal(0, len(resSub))
 }
 
-func (suite *ProjectsTestSuite) TestGetProjectsMessageCount() {
-
-	store := stores.NewMockStore("", "")
-	store.Initialize()
-
-	// test total message count per project
-	expectedTmpc := TotalProjectsMessageCount{
-		Projects: []ProjectMessageCount{
-			{
-				Project:              "ARGO",
-				MessageCount:         60,
-				AverageDailyMessages: 15,
-			},
-		},
-		TotalCount:           60,
-		AverageDailyMessages: 15,
-	}
-
-	tmpc, tmpcerr := GetProjectsMessageCount(
-		[]string{"ARGO"},
-		time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC),
-		time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC),
-		store,
-	)
-
-	suite.Equal(expectedTmpc, tmpc)
-	suite.Nil(tmpcerr)
-}
-
 func TestProjectsTestSuite(t *testing.T) {
 	suite.Run(t, new(ProjectsTestSuite))
 }

--- a/routing.go
+++ b/routing.go
@@ -74,7 +74,7 @@ var defaultRoutes = []APIRoute{
 
 	{"ams:metrics", "GET", "/metrics", handlers.OpMetrics},
 	{"ams:healthStatus", "GET", "/status", handlers.HealthCheck},
-	{"ams:dailyMessageAverage", "GET", "/metrics/daily-message-average", handlers.DailyMessageAverage},
+	{"ams:vaMetrics", "GET", "/metrics/va_metrics", handlers.VaMetrics},
 	{"users:byToken", "GET", "/users:byToken/{token}", handlers.UserListByToken},
 	{"users:byUUID", "GET", "/users:byUUID/{uuid}", handlers.UserListByUUID},
 	{"users:list", "GET", "/users", handlers.UserListAll},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -25,6 +25,44 @@ type MockStore struct {
 	OpMetrics          map[string]QopMetric
 }
 
+func (mk *MockStore) TopicsCount(startDate, endDate time.Time) (int, error) {
+
+	counter := 0
+
+	for _, sub := range mk.SubList {
+		if sub.CreatedOn.After(startDate) && sub.CreatedOn.Before(endDate) {
+			counter++
+		}
+	}
+
+	return counter, nil
+}
+
+func (mk *MockStore) SubscriptionsCount(startDate, endDate time.Time) (int, error) {
+
+	counter := 0
+	for _, t := range mk.TopicList {
+		if t.CreatedOn.After(startDate) && t.CreatedOn.Before(endDate) {
+			counter++
+		}
+	}
+
+	return counter, nil
+}
+
+func (mk *MockStore) UsersCount(startDate, endDate time.Time) (int, error) {
+
+	counter := 0
+
+	for _, u := range mk.UserList {
+		if u.CreatedOn.After(startDate) && u.CreatedOn.Before(endDate) {
+			counter++
+		}
+	}
+
+	return counter, nil
+}
+
 // QueryACL Topic/Subscription ACL
 func (mk *MockStore) QueryACL(projectUUID string, resource string, name string) (QAcl, error) {
 	if resource == "topics" {

--- a/stores/store.go
+++ b/stores/store.go
@@ -68,6 +68,9 @@ type Store interface {
 	QuerySchemas(projectUUID, schemaUUID, name string) ([]QSchema, error)
 	UpdateSchema(schemaUUID, name, schemaType, rawSchemaString string) error
 	DeleteSchema(schemaUUID string) error
+	UsersCount(startDate, endDate time.Time) (int, error)
+	TopicsCount(startDate, endDate time.Time) (int, error)
+	SubscriptionsCount(startDate, endDate time.Time) (int, error)
 	Clone() Store
 	Close()
 }

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -635,6 +635,15 @@ func (suite *StoreTestSuite) TestMockStore() {
 	ur2, _ := store.QueryRegistrations("ur-uuid1", "accepted", "", "", "", "")
 	suite.Equal(expur2, ur2)
 
+	sdate := time.Date(2008, 11, 19, 8, 0, 0, 0, time.Local)
+	edate := time.Date(2020, 11, 21, 6, 0, 0, 0, time.Local)
+	tc, _ := store3.TopicsCount(sdate, edate)
+	sc, _ := store3.SubscriptionsCount(sdate, edate)
+	uc, _ := store2.UsersCount(sdate, edate)
+
+	suite.Equal(3, tc)
+	suite.Equal(3, sc)
+	suite.Equal(9, uc)
 }
 
 func TestStoresTestSuite(t *testing.T) {


### PR DESCRIPTION
Rename the api call **/metrics/daily-message-average** to **/metrics/va_metrics**

The new api response will now include the **users_count**, **topics_count** and **subscriptions_count** for the specified time window for the whole service(not influenced by the projects parameter).

Rearrange some functions to group them under the metrics package.

Add some new methods to the store interface.

update swagger,docs,test.

