### PR TITLE
ARGO-2927 - Users:listall & project:members option for detailed view

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -515,7 +515,17 @@ func (suite *AuthTestSuite) TestAuth() {
 
 	var qUsers1 []User
 	qUsers1 = append(qUsers1, User{"uuid8", []ProjectRoles{{"ARGO2", []string{"consumer", "publisher"}, []string{}, []string{}}}, "UserZ", "", "", "", "", "S3CR3T1", "foo-email", []string{}, created, modified, ""})
-	qUsers1 = append(qUsers1, User{"uuid7", []ProjectRoles{}, "push_worker_0", "", "", "", "", "push_token", "foo-email", []string{"push_worker"}, created, modified, ""})
+	qUsers1 = append(qUsers1, User{
+		UUID:         "uuid7",
+		Name:         "push_worker_0",
+		FirstName:    "",
+		LastName:     "",
+		Description:  "",
+		Token:        "push_token",
+		Email:        "foo-email",
+		ServiceRoles: []string{"push_worker"}, CreatedOn: created, ModifiedOn: modified,
+		CreatedBy: "",
+	})
 	qUsers1 = append(qUsers1, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame2", "", "", "", "", "S3CR3T42", "foo-email", []string{}, created, modified, "UserA"})
 	qUsers1 = append(qUsers1, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame1", "", "", "", "", "S3CR3T41", "foo-email", []string{}, created, modified, "UserA"})
 	qUsers1 = append(qUsers1, User{"uuid4", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{"topic2"}, []string{"sub3", "sub4"}}}, "UserZ", "", "", "", "", "S3CR3T4", "foo-email", []string{}, created, modified, "UserA"})
@@ -524,29 +534,39 @@ func (suite *AuthTestSuite) TestAuth() {
 	qUsers1 = append(qUsers1, User{"uuid1", []ProjectRoles{{"ARGO", []string{"consumer", "publisher"}, []string{"topic1", "topic2"}, []string{"sub1", "sub2", "sub3"}}}, "UserA", "FirstA", "LastA", "OrgA", "DescA", "S3CR3T1", "foo-email", []string{}, created, modified, ""})
 	qUsers1 = append(qUsers1, User{"uuid0", []ProjectRoles{{"ARGO", []string{"consumer", "publisher"}, []string{}, []string{}}}, "Test", "", "", "", "", "S3CR3T", "Test@test.com", []string{}, created, modified, ""})
 	// return all users
-	pu1, e1 := PaginatedFindUsers("", 0, "", true, store2)
+	pu1, e1 := PaginatedFindUsers("", 0, "", true, true, store2)
 
 	var qUsers2 []User
 	qUsers2 = append(qUsers2, User{"uuid8", []ProjectRoles{{"ARGO2", []string{"consumer", "publisher"}, []string{}, []string{}}}, "UserZ", "", "", "", "", "S3CR3T1", "foo-email", []string{}, created, modified, ""})
-	qUsers2 = append(qUsers2, User{"uuid7", []ProjectRoles{}, "push_worker_0", "", "", "", "", "push_token", "foo-email", []string{"push_worker"}, created, modified, ""})
+	qUsers2 = append(qUsers2, User{
+		UUID:         "uuid7",
+		Name:         "push_worker_0",
+		FirstName:    "",
+		LastName:     "",
+		Description:  "",
+		Token:        "push_token",
+		Email:        "foo-email",
+		ServiceRoles: []string{"push_worker"}, CreatedOn: created, ModifiedOn: modified,
+		CreatedBy: "",
+	})
 	qUsers2 = append(qUsers2, User{"same_uuid", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{}, []string{}}}, "UserSame2", "", "", "", "", "S3CR3T42", "foo-email", []string{}, created, modified, "UserA"})
 
 	// return the first page with 2 users
-	pu2, e2 := PaginatedFindUsers("", 3, "", true, store2)
+	pu2, e2 := PaginatedFindUsers("", 3, "", true, true, store2)
 
 	var qUsers3 []User
 	qUsers3 = append(qUsers3, User{"uuid4", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{"topic2"}, []string{"sub3", "sub4"}}}, "UserZ", "", "", "", "", "S3CR3T4", "foo-email", []string{}, created, modified, "UserA"})
 	qUsers3 = append(qUsers3, User{"uuid3", []ProjectRoles{{"ARGO", []string{"publisher", "consumer"}, []string{"topic3"}, []string{"sub2"}}}, "UserX", "", "", "", "", "S3CR3T3", "foo-email", []string{}, created, modified, "UserA"})
 	// return the next 2 users
