### PR TITLE
ARGO-2899 Vulnerable GO version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'argo.registry:5000/epel-7-mgo1.14'
+            image 'argo.registry:5000/epel-7-mgo1.15'
             args '-u jenkins:jenkins'
         }
     }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ specific topics and receive messages.
 
 #### Build Requirements
 
- - Golang 1.14
+ - Golang 1.15
 
 #### Datastore Requirements
   - The service has been tested with mongodb from version `3.2.22` up to `4.2.3`.

--- a/argo-messaging.spec
+++ b/argo-messaging.spec
@@ -9,7 +9,6 @@ License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group: Unspecified
 Source0: %{name}-%{version}.tar.gz
-BuildRequires: golang
 BuildRequires: git
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent
 ExcludeArch: i386

--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -378,8 +378,8 @@ ConsumerLoop:
 					"backend_service": "kafka",
 					"topic":           topic,
 					"message":         msg,
-					"consumed":        string(consumed),
-					"max":             string(max),
+					"consumed":        consumed,
+					"max":             max,
 				},
 			).Debug("Consumed message")
 

--- a/doc/v1/docs/api_version.md
+++ b/doc/v1/docs/api_version.md
@@ -27,7 +27,7 @@ Json Response
     "release": "1.0.5",
     "commit": "f9f2e8c5f02lbcc94fe76b0d3cfa5d20d9365444",
     "build_time": "2019-11-01T12:51:04Z",
-    "golang": "go1.11.5",
+    "golang": "go1.15.6",
     "compiler": "gc",
     "os": "linux",
     "architecture": "amd64"


### PR DESCRIPTION
- Use the new image epel-7-mgo1.15 inside the Jenkisfile
- small adjustments for the upgrade to go1.15 from go 1.14