### PR TITLE
ARGO-2767 Implement authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ resides in two possible locations:
 - `verify_push_server` - (true|false) mutual TLS for the push server
 - `push_worker_token` - token for the active push worker user
 - `log_facilities` - ["syslog", "console"]  
+- `auth_option`: (`key`|`header`|`both`), where should the service look for the access token.
+
 
 #### Build & Run the service
 

--- a/config.json
+++ b/config.json
@@ -16,5 +16,6 @@
   "push_server_port": 5555,
   "verify_push_server": true,
   "push_worker_token": "8c8cbaeba3e1317c18cd5c03f3b1f596c23f922a",
-  "log_facilities": ["console"]
+  "log_facilities": ["console"],
+  "auth_option": "both" 
 }

--- a/config/config.json
+++ b/config/config.json
@@ -15,6 +15,7 @@
   "push_server_host": "localhost",
   "push_server_port": 5555,
   "verify_push_server": true,
-  "push_worker_token": "lol",
-  "log_facilities": []
+  "push_worker_token": "pw-token",
+  "log_facilities": [],
+  "auth_option": "header"
 }

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -9,6 +9,15 @@ info:
     url: http://argoeu.github.io/
     email: argo-dev@lists.grnet.gr
 
+securityDefinitions:
+  APIKeyHeader:
+    type: apiKey
+    in: header
+    name: x-api-key
+security:
+  - APIKeyHeader: []
+
+
 host: localhost
 schemes:
   - https

--- a/doc/v1/docs/api_auth.md
+++ b/doc/v1/docs/api_auth.md
@@ -2,6 +2,8 @@
 
 Each user is authenticated by adding the url parameter `?key=T0K3N` in each API request
 
+Users can also authenticate using the header `x-api-key`.
+
 If a user does not provide a valid token the following response is returned:
 ```json
 {

--- a/doc/v1/docs/api_basic.md
+++ b/doc/v1/docs/api_basic.md
@@ -6,6 +6,7 @@ The ARGO Messaging Service API implements the Google PubSub specification and th
 All methods must be called using HTTPS. Arguments can be passed as GET or POST params, or a mix. The response contains a `200 OK` for a successful request and a JSON object in case of an error. For failure results, the error property will contain a short machine-readable error code. In the case of problematic calls,  during handling user’s request the API responds using a predefined schema (described in chapter Errors), that contains a short machine-readable warning code, an error code and an error description  (or list of them, in the case of multiple errors).
 
 Each user is authenticated by adding the url parameter `?key=T0K3N` in each API request
+Users can also authenticate using the header `x-api-key`.
 
 ## Configuration file: config.json
 

--- a/doc/v1/docs/security.md
+++ b/doc/v1/docs/security.md
@@ -9,6 +9,9 @@ The large majority of api calls support the `url parameter`, <b>key</b>.
 
 E.g. `/v1/projects?key=b328c7890f061f87cbd4rff34f36fa2ae20993a5`
 
+<b> The service also supports the use of the x-api-key header
+for the user to provide its key. </b>
+
 - Each request will extract the key from the request parameters
 and will try to find a user associated with it in the respective
 data store.

--- a/routing.go
+++ b/routing.go
@@ -38,6 +38,8 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *o
 	// reference routes input in API object too keep info centralized
 	ar.Routes = routes
 
+	tokenExtractStrategy := handlers.GetRequestTokenExtractStrategy(cfg.AuthOption())
+
 	// For each route
 	for _, route := range ar.Routes {
 
@@ -49,8 +51,8 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *o
 
 		// skip authentication/authorization for the health status and profile api calls
 		if route.Name != "ams:healthStatus" && "users:profile" != route.Name && route.Name != "version:list" {
-			handler = handlers.WrapAuthorize(handler, route.Name)
-			handler = handlers.WrapAuthenticate(handler)
+			handler = handlers.WrapAuthorize(handler, route.Name, tokenExtractStrategy)
+			handler = handlers.WrapAuthenticate(handler, tokenExtractStrategy)
 		}
 
 		handler = handlers.WrapValidate(handler)


### PR DESCRIPTION
Provide a new config field that can take the value of key, header or both.
the default value is key.

In the case of header, the service will look to find the appropriate access token in the x-api-key header.
In the case of key, the service will look to find the appropriate access token in the key URL parameter.
In the case of both, the service will first look to find an x-api-key token and then back off to the URL parameter in case it is empty.