-	pu3, e3 := PaginatedFindUsers("NA==", 2, "", true, store2)
+	pu3, e3 := PaginatedFindUsers("NA==", 2, "", true, true, store2)
 
 	// empty collection
 	store3 := stores.NewMockStore("", "")
 	store3.UserList = []stores.QUser{}
-	pu4, e4 := PaginatedFindUsers("", 0, "", true, store3)
+	pu4, e4 := PaginatedFindUsers("", 0, "", true, true, store3)
 
 	// invalid id
-	_, e5 := PaginatedFindUsers("invalid", 0, "", true, store2)
+	_, e5 := PaginatedFindUsers("invalid", 0, "", true, true, store2)
 
 	// check user list by project
 	var qUsersB []User
@@ -556,7 +576,26 @@ func (suite *AuthTestSuite) TestAuth() {
 	var qUsersC []User
 	qUsersC = append(qUsersC, User{"uuid8", []ProjectRoles{{"ARGO2", []string{"consumer", "publisher"}, []string{}, []string{}}}, "UserZ", "", "", "", "", "", "foo-email", []string{}, created, modified, ""})
 
-	puC, e1 := PaginatedFindUsers("", 1, "argo_uuid2", false, store2)
+	// check for non detailed view
+	var ndUser []User
+	ndUser = append(ndUser, User{
+		UUID:         "uuid8",
+		Name:         "UserZ",
+		FirstName:    "",
+		LastName:     "",
+		Organization: "",
+		Description:  "",
+		Token:        "S3CR3T1",
+		Email:        "foo-email",
+		ServiceRoles: []string{},
+		CreatedOn:    created,
+		ModifiedOn:   modified,
+		CreatedBy:    ""})
+
+	ndu, _ := PaginatedFindUsers("", 1, "", true, false, store2)
+	suite.Equal(ndUser, ndu.Users)
+
+	puC, e1 := PaginatedFindUsers("", 1, "argo_uuid2", false, true, store2)
 	suite.Equal(qUsersC, puC.Users)
 	suite.Equal(int32(1), puC.TotalSize)
 	suite.Equal("", puC.NextPageToken)

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -710,6 +710,7 @@ paths:
         - $ref: '#/parameters/ApiKey'
         - $ref: '#/parameters/PageToken'
         - $ref: '#/parameters/PageSize'
+        - $ref: '#/parameters/UserDetails'
         - name: PROJECT
           in: path
           description: Name of the project
@@ -956,6 +957,7 @@ paths:
         - $ref: '#/parameters/ApiKey'
         - $ref: '#/parameters/PageToken'
         - $ref: '#/parameters/PageSize'
+        - $ref: '#/parameters/UserDetails'
       tags:
         - Users
       responses:
@@ -2247,6 +2249,13 @@ parameters:
     name: details
     in: query
     description: report detailed error for ams push server
+    required: false
+    type: boolean
+    default: false
+  UserDetails:
+    name: details
+    in: query
+    description: report detailed information for each user(projects, subscriptions, topics)
     required: false
     type: boolean
     default: false

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -212,10 +212,14 @@ Please refer to section [Errors](api_errors.md) to see all possible Errors
 
 ### [GET] List all users that are members of a specific project
 
+- `details`, if set to `true`, it will return the detailed view of each user,
+containing the projects, subscriptions and topics that the user belongs to.
+
+
 ### Example request
 ```
 curl -X GET -H "Content-Type: application/json"
-  "https://{URL}/v1/projects/ARGO2/members?key=S3CR3T"
+  "https://{URL}/v1/projects/ARGO2/members?key=S3CR3T&details=true"
 ```
 
 ### Responses  
@@ -253,7 +257,7 @@ Success Response
 }
 ```
 
-### Unpriviledge mode (non service_admin user)
+### The Unprivileged mode (non service_admin user)
 When a user is project_admin instead of service_admin and lists a project's users the results
 returned remove user information such as `token`, `service_roles` and `created_by` For example:
 

--- a/doc/v1/docs/api_users.md
+++ b/doc/v1/docs/api_users.md
@@ -3,7 +3,11 @@
 ARGO Messaging Service supports calls for creating and modifing users
 
 ## [GET] Manage Users - List all users
+
 This request lists all available users in the service using pagination
+
+- `details`, if set to `true`, it will return the detailed view of each user,
+containing the projects, subscriptions and topics that the user belongs to.
 
 It is important to note that if there are no results to return the service will return the following:
 
@@ -30,7 +34,7 @@ GET "/v1/users"
 ### Example request
 ```
 curl -X GET -H "Content-Type: application/json"
