### PR TITLE
AM-254: ams: Enable create_sub to handle mattermost webhooks

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
   title: argo-messaging-api
   description: "ARGO is a lightweight service for Service Level Monitoring designed for medium and large sized e-Infrastructures. This swagger UI interface provides access to the specification of the ARGO messaging api, which can be used to produce or consume messages."
-  version: "0.9.2"
+  version: "1.2.0"
   contact:
     name: ARGO Developers
     url: http://argoeu.github.io/
@@ -2658,7 +2658,7 @@ definitions:
       ackDeadlineSeconds:
         type: integer
         description: maximum wait time in seconds for Acknowledgement
-      created_on:
+      createdOn:
         type: string
         description: creation date
   PushConfigRef:
@@ -2675,14 +2675,20 @@ definitions:
       maxMessages:
         type: integer
         description: batch size of messages per push action
-      authorization_header:
+      authorizationHeader:
         $ref: '#/definitions/AuthorizationHeader'
       retryPolicy:
         $ref: '#/definitions/RetryPolicy'
-      verification_hash:
+      verificationHash:
         type: string
       verified:
         type: boolean
+      mattermostUrl:
+        type: string
+      mattermostUsername:
+        type: string
+      mattermostChannel:
+        type: string
 
   PushStatus:
     type: object

--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -891,17 +891,17 @@ paths:
           description: Name of the user
           required: true
           type: string
-        - name: User information
+        - name: User roles in the project
           in: body
-          description: Extra user information such as roles and email
+          description: User roles in the project
           required: false
           schema:
             type: object
             properties:
-              projects:
+              roles:
                 type: array
                 items:
-                  $ref: "#/definitions/ProjectRoles"
+                  type: string
       tags:
         - Projects
       responses:

--- a/doc/v1/docs/api_projects.md
+++ b/doc/v1/docs/api_projects.md
@@ -455,9 +455,7 @@ curl -X POST -H "Content-Type: application/json"
 
 ```json
 {
-  "roles": ["consumer"],
-   "topics": ["topic1"],
-   "subscriptions": ["sub1"]
+  "roles": ["consumer"]
 }
 ```
 
@@ -477,12 +475,8 @@ Success Response
              "roles": [
                 "consumer"
              ],
-             "topics": [
-                "topic1"
-             ],
-             "subscriptions": [
-                "sub1"
-             ]
+             "topics": [],
+             "subscriptions": []
           }
        ],
        "name": "NewUSer",

--- a/doc/v1/docs/api_subs.md
+++ b/doc/v1/docs/api_subs.md
@@ -33,7 +33,7 @@ Success Response
  "name": "projects/BRAND_NEW/subscriptions/alert_engine",
  "topic": "projects/BRAND_NEW/topics/monitoring",
  "ackDeadlineSeconds": 10  ,
- "created_on": "2020-11-19T00:00:00Z"
+ "createdOn": "2020-11-19T00:00:00Z"
 }
 ```
 
@@ -42,7 +42,12 @@ Whenever a subscription is created with a valid push configuration, the service 
 should be later used to validate the ownership of the registered push endpoint, and will mark the subscription as 
 unverified.
 
-The `maxMessages` field declares the number of messages that should be send per
+The `type` field specifies what kind of push subscription the service will handle.
+The `http_endpoint` type is about subscriptions that will forward their messages
+to remote http endpoints. The `mattermost` type is about subscriptions that will
+forward their messages to mattermost channels through a mattermost webhook.
+
+The `maxMessages` field declares the number of messages that should be sent per
 push action. The default value is `1`. If `maxMessages` holds a value of `1` your
 push endpoint should expect a request body with the following schema:
 
@@ -88,12 +93,13 @@ should expect a request body with the following schema:
 }
 ```
 
-## Request to create Push Enabled Subscription
+## Request to create Push Enabled Subscription for http_endpoint
 ```json
 {
  "topic": "projects/BRAND_NEW/topics/monitoring",
  "ackDeadlineSeconds":10,
   "pushConfig": {
+    "type": "http_endpoint",
     "pushEndpoint": "https://127.0.0.1:5000/receive_here",
     "maxMessages": 3,
     "retryPolicy": {
@@ -112,7 +118,7 @@ should expect a request body with the following schema:
   "pushConfig": {
     "pushEndpoint": "https://127.0.0.1:5000/receive_here",
     "maxMessages": 3,
-    "authorization_header": {
+    "authorizationHeader": {
       "type": "autogen",
       "value": "4551h9j7f7dde380a5f8bc4fdb4fe980c565b67b"
     } ,
@@ -120,10 +126,55 @@ should expect a request body with the following schema:
       "type": "linear", 
       "period": 1000              	
     },
-    "verification_hash": "9d5189f7f758e380a5f8bc4fdb4fe980c565b67b",
-    "verified": false
+    "verificationHash": "9d5189f7f758e380a5f8bc4fdb4fe980c565b67b",
+    "verified": false,
+    "mattermostUrl": "",
+    "mattermostUsername": "",
+    "mattermostChannel": ""
     },
-  "created_on": "2020-11-19T00:00:00Z"
+  "createdOn": "2020-11-19T00:00:00Z"
+}
+```
+
+
+## Request to create Push Enabled Subscription for mattermost
+```json
+{
+ "topic": "projects/BRAND_NEW/topics/monitoring",
+ "ackDeadlineSeconds":10,
+  "pushConfig": {
+    "type": "mattermost",
+    "mattermostUrl": "webhook.com",
+    "mattermostUsername": "mattermost",
+    "mattermostChannel": "channel",
+    "retryPolicy": {
+      "type": "linear", 
+      "period": 1000              	
+    }
+   }
+}
+```
+
+### Response
+```json
+{
+ "name": "projects/BRAND_NEW/subscriptions/alert_engine",
+ "topic": "projects/BRAND_NEW/topics/monitoring",
+ "ackDeadlineSeconds": 10,
+  "pushConfig": {
+    "pushEndpoint": "",
+    "maxMessages": 1,
+    "retryPolicy": {
+      "type": "linear", 
+      "period": 1000              	
+    },
+    "verificationHash": "",
+    "verified": true,
+    "mattermostUrl": "webhook.com",
+    "mattermostUsername": "mattermost",
+    "mattermostChannel": "channel"
+    },
+  "createdOn": "2020-11-19T00:00:00Z"
 }
 ```
 
