### PR TITLE
AM-284 API Call: Per project_admin usage report

### DIFF
--- a/doc/swagger/swagger.yaml
+++ b/doc/swagger/swagger.yaml
@@ -1250,6 +1250,32 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /users/usageReport:
+    get:
+      summary: Show the projects and their metrics, alongside service operational metrics based on the provided key
+      description: |
+        Show a specific's user usage information regarding its projects
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+        - $ref: '#/parameters/StartDate'
+        - $ref: '#/parameters/EndDate'
+        - $ref: '#/parameters/Projects'
+      tags:
+        - Users
+      responses:
+        200:
+          description: A User usage report object
+          schema:
+            $ref: '#/definitions/UserUsageReport'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        500:
+          $ref: "#/responses/500"
+
   /users/{USER}:refreshToken:
     post:
       summary: Refreshes the token of an existing user
@@ -2562,6 +2588,17 @@ definitions:
         type: string
       schema:
         type: object
+
+  UserUsageReport:
+    type: object
+    properties:
+      va_report:
+        type: object
+        $ref: '#/definitions/VAMetrics'
+      operational_metrics:
+        type: array
+        items:
+          $ref: '#/definitions/Metric'
 
   VAMetrics:
     type: object

--- a/metrics/models.go
+++ b/metrics/models.go
@@ -84,6 +84,11 @@ type Timepoint struct {
 	Value     interface{} `json:"value"`
 }
 
