### PR TITLE
Update receiver endpoint example. Add vscode gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 argo-messaging
 _workspace/
 .idea
+.vscode/


### PR DESCRIPTION

Updates in flask receive endpoint:
- [x] Add configurable host parameter to listen to (default is 127.0.0.1)
- [x] Add an global list that collects received messages (apart from displaying them in log)
- [x] Add an HTTP GET `/messages` handler to view received messages since the endpoint started. It displays received messages as a simple html page that auto-refreshes every 3 seconds
- [x] Update example usage information in comments