@@ -182,14 +233,14 @@ unverified.
 The owner of the push endpoint needs to execute the following steps in order to verify the ownership of the
 registered endpoint.
 
-- Open an api call with a path of `/ams_verification_hash`. The service will try to access this path using the `host:port`
+- Open an api call with a path of `/ams_verificationHash`. The service will try to access this path using the `host:port`
 of the push endpoint. For example, if the push endpoint is `https://example.com:8443/receive_here`, the  push endpoint should also
-support the api route of `https://example.com:8443/ams_verification_hash`.
+support the api route of `https://example.com:8443/ams_verificationHash`.
 
-- The api route of `https://example.com:8443/ams_verification_hash` should support the http `GET` method.
+- The api route of `https://example.com:8443/ams_verificationHash` should support the http `GET` method.
 
-- A `GET` request to `https://example.com:8443/ams_verification_hash` should return a response body 
-with only the `verification_hash`
+- A `GET` request to `https://example.com:8443/ams_verificationHash` should return a response body 
+with only the `verificationHash`
 that is found inside the subscriptions push configuration, 
 a `status code` of `200` and the header `Content-type: plain/text`.
 
@@ -279,14 +330,14 @@ Success Response
     "topic": "projects/BRAND_NEW/topics/monitoring",
     "pushConfig": {},
     "ackDeadlineSeconds": 10,
-    "created_on": "2020-11-19T00:00:00Z"
+    "createdOn": "2020-11-19T00:00:00Z"
   },
  {
    "name": "projects/BRAND_NEW/subscriptions/alert_engine2",
    "topic": "projects/BRAND_NEW/topics/monitoring",
    "pushConfig": {},
    "ackDeadlineSeconds": 10,
-   "created_on": "2020-11-19T00:00:00Z"
+   "createdOn": "2020-11-19T00:00:00Z"
  }],
  "nextPageToken": "",
  "totalSize": 2
@@ -321,7 +372,7 @@ Success Response
     "topic": "projects/BRAND_NEW/topics/monitoring",
     "pushConfig": {},
     "ackDeadlineSeconds": 10,
-    "created_on": "2020-11-19T00:00:00Z"
+    "createdOn": "2020-11-19T00:00:00Z"
   }
  ],
  "nextPageToken": "",
@@ -357,7 +408,7 @@ Success Response
     "topic": "projects/BRAND_NEW/topics/monitoring",
     "pushConfig": {},
     "ackDeadlineSeconds": 10,
-    "created_on": "2020-11-19T00:00:00Z"
+    "createdOn": "2020-11-19T00:00:00Z"
   }
  ],
  "nextPageToken": "some_token",