-  "https://{URL}/v1/users?key=S3CR3T"
+  "https://{URL}/v1/users?key=S3CR3T&details=true"
 ```
 
 ### Responses  
@@ -183,7 +187,7 @@ Success Response
 ### Example request
 ```
 curl -X GET -H "Content-Type: application/json"
-  "https://{URL}/v1/users?key=S3CR3T&pageSize=2"
+  "https://{URL}/v1/users?key=S3CR3T&pageSize=2&details=true"
 ```
 
 ### Responses  
@@ -253,7 +257,7 @@ Success Response
 ### Example request
 ```
 curl -X GET -H "Content-Type: application/json"
-  "https://{URL}/v1/users?key=S3CR3T&pageSize=3&pageToken=some_token2"
+  "https://{URL}/v1/users?key=S3CR3T&pageSize=3&pageToken=some_token2&details=true"
 ```
 
 ### Responses  
@@ -355,7 +359,7 @@ Success Response
 ### Example request
 ```
 curl -X GET -H "Content-Type: application/json"
-  "https://{URL}/v1/users?key=S3CR3T&project=ARGO2"
+  "https://{URL}/v1/users?key=S3CR3T&project=ARGO2&details=true"
 ```
 
 ### Responses  

--- a/handlers/projects.go
+++ b/handlers/projects.go
@@ -835,6 +835,12 @@ func ProjectListUsers(w http.ResponseWriter, r *http.Request) {
 	urlValues := r.URL.Query()
 	pageToken := urlValues.Get("pageToken")
 	strPageSize := urlValues.Get("pageSize")
+	details := urlValues.Get("details")
+	usersDetailedView := false
+
+	if details == "true" {
+		usersDetailedView = true
+	}
 
 	if strPageSize != "" {
 		if pageSize, err = strconv.Atoi(strPageSize); err != nil {
@@ -849,7 +855,7 @@ func ProjectListUsers(w http.ResponseWriter, r *http.Request) {
 	priviledged := auth.IsServiceAdmin(refRoles)
 
 	// Get Results Object - call is always priviledged because this handler is only accessible by service admins
-	if paginatedUsers, err = auth.PaginatedFindUsers(pageToken, int32(pageSize), projectUUID, priviledged, refStr); err != nil {
+	if paginatedUsers, err = auth.PaginatedFindUsers(pageToken, int32(pageSize), projectUUID, priviledged, usersDetailedView, refStr); err != nil {
 		err := APIErrorInvalidData("Invalid page token")
 		respondErr(w, err)
 		return

--- a/handlers/registrations_test.go
+++ b/handlers/registrations_test.go
@@ -140,7 +140,6 @@ func (suite *RegistrationsHandlersTestSuite) TestAcceptRegisterUser() {
 		uname: "urname",
 		expectedResponse: `{
    "uuid": "{{UUID}}",
-   "projects": [],
    "name": "urname",
    "first_name": "urfname",
    "last_name": "urlname",

--- a/handlers/users.go
+++ b/handlers/users.go
@@ -436,13 +436,19 @@ func UserListAll(w http.ResponseWriter, r *http.Request) {
 	// Grab context references
 	refStr := gorillaContext.Get(r, "str").(stores.Store)
 	refRoles := gorillaContext.Get(r, "auth_roles").([]string)
+	usersDetailedView := false
 
 	// Grab url path variables
 	urlValues := r.URL.Query()
 	pageToken := urlValues.Get("pageToken")
 	strPageSize := urlValues.Get("pageSize")
 	projectName := urlValues.Get("project")
+	details := urlValues.Get("details")
 	projectUUID := ""
+
+	if details == "true" {
+		usersDetailedView = true
+	}
 
 	if projectName != "" {
 		projectUUID = projects.GetUUIDByName(projectName, refStr)
@@ -466,7 +472,7 @@ func UserListAll(w http.ResponseWriter, r *http.Request) {
 	priviledged := auth.IsServiceAdmin(refRoles)
 
 	// Get Results Object - call is always priviledged because this handler is only accessible by service admins
-	if paginatedUsers, err = auth.PaginatedFindUsers(pageToken, int32(pageSize), projectUUID, priviledged, refStr); err != nil {
+	if paginatedUsers, err = auth.PaginatedFindUsers(pageToken, int32(pageSize), projectUUID, priviledged, usersDetailedView, refStr); err != nil {
 		err := APIErrorInvalidData("Invalid page token")
 		respondErr(w, err)
 		return

--- a/handlers/users_test.go
+++ b/handlers/users_test.go
@@ -708,7 +708,7 @@ func (suite *UsersHandlersTestSuite) TestUserListOne() {
 
 func (suite *UsersHandlersTestSuite) TestUserListAll() {
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?details=true", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -737,7 +737,6 @@ func (suite *UsersHandlersTestSuite) TestUserListAll() {
       },
       {
          "uuid": "uuid7",
-         "projects": [],
          "name": "push_worker_0",
          "token": "push_token",
          "email": "foo-email",
@@ -941,7 +940,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAll() {
 
 func (suite *UsersHandlersTestSuite) TestUserListAllStartingPage() {
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageSize=2", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageSize=2&details=true", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -970,7 +969,6 @@ func (suite *UsersHandlersTestSuite) TestUserListAllStartingPage() {
       },
       {
          "uuid": "uuid7",
-         "projects": [],
          "name": "push_worker_0",
          "token": "push_token",
          "email": "foo-email",
@@ -1002,7 +1000,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllStartingPage() {
 
 func (suite *UsersHandlersTestSuite) TestUserListAllProjectARGO() {
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?project=ARGO", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?project=ARGO&details=true", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1203,7 +1201,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllProjectARGO() {
 
 func (suite *UsersHandlersTestSuite) TestUserListAllProjectARGO2() {
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?project=ARGO2", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?project=ARGO2&details=true", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1282,7 +1280,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllProjectUNKNOWN() {
 
 func (suite *UsersHandlersTestSuite) TestUserListAllStartingAtSecond() {
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageSize=2&pageToken=Nw==", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageSize=2&pageToken=Nw==&details=true", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1291,7 +1289,6 @@ func (suite *UsersHandlersTestSuite) TestUserListAllStartingAtSecond() {
    "users": [
       {
          "uuid": "uuid7",
-         "projects": [],
          "name": "push_worker_0",
          "token": "push_token",
          "email": "foo-email",
@@ -1314,6 +1311,55 @@ func (suite *UsersHandlersTestSuite) TestUserListAllStartingAtSecond() {
                "subscriptions": []
             }
          ],
+         "name": "UserSame2",
+         "token": "S3CR3T42",
+         "email": "foo-email",
+         "service_roles": [],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z",
+         "created_by": "UserA"
+      }
+   ],
+   "nextPageToken": "NQ==",
+   "totalSize": 2
+}`
+
+	cfgKafka := config.NewAPICfg()
+	cfgKafka.LoadStrJSON(suite.cfgStr)
+
+	brk := brokers.MockBroker{}
+	str := stores.NewMockStore("whatever", "argo_mgs")
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	mgr := oldPush.Manager{}
+	router.HandleFunc("/v1/users", WrapMockAuthConfig(UserListAll, cfgKafka, &brk, str, &mgr, nil, "service_admin"))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
+func (suite *UsersHandlersTestSuite) TestUserListAllStartingAtSecondNoUserDetails() {
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageSize=2&pageToken=Nw==&details=false", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{
+   "users": [
+      {
+         "uuid": "uuid7",
+         "name": "push_worker_0",
+         "token": "push_token",
+         "email": "foo-email",
+         "service_roles": [
+            "push_worker"
+         ],
+         "created_on": "2009-11-10T23:00:00Z",
+         "modified_on": "2009-11-10T23:00:00Z"
+      },
+      {
+         "uuid": "same_uuid",
          "name": "UserSame2",
          "token": "S3CR3T42",
          "email": "foo-email",
@@ -1373,7 +1419,7 @@ func (suite *UsersHandlersTestSuite) TestUserListAllEmptyCollection() {
 
 func (suite *UsersHandlersTestSuite) TestUserListAllIntermediatePage() {
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageToken=NA==&pageSize=2", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/users?pageToken=NA==&pageSize=2&details=true", nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Enhance the 2 users:listall and project:members API calls to now include an extra URL parameter, details that can hold a boolean value.

True: will return the full detailed view of a user, including projects, subs and topics
False(default): will return just the basic info for each user.