### PR TITLE
ARGO-2762 Projects:members user count bug

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -567,12 +567,12 @@ func (suite *AuthTestSuite) TestAuth() {
 	suite.Nil(e1)
 
 	suite.Equal(qUsers2, pu2.Users)
-	suite.Equal(int32(9), pu2.TotalSize)
+	suite.Equal(int32(3), pu2.TotalSize)
 	suite.Equal("NQ==", pu2.NextPageToken)
 	suite.Nil(e2)
 
 	suite.Equal(qUsers3, pu3.Users)
-	suite.Equal(int32(9), pu3.TotalSize)
+	suite.Equal(int32(2), pu3.TotalSize)
 	suite.Equal("Mg==", pu3.NextPageToken)
 	suite.Nil(e3)
 

--- a/handlers/users_test.go
+++ b/handlers/users_test.go
@@ -982,7 +982,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllStartingPage() {
       }
    ],
    "nextPageToken": "Ng==",
-   "totalSize": 9
+   "totalSize": 2
 }`
 
 	cfgKafka := config.NewAPICfg()
@@ -1324,7 +1324,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllStartingAtSecond() {
       }
    ],
    "nextPageToken": "NQ==",
-   "totalSize": 9
+   "totalSize": 2
 }`
 
 	cfgKafka := config.NewAPICfg()
@@ -1433,7 +1433,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllIntermediatePage() {
       }
    ],
    "nextPageToken": "Mg==",
-   "totalSize": 9
+   "totalSize": 2
 }`
 
 	cfgKafka := config.NewAPICfg()

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -710,11 +710,12 @@ func (mk *MockStore) QueryUsers(projectUUID string, uuid string, name string) ([
 func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int32, projectUUID string) ([]QUser, int32, string, error) {
 
 	var qUsers []QUser
-	var totalSize int32
 	var nextPageToken string
 	var err error
 	var pg int
 	var limit int
+
+	totalSize := int32(0)
 
 	if pageSize == 0 {
 		limit = len(mk.UserList)
@@ -733,8 +734,6 @@ func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int32, proje
 		id2 := mk.UserList[j].ID.(int)
 		return id1 > id2
 	})
-
-	totalSize = int32(len(mk.UserList))
 
 	for _, user := range mk.UserList {
 
@@ -779,8 +778,16 @@ func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int32, proje
 		qUsers = qUsers[:len(qUsers)-1]
 	}
 
-	if projectUUID != "" {
+	if projectUUID == "" {
 		totalSize = int32(len(qUsers))
+	} else {
+		for _, user := range mk.UserList {
+			for _, project := range user.Projects {
+				if projectUUID == project.ProjectUUID {
+					totalSize++
+				}
+			}
+		}
 	}
 
 	return qUsers, totalSize, nextPageToken, err

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -608,10 +608,15 @@ func (mong *MongoStore) PaginatedQueryUsers(pageToken string, pageSize int32, pr
 	db := mong.Session.DB(mong.Database)
 	c := db.C("users")
 
-	// check the total of the users selected by the query not taking into acount pagination
+	// check the total of the users selected by the query not taking into account pagination
 	if size, err = c.Find(query).Count(); err != nil {
-		log.Fatal("STORE", "\t", err.Error())
-
+		log.WithFields(
+			log.Fields{
+				"type":            "backend_log",
+				"backend_service": "mongo",
+				"backend_hosts":   mong.Server,
+			},
+		).Fatal(err.Error())
 	}
 	totalSize = int32(size)
 
@@ -675,20 +680,7 @@ func (mong *MongoStore) PaginatedQueryUsers(pageToken string, pageSize int32, pr
 		qUsers = qUsers[:len(qUsers)-1]
 	}
 
-	if size, err = c.Count(); err != nil {
-		log.WithFields(
-			log.Fields{
-				"type":            "backend_log",
-				"backend_service": "mongo",
-				"backend_hosts":   mong.Server,
-			},
-		).Fatal(err.Error())
-	}
-
-	totalSize = int32(size)
-
 	return qUsers, totalSize, nextPageToken, err
-
 }
 
 //QuerySubsByTopic returns subscriptions of a specific topic

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -509,7 +509,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(8, qUsers2[0].ID)
 	suite.Equal(7, qUsers2[1].ID)
 	suite.Equal("6", pg2)
-	suite.Equal(int32(9), ts2)
+	suite.Equal(int32(2), ts2)
 
 	suite.Equal(0, len(qUsers3))
 	suite.Equal("", pg3)
@@ -518,7 +518,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(4, qUsers4[0].ID)
 	suite.Equal(3, qUsers4[1].ID)
 	suite.Equal("2", pg4)
-	suite.Equal(int32(9), ts4)
+	suite.Equal(int32(2), ts4)
 
 	// test update topic latest publish time
 	e1ulp := store2.UpdateTopicLatestPublish("argo_uuid", "topic1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.Local))


### PR DESCRIPTION
The paginated users query method doesn't honor the project_uuid parameter when counting how many users exist under the specified project.It instead returns the count for the whole collection despite returning users for the specific project.