@@ -527,7 +578,7 @@ This request modifies the push configuration of a subscription
    "pushConfig":{  
       "pushEndpoint":"",
       "maxMessages": 5,
-      "authorization_header": {
+      "authorizationHeader": {
          "type": "autogen"
       },
       "retryPolicy":{  

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ARGOeu/argo-messaging
 
-go 1.14
+go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect

--- a/handlers/projects.go
+++ b/handlers/projects.go
@@ -753,8 +753,6 @@ func ProjectUserAdd(w http.ResponseWriter, r *http.Request) {
 	userProjects = append(userProjects, auth.ProjectRoles{
 		Project: projName,
 		Roles:   data.Roles,
-		Subs:    data.Subs,
-		Topics:  data.Topics,
 	})
 
 	_, err = auth.UpdateUser(userUUID, userFN, userLN, userOrg, userDesc, userName, userProjects, userEmail, userSRoles, modified, false, refStr)

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	// Initialize CORS specifics
-	xReqWithConType := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-Type", "x-api-key"})
+	xReqWithConType := handlers.AllowedHeaders([]string{"X-Requested-With", "Content-PushType", "x-api-key"})
 	allowVerbs := handlers.AllowedMethods([]string{"OPTIONS", "POST", "GET", "PUT", "DELETE", "HEAD"})
 	// Initialize server wth proper parameters
 	server := &http.Server{Addr: ":" + strconv.Itoa(cfg.Port), Handler: handlers.CORS(xReqWithConType, allowVerbs)(API.Router), TLSConfig: config}

--- a/push/grpc/client/client.go
+++ b/push/grpc/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/ARGOeu/argo-messaging/config"
 	amsPb "github.com/ARGOeu/argo-messaging/push/grpc/proto"
+	"github.com/ARGOeu/argo-messaging/subscriptions"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -119,19 +120,19 @@ func (c *GrpcClient) SubscriptionStatus(ctx context.Context, fullSub string) Cli
 }
 
 // ActivateSubscription is a wrapper over the grpc ActivateSubscription call
-func (c *GrpcClient) ActivateSubscription(ctx context.Context, fullSub, fullTopic, pushEndpoint, retryType string, retryPeriod uint32, maxMessages int64, authzHeader string) ClientStatus {
+func (c *GrpcClient) ActivateSubscription(ctx context.Context, subscription subscriptions.Subscription) ClientStatus {
 
 	actSubR := &amsPb.ActivateSubscriptionRequest{
 		Subscription: &amsPb.Subscription{
-			FullName:  fullSub,
-			FullTopic: fullTopic,
+			FullName:  subscription.FullName,
+			FullTopic: subscription.FullTopic,
 			PushConfig: &amsPb.PushConfig{
-				PushEndpoint:        pushEndpoint,
-				MaxMessages:         maxMessages,
-				AuthorizationHeader: authzHeader,
+				PushEndpoint:        subscription.PushCfg.Pend,
+				MaxMessages:         subscription.PushCfg.MaxMessages,
+				AuthorizationHeader: subscription.PushCfg.AuthorizationHeader.Value,
 				RetryPolicy: &amsPb.RetryPolicy{
-					Type:   retryType,
-					Period: retryPeriod,
+					Type:   subscription.PushCfg.RetPol.PolicyType,
+					Period: uint32(subscription.PushCfg.RetPol.Period),
 				},
 			},
 		}}

--- a/push/grpc/client/mock.go
+++ b/push/grpc/client/mock.go
@@ -3,6 +3,7 @@ package push
 import (
 	"context"
 	"fmt"
+	"github.com/ARGOeu/argo-messaging/subscriptions"
 )
 
 type MockClient struct{}
@@ -26,32 +27,32 @@ func (*MockClient) Target() string {
 
 func (*MockClient) Dial() error { return nil }
 
-func (*MockClient) ActivateSubscription(ctx context.Context, fullSub, fullTopic, pushEndpoint, retryType string, retryPeriod uint32, maxMessages int64, authzHeader string) ClientStatus {
+func (*MockClient) ActivateSubscription(ctx context.Context, subscription subscriptions.Subscription) ClientStatus {
 
-	switch fullSub {
+	switch subscription.FullName {
 	case "/projects/ARGO/subscriptions/subNew":
 
 		return &MockClientStatus{
-			Status: fmt.Sprintf("Subscription %v activated", fullSub),
+			Status: fmt.Sprintf("Subscription %v activated", subscription.FullName),
 		}
 
 	case "/projects/ARGO/subscriptions/sub1":
 
 		return &GrpcClientStatus{
 			err:     nil,
-			message: fmt.Sprintf("Subscription %v activated", fullSub),
+			message: fmt.Sprintf("Subscription %v activated", subscription.FullName),
 		}
 
 	case "/projects/ARGO/subscriptions/sub4":
 
 		return &GrpcClientStatus{
 			err:     nil,
-			message: fmt.Sprintf("Subscription %v activated", fullSub),
+			message: fmt.Sprintf("Subscription %v activated", subscription.FullName),
 		}
 	}
 
 	return &MockClientStatus{
-		Status: fmt.Sprintf("Subscription %v is already active", fullSub),
+		Status: fmt.Sprintf("Subscription %v is already active", subscription.FullName),
 	}
 
 }

--- a/push/grpc/client/pushclient.go
+++ b/push/grpc/client/pushclient.go
@@ -2,6 +2,7 @@ package push
 
 import (
 	"context"
+	"github.com/ARGOeu/argo-messaging/subscriptions"
 )
 
 // Client help us interface with any push backend mechanism
@@ -10,7 +11,7 @@ type Client interface {
 	Dial() error
 	// ActivateSubscription provides the push backend
 	// with all the necessary information to start the push functionality for the respective subscription
-	ActivateSubscription(ctx context.Context, fullSub, fullTopic, pushEndpoint, retryType string, retryPeriod uint32, maxMessages int64, authzHeader string) ClientStatus
+	ActivateSubscription(ctx context.Context, subscription subscriptions.Subscription) ClientStatus
 	// DeactivateSubscription asks the push backend to stop the push functionality for the respective subscription
 	DeactivateSubscription(ctx context.Context, fullSub string) ClientStatus
 	// SubscriptionStatus returns the current push status oif the given subscription

--- a/push/sender.go
+++ b/push/sender.go
@@ -38,7 +38,7 @@ func NewHTTPSender(timeoutSec int) *HTTPSender {
 func (hs *HTTPSender) Send(msg string, endpoint string) error {
 	var jsonStr = []byte(msg)
 	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonStr))
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-PushType", "application/json")
 	log.Debug("Sending to endpoint:", endpoint)
 	log.Debug("message contents:", msg)
 

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -867,10 +867,30 @@ func (mk *MockStore) Initialize() {
 	mk.TopicList = append(mk.TopicList, qtop4)
 
 	// populate Subscriptions
-	qsub1 := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}
-	qsub2 := QSub{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}}
-	qsub3 := QSub{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}}
-	qsub4 := QSub{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}}
+	qsub1 := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "",
+		"", "", 0, "", "", 10, "",
+		0, 0, 0, "", false, "", "", "",
+		time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC),
+		10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}
+
+	qsub2 := QSub{1, "argo_uuid", "sub2", "topic2", 0, 0, "",
+		"", "", 0, "", "", 10, "",
+		0, 0, 0, "", false, "", "", "",
+		time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC),
+		8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}}
+
+	qsub3 := QSub{2, "argo_uuid", "sub3", "topic3", 0, 0, "",
+		"", "", 0, "", "", 10, "",
+		0, 0, 0, "", false, "", "", "",
+		time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC),
+		5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}}
+
+	qsub4 := QSub{3, "argo_uuid", "sub4", "topic4", 0, 0, "",
+		"http_endpoint", "endpoint.foo", 1, "autogen",
+		"auth-header-1", 10, "linear", 300, 0, 0,
+		"push-id-1", true, "", "", "",
+		time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+		0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}}
 	mk.SubList = append(mk.SubList, qsub1)
 	mk.SubList = append(mk.SubList, qsub2)
 	mk.SubList = append(mk.SubList, qsub3)