+type UserUsageReport struct {
+	VAReport           VAReport   `json:"va_metrics"`
+	OperationalMetrics MetricList `json:"operational_metrics"`
+}
+
 // ExportJSON exports whole ProjectTopic structure
 func (m *Metric) ExportJSON() (string, error) {
 	output, err := json.MarshalIndent(m, "", "   ")

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -225,3 +225,22 @@ func GenerateVAReport(projects []string, startDate time.Time, endDate time.Time,
 
 	return vaReport, nil
 }
+
+// GetUserUsageReport returns a VAReport populated with the needed metrics alongside service operational metrics
+func GetUserUsageReport(projects []string, startDate time.Time, endDate time.Time, str stores.Store) (UserUsageReport, error) {
+
+	vr, err := GetVAReport(projects, startDate, endDate, str)
+	if err != nil {
+		return UserUsageReport{}, err
+	}
+
+	om, err := GetUsageCpuMem(str)
+	if err != nil {
+		return UserUsageReport{}, err
+	}
+
+	return UserUsageReport{
+		VAReport:           vr,
+		OperationalMetrics: om,
+	}, nil
+}

--- a/routing.go
+++ b/routing.go
@@ -50,7 +50,10 @@ func NewRouting(cfg *config.APICfg, brk brokers.Broker, str stores.Store, mgr *o
 		handler = handlers.WrapLog(handler, route.Name)
 
 		// skip authentication/authorization for the health status and profile api calls
-		if route.Name != "ams:healthStatus" && "users:profile" != route.Name && route.Name != "version:list" {
+		if route.Name != "ams:healthStatus" &&
+			"users:profile" != route.Name &&
+			route.Name != "version:list" &&
+			route.Name != "users:usageReport" {
 			handler = handlers.WrapAuthorize(handler, route.Name, tokenExtractStrategy)
 			handler = handlers.WrapAuthenticate(handler, tokenExtractStrategy)
 		}
@@ -86,6 +89,7 @@ var defaultRoutes = []APIRoute{
 	{"users:byUUID", "GET", "/users:byUUID/{uuid}", handlers.UserListByUUID},
 	{"users:list", "GET", "/users", handlers.UserListAll},
 	{"users:profile", "GET", "/users/profile", handlers.UserProfile},
+	{"users:usageReport", "GET", "/users/usageReport", handlers.UserUsageReport},
 	{"users:show", "GET", "/users/{user}", handlers.UserListOne},
 	{"users:refreshToken", "POST", "/users/{user}:refreshToken", handlers.RefreshToken},
 	{"users:create", "POST", "/users/{user}", handlers.UserCreate},

--- a/website/docs/api_advanced/api_metrics.md
+++ b/website/docs/api_advanced/api_metrics.md
@@ -102,7 +102,7 @@ Success Response
 ### Errors
 Please refer to section [Errors](/api_basic/api_errors.md) to see all possible Errors
 
-## [GET] Get Daily Message Average
+## [GET] Get a VA Report
 
 This request returns the total amount of messages per project for the given time window. The number of messages
 is calculated using the `daily message count` for each one of the project's topics.
@@ -121,14 +121,14 @@ GET "/v1/metrics/daily-message-average"
 
 ```bash
 curl -H "Content-Type: application/json"
- "https://{URL}/v1/metrics/daily-message-average"
+ "https://{URL}/v1/metrics/va_metrics"
 ```
 
 ### Example request with URL parameters
 
 ```bash
 curl -H "Content-Type: application/json"
- "https://{URL}/v1/metrics/daily-message-average?start_date=2019-03-01&end_date=2019-07-24&projects=ARGO,ARGO-2"
+ "https://{URL}/v1/metrics/va_metrics?start_date=2019-03-01&end_date=2019-07-24&projects=ARGO,ARGO-2"
 ```
 
 ### Responses
@@ -157,3 +157,125 @@ Success Response
 ```
 ### Errors
 Please refer to section [Errors](/api_basic/api_errors.md) to see all possible Errors
+
+## [GET] Get User usage report
+
+This is a combination of the va_metrics and the operational_metrics
+api calls.The user will receive data for all of the projects that has
+the project_admin role alongisde the operational metrics of the service.
+
+### Request
+```
+GET "/v1/users/usageReport"
+
+```
+### URL parameters
+`start_date`: start date for querying projects topics daily message count(optional), default value is the start unix time
+`end_date`: start date for querying projects topics daily message count(optional), default is the time of the api call
+`projects`: which projects to include to the query(optional), default is all registered projects
+
+### Example request
+
+```bash
+curl -H "Content-Type: application/json"
+ "https://{URL}/v1/users/usageReport"
+```
+
+### Example request with URL parameters
+
+```bash
+curl -H "Content-Type: application/json"
+ "https://{URL}/v1/users/usageReport?start_date=2019-03-01&end_date=2019-07-24&projects=ARGO,ARGO-2"
+```
+
+### Responses
+Success Response
+`200 OK`
+
+```json
+{
+    "va_metrics": {
+        "projects_metrics": {
+            "projects": [
+                {
+                    "project": "e2epush",
+                    "message_count": 27,
+                    "average_daily_messages": 0.03,
+                    "topics_count": 3,
+                    "subscriptions_count": 6,
+                    "users_count": 0
+                }
+            ],
+            "total_message_count": 27,
+            "average_daily_messages": 0.03
+        },
+        "total_users_count": 0,
+        "total_topics_count": 3,
+        "total_subscriptions_count": 6
+    },
+    "operational_metrics": {
+        "metrics": [
+            {
+                "metric": "ams_node.cpu_usage",
+                "metric_type": "percentage",
+                "value_type": "float64",
+                "resource_type": "ams_node",
+                "resource_name": "test-MBP",
+                "timeseries": [
+                    {
+                        "timestamp": "2022-09-13T09:39:56Z",
+                        "value": 0
+                    }
+                ],
+                "description": "Percentage value that displays the CPU usage of ams service in the specific node"
+            },
+            {
+                "metric": "ams_node.memory_usage",
+                "metric_type": "percentage",
+                "value_type": "float64",
+                "resource_type": "ams_node",
+                "resource_name": "test-MBP",
+                "timeseries": [
+                    {
+                        "timestamp": "2022-09-13T09:39:56Z",
+                        "value": 0.1
+                    }
+                ],
+                "description": "Percentage value that displays the Memory usage of ams service in the specific node"
+            },
+            {
+                "metric": "ams_node.cpu_usage",
+                "metric_type": "percentage",
+                "value_type": "float64",
+                "resource_type": "ams_node",
+                "resource_name": "4",
+                "timeseries": [
+                    {
+                        "timestamp": "2022-09-13T09:39:56Z",
+                        "value": 0
+                    }
+                ],
+                "description": "Percentage value that displays the CPU usage of ams service in the specific node"
+            },
+            {
+                "metric": "ams_node.memory_usage",
+                "metric_type": "percentage",
+                "value_type": "float64",
+                "resource_type": "ams_node",
+                "resource_name": "4",
+                "timeseries": [
+                    {
+                        "timestamp": "2022-09-13T09:39:56Z",
+                        "value": 0.1
+                    }
+                ],
+                "description": "Percentage value that displays the Memory usage of ams service in the specific node"
+            }
+        ]
+    }
+}
+```
+### Errors
+Please refer to section [Errors](/api_basic/api_errors.md) to see all possible Errors
+
+


### PR DESCRIPTION
Add a new api call that will allow project admins to va metrics for their projects along side operational metrics for the service.
The user also has the ability to filter which of his projects wants data for, using the url query projects paramater.
The end_date and start_date parameters of the va report are supported.

GET @ /v1/users/usageReport