@@ -1141,26 +1161,31 @@ func (mk *MockStore) LinkTopicSchema(projectUUID, name, schemaUUID string) error
 }
 
 // InsertSub inserts a new sub object to the store
-func (mk *MockStore) InsertSub(projectUUID string, name string, topic string, offset int64, maxMessages int64, authT string, authH string, ack int, push string, rPolicy string, rPeriod int, vhash string, verified bool, createdOn time.Time) error {
+func (mk *MockStore) InsertSub(projectUUID string, name string, topic string,
+	offset int64, ack int, pushCfg QPushConfig, createdOn time.Time) error {
 	sub := QSub{
 		ID:                  len(mk.SubList),
 		ProjectUUID:         projectUUID,
 		Name:                name,
 		Topic:               topic,
 		Offset:              offset,
+		NextOffset:          0,
+		PendingAck:          "",
 		Ack:                 ack,
-		MaxMessages:         maxMessages,
-		AuthorizationType:   authT,
-		AuthorizationHeader: authH,
-		PushEndpoint:        push,
-		RetPolicy:           rPolicy,
-		RetPeriod:           rPeriod,
-		VerificationHash:    vhash,
-		Verified:            verified,
+		PushType:            pushCfg.Type,
+		MaxMessages:         pushCfg.MaxMessages,
+		AuthorizationType:   pushCfg.AuthorizationType,
+		AuthorizationHeader: pushCfg.AuthorizationHeader,
+		PushEndpoint:        pushCfg.PushEndpoint,
+		RetPolicy:           pushCfg.RetPolicy,
+		RetPeriod:           pushCfg.RetPeriod,
+		VerificationHash:    pushCfg.VerificationHash,
+		Verified:            pushCfg.Verified,
+		MattermostUrl:       pushCfg.MattermostUrl,
+		MattermostChannel:   pushCfg.MattermostChannel,
+		MattermostUsername:  pushCfg.MattermostUsername,
 		MsgNum:              0,
 		TotalBytes:          0,
-		LatestConsume:       time.Time{},
-		ConsumeRate:         0,
 		CreatedOn:           createdOn,
 		ACL:                 []string{},
 	}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -1445,7 +1445,8 @@ func (mong *MongoStore) InsertProject(uuid string, name string, createdOn time.T
 }
 
 // InsertSub inserts a subscription to the store
-func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string, offset int64, maxMessages int64, authzType string, authzHeader string, ack int, push string, rPolicy string, rPeriod int, vhash string, verified bool, createdOn time.Time) error {
+func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string,
+	offset int64, ack int, pushCfg QPushConfig, createdOn time.Time) error {
 	sub := QSub{
 		ProjectUUID:         projectUUID,
 		Name:                name,
@@ -1454,14 +1455,18 @@ func (mong *MongoStore) InsertSub(projectUUID string, name string, topic string,
 		NextOffset:          0,
 		PendingAck:          "",
 		Ack:                 ack,
-		MaxMessages:         maxMessages,
-		AuthorizationType:   authzType,
-		AuthorizationHeader: authzHeader,
-		PushEndpoint:        push,
-		RetPolicy:           rPolicy,
-		RetPeriod:           rPeriod,
-		VerificationHash:    vhash,
-		Verified:            verified,
+		PushType:            pushCfg.Type,
+		MaxMessages:         pushCfg.MaxMessages,
+		AuthorizationType:   pushCfg.AuthorizationType,
+		AuthorizationHeader: pushCfg.AuthorizationHeader,
+		PushEndpoint:        pushCfg.PushEndpoint,
+		RetPolicy:           pushCfg.RetPolicy,
+		RetPeriod:           pushCfg.RetPeriod,
+		VerificationHash:    pushCfg.VerificationHash,
+		Verified:            pushCfg.Verified,
+		MattermostUrl:       pushCfg.MattermostUrl,
+		MattermostChannel:   pushCfg.MattermostChannel,
+		MattermostUsername:  pushCfg.MattermostUsername,
 		MsgNum:              0,
 		TotalBytes:          0,
 		CreatedOn:           createdOn,

--- a/stores/query_models.go
+++ b/stores/query_models.go
@@ -13,6 +13,7 @@ type QSub struct {
 	Offset              int64       `bson:"offset"`
 	NextOffset          int64       `bson:"next_offset"`
 	PendingAck          string      `bson:"pending_ack"`
+	PushType            string      `bson:"push_type"`
 	PushEndpoint        string      `bson:"push_endpoint"`
 	MaxMessages         int64       `bson:"max_messages"`
 	AuthorizationType   string      `bson:"authorization_type"`
@@ -24,10 +25,29 @@ type QSub struct {
 	TotalBytes          int64       `bson:"total_bytes"`
 	VerificationHash    string      `bson:"verification_hash"`
 	Verified            bool        `bson:"verified"`
+	MattermostUrl       string      `bson:"mattermost_url"`
+	MattermostUsername  string      `bson:"mattermost_username"`
+	MattermostChannel   string      `bson:"mattermost_channel"`
 	LatestConsume       time.Time   `bson:"latest_consume"`
 	ConsumeRate         float64     `bson:"consume_rate"`
 	CreatedOn           time.Time   `bson:"created_on"`
 	ACL                 []string    `bson:"acl"`
+}
+
+// QPushConfig holds optional configuration for push operations
+type QPushConfig struct {
+	Type                string `bson:"type"`
+	PushEndpoint        string `bson:"push_endpoint"`
+	MaxMessages         int64  `bson:"max_messages"`
+	AuthorizationType   string `bson:"authorization_type"`
+	AuthorizationHeader string `bson:"authorization_header"`
+	RetPolicy           string `bson:"retry_policy"`
+	RetPeriod           int    `bson:"retry_period"`
+	VerificationHash    string `bson:"verification_hash"`
+	Verified            bool   `bson:"verified"`
+	MattermostUrl       string `bson:"mattermost_url"`
+	MattermostUsername  string `bson:"mattermost_username"`
+	MattermostChannel   string `bson:"mattermost_channel"`
 }
 
 // QAcl holds a list of authorized users queried from topic or subscription collections

--- a/stores/store.go
+++ b/stores/store.go
@@ -45,7 +45,7 @@ type Store interface {
 	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubBytes(projectUUID string, name string, totalBytes int64) error
 	IncrementSubMsgNum(projectUUID string, name string, num int64) error
-	InsertSub(projectUUID string, name string, topic string, offest int64, maxMessages int64, authzType string, authzHeader string, ack int, push string, rPolicy string, rPeriod int, vhash string, verified bool, createdOn time.Time) error
+	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, pushCfg QPushConfig, createdOn time.Time) error
 	HasProject(name string) bool
 	HasUsers(projectUUID string, users []string) (bool, []string)
 	QueryOneSub(projectUUID string, name string) (QSub, error)

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -26,10 +26,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 
 	eSubList := []QSub{
-		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
-		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}},
-		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
-		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
+		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "http_endpoint", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, "", "", "", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
+		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}},
+		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
+		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
 	}
 	// retrieve all topics
 	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
@@ -102,8 +102,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve first 2 subs
 	eSubListFirstPage := []QSub{
-		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
-		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}}}
+		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "http_endpoint", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, "", "", "", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
+		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}}}
 
 	subList2, ts2, pg2, err2 := store.QuerySubs("argo_uuid", "", "", "", 2)
 	suite.Equal(eSubListFirstPage, subList2)
@@ -112,8 +112,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve next 2 subs
 	eSubListNextPage := []QSub{
-		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
-		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
+		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
+		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
 	}
 
 	subList3, ts3, pg3, err3 := store.QuerySubs("argo_uuid", "", "", "1", 2)
@@ -123,7 +123,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve user's subs
 	eSubList4 := []QSub{
-		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "endpoint.foo", MaxMessages: 1, AuthorizationType: "autogen", AuthorizationHeader: "auth-header-1", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, VerificationHash: "push-id-1", Verified: true, LatestConsume: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), ConsumeRate: 0, CreatedOn: time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), ACL: []string{}},
+		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushType: "http_endpoint", PushEndpoint: "endpoint.foo", MaxMessages: 1, AuthorizationType: "autogen", AuthorizationHeader: "auth-header-1", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, VerificationHash: "push-id-1", Verified: true, LatestConsume: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), ConsumeRate: 0, CreatedOn: time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 		{ID: 2, ProjectUUID: "argo_uuid", Name: "sub3", Topic: "topic3", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", MaxMessages: 0, Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, LatestConsume: time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), ConsumeRate: 5.45, CreatedOn: time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 		{ID: 1, ProjectUUID: "argo_uuid", Name: "sub2", Topic: "topic2", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", MaxMessages: 0, Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, LatestConsume: time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), ConsumeRate: 8.99, CreatedOn: time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 	}
@@ -136,7 +136,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// retrieve user's subs
 	eSubList5 := []QSub{
-		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "endpoint.foo", MaxMessages: 1, AuthorizationType: "autogen", AuthorizationHeader: "auth-header-1", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, VerificationHash: "push-id-1", Verified: true, LatestConsume: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), ConsumeRate: 0, CreatedOn: time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), ACL: []string{}},
+		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushType: "http_endpoint", PushEndpoint: "endpoint.foo", MaxMessages: 1, AuthorizationType: "autogen", AuthorizationHeader: "auth-header-1", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, VerificationHash: "push-id-1", Verified: true, LatestConsume: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), ConsumeRate: 0, CreatedOn: time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 		{ID: 2, ProjectUUID: "argo_uuid", Name: "sub3", Topic: "topic3", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", MaxMessages: 0, Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, LatestConsume: time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), ConsumeRate: 5.45, CreatedOn: time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 	}
 	subList5, ts5, pg5, err5 := store.QuerySubs("argo_uuid", "uuid1", "", "", 2)
@@ -211,7 +211,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
 
 	store.InsertTopic("argo_uuid", "topicFresh", "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.UTC))
-	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 10, "", "", 0, "", false, time.Date(2020, 12, 19, 0, 0, 0, 0, time.UTC))
+	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, QPushConfig{}, time.Date(2020, 12, 19, 0, 0, 0, 0, time.UTC))
 
 	eTopList2 := []QTopic{
 		{4, "argo_uuid", "topicFresh", 0, 0, time.Time{}, 0, "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.UTC), []string{}},
@@ -222,11 +222,11 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 
 	eSubList2 := []QSub{
-		{4, "argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Time{}, 0, time.Date(2020, 12, 19, 0, 0, 0, 0, time.UTC), []string{}},
-		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
-		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}},
-		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
-		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}}
+		{4, "argo_uuid", "subFresh", "topicFresh", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Time{}, 0, time.Date(2020, 12, 19, 0, 0, 0, 0, time.UTC), []string{}},
+		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "http_endpoint", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, "", "", "", time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
+		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}},
+		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
+		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}}
 
 	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList2, tpList)
@@ -250,7 +250,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("not found", err.Error())
 
 	sb, err := store.QueryOneSub("argo_uuid", "sub1")
-	esb := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", 0, "", "", 10, "", 0, 0, 0, "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}
+	esb := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}
 	suite.Equal(esb, sb)
 
 	// Test modify ack deadline in store

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -23,8 +23,11 @@ const (
 	SlowStartRetryPolicyType          = "slowstart"
 	AutoGenerationAuthorizationHeader = "autogen"
 	DisabledAuthorizationHeader       = "disabled"
+	HttpEndpointPushConfig            = "http_endpoint"
+	MattermostPushConfig              = "mattermost"
 	UnSupportedRetryPolicyError       = `Retry policy can only be of 'linear' or 'slowstart' type`
 	UnSupportedAuthorizationHeader    = `Authorization header type can only be of 'autogen' or 'disabled' type`
+	UnsupportedPushConfig             = `Push configuration type can only be of 'http_endpoint' or 'mattermost'`
 )
 
 var supportedRetryPolicyTypes = []string{
@@ -35,6 +38,11 @@ var supportedRetryPolicyTypes = []string{
 var supportedAuthorizationHeaderTypes = []string{
 	AutoGenerationAuthorizationHeader,
 	DisabledAuthorizationHeader,
+}
+
+var supportedPushConfigTypes = []string{
+	HttpEndpointPushConfig,
+	MattermostPushConfig,
 }
 
 // Subscription struct to hold information for a given topic
@@ -49,20 +57,24 @@ type Subscription struct {
 	Offset        int64      `json:"-"`
 	NextOffset    int64      `json:"-"`
 	PendingAck    string     `json:"-"`
-	PushStatus    string     `json:"push_status,omitempty"`
-	CreatedOn     string     `json:"created_on"`
+	PushStatus    string     `json:"pushStatus,omitempty"`
+	CreatedOn     string     `json:"createdOn"`
 	LatestConsume time.Time  `json:"-"`
 	ConsumeRate   float64    `json:"-"`
 }
 
 // PushConfig holds optional configuration for push operations
 type PushConfig struct {
+	Type                string              `json:"type"`
 	Pend                string              `json:"pushEndpoint"`
 	MaxMessages         int64               `json:"maxMessages"`
-	AuthorizationHeader AuthorizationHeader `json:"authorization_header"`
+	AuthorizationHeader AuthorizationHeader `json:"authorizationHeader"`
 	RetPol              RetryPolicy         `json:"retryPolicy"`
-	VerificationHash    string              `json:"verification_hash"`
+	VerificationHash    string              `json:"verificationHash"`
 	Verified            bool                `json:"verified"`
+	MattermostUrl       string              `json:"mattermostUrl"`
+	MattermostUsername  string              `json:"mattermostUsername"`
+	MattermostChannel   string              `json:"mattermostChannel"`
 }
 
 // SubMetrics holds the subscription's metric details
@@ -357,7 +369,7 @@ func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store s
 		curSub.NextOffset = item.NextOffset
 		curSub.Ack = item.Ack
 		curSub.CreatedOn = item.CreatedOn.UTC().Format("2006-01-02T15:04:05Z")
-		if item.PushEndpoint != "" {
+		if item.PushType != "" {
 			rp := RetryPolicy{
 				PolicyType: item.RetPolicy,
 			}
@@ -383,6 +395,10 @@ func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store s
 				RetPol:              rp,
 				VerificationHash:    item.VerificationHash,
 				Verified:            item.Verified,
+				MattermostUrl:       item.MattermostUrl,
+				MattermostChannel:   item.MattermostChannel,
+				MattermostUsername:  item.MattermostUsername,
+				Type:                item.PushType,
 			}
 		}
 		curSub.LatestConsume = item.LatestConsume
@@ -433,8 +449,9 @@ func LoadPushSubs(store stores.Store) PaginatedSubscriptions {
 	return result
 }
 
-// CreateSub creates a new subscription
-func CreateSub(projectUUID string, name string, topic string, push string, offset int64, maxMessages int64, authzType string, authzHeader string, ack int, retPolicy string, retPeriod int, vhash string, verified bool, createdOn time.Time, store stores.Store) (Subscription, error) {
+// Create creates a new subscription
+func Create(projectUUID string, name string, topic string, offset int64, ack int,
+	pushCfg PushConfig, createdOn time.Time, store stores.Store) (Subscription, error) {
 
 	if HasSub(projectUUID, name, store) {
 		return Subscription{}, errors.New("exists")
@@ -444,11 +461,26 @@ func CreateSub(projectUUID string, name string, topic string, push string, offse
 		ack = 10
 	}
 
-	if retPolicy == SlowStartRetryPolicyType {
-		retPeriod = 0
+	if pushCfg.RetPol.PolicyType == SlowStartRetryPolicyType {
+		pushCfg.RetPol.Period = 0
 	}
 
-	err := store.InsertSub(projectUUID, name, topic, offset, maxMessages, authzType, authzHeader, ack, push, retPolicy, retPeriod, vhash, verified, createdOn)
+	qPushCfg := stores.QPushConfig{
+		Type:                pushCfg.Type,
+		PushEndpoint:        pushCfg.Pend,
+		MaxMessages:         pushCfg.MaxMessages,
+		AuthorizationType:   pushCfg.AuthorizationHeader.Type,
+		AuthorizationHeader: pushCfg.AuthorizationHeader.Value,
+		RetPolicy:           pushCfg.RetPol.PolicyType,
+		RetPeriod:           pushCfg.RetPol.Period,
+		VerificationHash:    pushCfg.VerificationHash,
+		Verified:            pushCfg.Verified,
+		MattermostChannel:   pushCfg.MattermostChannel,
+		MattermostUrl:       pushCfg.MattermostUrl,
+		MattermostUsername:  pushCfg.MattermostUsername,
+	}
+
+	err := store.InsertSub(projectUUID, name, topic, offset, ack, qPushCfg, createdOn)
 	if err != nil {
 		return Subscription{}, errors.New("backend error")
 	}

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -201,6 +201,7 @@ func (suite *SubTestSuite) TestGetSubsByProject() {
 	rp := RetryPolicy{"linear", 300}
 	authCFG := AuthorizationHeader{"autogen", "auth-header-1"}
 	expSub4.PushCfg = PushConfig{
+		Type:                "http_endpoint",
 		Pend:                "endpoint.foo",
 		AuthorizationHeader: authCFG,
 		RetPol:              rp,
@@ -304,6 +305,7 @@ func (suite *SubTestSuite) TestLoadFromCfg() {
 	expSub4.CreatedOn = "2020-11-22T00:00:00Z"
 	rp := RetryPolicy{"linear", 300}
 	expSub4.PushCfg = PushConfig{
+		Type:                "http_endpoint",
 		Pend:                "endpoint.foo",
 		AuthorizationHeader: authCFG,
 		RetPol:              rp,
@@ -355,11 +357,13 @@ func (suite *SubTestSuite) TestCreateSubStore() {
 
 	store := stores.NewMockStore(APIcfg.StoreHost, APIcfg.StoreDB)
 
-	sub, err := CreateSub("argo_uuid", "sub1", "topic1", "", 0, 0, "", "", 0, "linear", 300, "", true, time.Date(2019, 7, 7, 0, 0, 0, 0, time.UTC), store)
+	sub, err := Create("argo_uuid", "sub1", "topic1", 0, 300,
+		PushConfig{}, time.Date(2019, 7, 7, 0, 0, 0, 0, time.UTC), store)
 	suite.Equal(Subscription{}, sub)
 	suite.Equal("exists", err.Error())
 
-	sub2, err2 := CreateSub("argo_uuid", "subNew", "topicNew", "", 0, 0, "", "", 0, "linear", 300, "", true, time.Date(2019, 7, 7, 0, 0, 0, 0, time.UTC), store)
+	sub2, err2 := Create("argo_uuid", "subNew", "topicNew", 0, 0,
+		PushConfig{}, time.Date(2019, 7, 7, 0, 0, 0, 0, time.UTC), store)
 	expSub := New("argo_uuid", "ARGO", "subNew", "topicNew")
 	expSub.CreatedOn = "2019-07-07T00:00:00Z"
 	suite.Equal(expSub, sub2)
@@ -527,15 +531,19 @@ func (suite *SubTestSuite) TestExportJson() {
    "name": "/projects/ARGO/subscriptions/sub1",
    "topic": "/projects/ARGO/topics/topic1",
    "pushConfig": {
+      "type": "",
       "pushEndpoint": "",
       "maxMessages": 0,
-      "authorization_header": {},
+      "authorizationHeader": {},
       "retryPolicy": {},
-      "verification_hash": "",
-      "verified": false
+      "verificationHash": "",
+      "verified": false,
+      "mattermostUrl": "",
+      "mattermostUsername": "",
+      "mattermostChannel": ""
    },
    "ackDeadlineSeconds": 10,
-   "created_on": "2020-11-19T00:00:00Z"
+   "createdOn": "2020-11-19T00:00:00Z"
 }`
 	suite.Equal(expJSON, outJSON)
 
@@ -545,9 +553,10 @@ func (suite *SubTestSuite) TestExportJson() {
          "name": "/projects/ARGO/subscriptions/sub4",
          "topic": "/projects/ARGO/topics/topic4",
          "pushConfig": {
+            "type": "http_endpoint",
             "pushEndpoint": "endpoint.foo",
             "maxMessages": 1,
-            "authorization_header": {
+            "authorizationHeader": {
                "type": "autogen",
                "value": "auth-header-1"
             },
@@ -555,53 +564,68 @@ func (suite *SubTestSuite) TestExportJson() {
                "type": "linear",
                "period": 300
             },
-            "verification_hash": "push-id-1",
-            "verified": true
+            "verificationHash": "push-id-1",
+            "verified": true,
+            "mattermostUrl": "",
+            "mattermostUsername": "",
+            "mattermostChannel": ""
          },
          "ackDeadlineSeconds": 10,
-         "created_on": "2020-11-22T00:00:00Z"
+         "createdOn": "2020-11-22T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/subscriptions/sub3",
          "topic": "/projects/ARGO/topics/topic3",
          "pushConfig": {
+            "type": "",
             "pushEndpoint": "",
             "maxMessages": 0,
-            "authorization_header": {},
+            "authorizationHeader": {},
             "retryPolicy": {},
-            "verification_hash": "",
-            "verified": false
+            "verificationHash": "",
+            "verified": false,
+            "mattermostUrl": "",
+            "mattermostUsername": "",
+            "mattermostChannel": ""
          },
          "ackDeadlineSeconds": 10,
-         "created_on": "2020-11-21T00:00:00Z"
+         "createdOn": "2020-11-21T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/subscriptions/sub2",
          "topic": "/projects/ARGO/topics/topic2",
          "pushConfig": {
+            "type": "",
             "pushEndpoint": "",
             "maxMessages": 0,
-            "authorization_header": {},
+            "authorizationHeader": {},
             "retryPolicy": {},
-            "verification_hash": "",
-            "verified": false
+            "verificationHash": "",
+            "verified": false,
+            "mattermostUrl": "",
+            "mattermostUsername": "",
+            "mattermostChannel": ""
          },
          "ackDeadlineSeconds": 10,
-         "created_on": "2020-11-20T00:00:00Z"
+         "createdOn": "2020-11-20T00:00:00Z"
       },
       {
          "name": "/projects/ARGO/subscriptions/sub1",
          "topic": "/projects/ARGO/topics/topic1",
          "pushConfig": {
+            "type": "",
             "pushEndpoint": "",
             "maxMessages": 0,
-            "authorization_header": {},
+            "authorizationHeader": {},
             "retryPolicy": {},
-            "verification_hash": "",
-            "verified": false
+            "verificationHash": "",
+            "verified": false,
+            "mattermostUrl": "",
+            "mattermostUsername": "",
+            "mattermostChannel": ""
          },
          "ackDeadlineSeconds": 10,
-         "created_on": "2020-11-19T00:00:00Z"
+         "createdOn": "2020-11-19T00:00:00Z"
       }
    ],
    "nextPageToken": "",


### PR DESCRIPTION
Introduced 4 new fields to the push config struct.

type, which indicates what type of push subscriptions is going to be created, http_endpoint or mattermost
mattermost_url(required), which is the  webhook_url
mattermost_username, which is the name the message will be delivered under in the channel
mattermost_channel, which is the channel where the messages will be delivered

Also changed some function definitions since the number of arguments has grown too much and readability has been reduced.