### PR TITLE
AM-306 Static analysis assessment fixes

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -597,26 +597,26 @@ func (suite *AuthTestSuite) TestAuth() {
 
 	puC, e1 := PaginatedFindUsers("", 1, "argo_uuid2", false, true, store2)
 	suite.Equal(qUsersC, puC.Users)
-	suite.Equal(int32(1), puC.TotalSize)
+	suite.Equal(int64(1), puC.TotalSize)
 	suite.Equal("", puC.NextPageToken)
 
 	suite.Equal(qUsers1, pu1.Users)
-	suite.Equal(int32(9), pu1.TotalSize)
+	suite.Equal(int64(9), pu1.TotalSize)
 	suite.Equal("", pu1.NextPageToken)
 	suite.Nil(e1)
 
 	suite.Equal(qUsers2, pu2.Users)
-	suite.Equal(int32(3), pu2.TotalSize)
+	suite.Equal(int64(3), pu2.TotalSize)
 	suite.Equal("NQ==", pu2.NextPageToken)
 	suite.Nil(e2)
 
 	suite.Equal(qUsers3, pu3.Users)
-	suite.Equal(int32(2), pu3.TotalSize)
+	suite.Equal(int64(2), pu3.TotalSize)
 	suite.Equal("Mg==", pu3.NextPageToken)
 	suite.Nil(e3)
 
 	suite.Equal(0, len(pu4.Users))
-	suite.Equal(int32(0), pu4.TotalSize)
+	suite.Equal(int64(0), pu4.TotalSize)
 	suite.Equal("", pu4.NextPageToken)
 	suite.Nil(e4)
 

--- a/auth/users.go
+++ b/auth/users.go
@@ -55,7 +55,7 @@ type Users struct {
 type PaginatedUsers struct {
 	Users         []User `json:"users"`
 	NextPageToken string `json:"nextPageToken"`
-	TotalSize     int32  `json:"totalSize"`
+	TotalSize     int64  `json:"totalSize"`
 }
 
 // UserRegistration holds information about a new user registration
@@ -75,7 +75,7 @@ type UserRegistration struct {
 	ModifiedAt      string `json:"modified_at,omitempty"`
 }
 
-// UserRegistration holds a list with all the user registrations in the service
+// UserRegistrationsList holds a list with all the user registrations in the service
 type UserRegistrationsList struct {
 	UserRegistrations []UserRegistration `json:"user_registrations"`
 }
@@ -391,9 +391,9 @@ func FindUsers(projectUUID string, uuid string, name string, priviledged bool, s
 }
 
 // PaginatedFindUsers returns a page of users
-func PaginatedFindUsers(pageToken string, pageSize int32, projectUUID string, privileged, detailedView bool, store stores.Store) (PaginatedUsers, error) {
+func PaginatedFindUsers(pageToken string, pageSize int64, projectUUID string, privileged, detailedView bool, store stores.Store) (PaginatedUsers, error) {
 
-	var totalSize int32
+	var totalSize int64
 	var nextPageToken string
 	var err error
 	var users []stores.QUser

--- a/handlers/projects.go
+++ b/handlers/projects.go
@@ -849,11 +849,14 @@ func ProjectListUsers(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// check that user is indeed a service admin in order to be priviledged to see full user info
-	priviledged := auth.IsServiceAdmin(refRoles)
+	// check that user is indeed a service admin in order to be privileged to see full user info
+	privileged := auth.IsServiceAdmin(refRoles)
 
-	// Get Results Object - call is always priviledged because this handler is only accessible by service admins
-	if paginatedUsers, err = auth.PaginatedFindUsers(pageToken, int32(pageSize), projectUUID, priviledged, usersDetailedView, refStr); err != nil {
+	// Get Results Object - call is always privileged because this handler is only accessible by service admins
+	paginatedUsers, err =
+		auth.PaginatedFindUsers(pageToken, int64(pageSize), projectUUID, privileged, usersDetailedView, refStr)
+
+	if err != nil {
 		err := APIErrorInvalidData("Invalid page token")
 		respondErr(w, err)
 		return

--- a/handlers/subscriptions.go
+++ b/handlers/subscriptions.go
@@ -1286,7 +1286,8 @@ func SubListAll(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if res, err = subscriptions.Find(projectUUID, userUUID, "", pageToken, int32(pageSize), refStr); err != nil {
+	res, err = subscriptions.Find(projectUUID, userUUID, "", pageToken, int64(pageSize), refStr)
+	if err != nil {
 		err := APIErrorInvalidData("Invalid page token")
 		respondErr(w, err)
 		return

--- a/handlers/topics.go
+++ b/handlers/topics.go
@@ -540,7 +540,7 @@ func TopicListAll(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if res, err = topics.Find(projectUUID, userUUID, "", pageToken, int32(pageSize), refStr); err != nil {
+	if res, err = topics.Find(projectUUID, userUUID, "", pageToken, int64(pageSize), refStr); err != nil {
 		err := APIErrorInvalidData("Invalid page token")
 		respondErr(w, err)
 		return

--- a/handlers/users.go
+++ b/handlers/users.go
@@ -470,11 +470,14 @@ func UserListAll(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// check that user is indeed a service admin in order to be priviledged to see full user info
-	priviledged := auth.IsServiceAdmin(refRoles)
+	// check that user is indeed a service admin in order to be privileged to see full user info
+	privileged := auth.IsServiceAdmin(refRoles)
 
-	// Get Results Object - call is always priviledged because this handler is only accessible by service admins
-	if paginatedUsers, err = auth.PaginatedFindUsers(pageToken, int32(pageSize), projectUUID, priviledged, usersDetailedView, refStr); err != nil {
+	// Get Results Object - call is always privileged because this handler is only accessible by service admins
+	paginatedUsers, err =
+		auth.PaginatedFindUsers(pageToken, int64(pageSize), projectUUID, privileged, usersDetailedView, refStr)
+
+	if err != nil {
 		err := APIErrorInvalidData("Invalid page token")
 		respondErr(w, err)
 		return

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -756,7 +756,7 @@ func (mk *MockStore) QueryUsers(projectUUID string, uuid string, name string) ([
 }
 
 // PaginatedQueryUsers provides query to the list of users using pagination parameters
-func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int32, projectUUID string) ([]QUser, int32, string, error) {
+func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int64, projectUUID string) ([]QUser, int64, string, error) {
 
 	var qUsers []QUser
 	var nextPageToken string
@@ -764,7 +764,7 @@ func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int32, proje
 	var pg int
 	var limit int
 
-	totalSize := int32(0)
+	totalSize := int64(0)
 
 	if pageSize == 0 {
 		limit = len(mk.UserList)
@@ -828,7 +828,7 @@ func (mk *MockStore) PaginatedQueryUsers(pageToken string, pageSize int32, proje
 	}
 
 	if projectUUID == "" {
-		totalSize = int32(len(qUsers))
+		totalSize = int64(len(qUsers))
 	} else {
 		for _, user := range mk.UserList {
 			for _, project := range user.Projects {
@@ -1322,10 +1322,10 @@ func (mk *MockStore) QueryPushSubs() []QSub {
 }
 
 // QuerySubs Query Subscription info from store
-func (mk *MockStore) QuerySubs(projectUUID, userUUID, name, pageToken string, pageSize int32) ([]QSub, int32, string, error) {
+func (mk *MockStore) QuerySubs(projectUUID, userUUID, name, pageToken string, pageSize int64) ([]QSub, int64, string, error) {
 
 	var qSubs []QSub
-	var totalSize int32
+	var totalSize int64
 	var nextPageToken string
 	var err error
 	var pg int
@@ -1400,7 +1400,7 @@ func (mk *MockStore) QuerySubs(projectUUID, userUUID, name, pageToken string, pa
 
 		}
 
-		totalSize = int32(counter)
+		totalSize = int64(counter)
 
 		if len(qSubs) > 0 && len(qSubs) == int(pageSize)+1 {
 			nextPageToken = strconv.Itoa(qSubs[int(pageSize)].ID.(int))
@@ -1473,10 +1473,10 @@ func (mk *MockStore) QueryTopicsByACL(projectUUID, user string) ([]QTopic, error
 }
 
 // QueryTopics Query Subscription info from store
-func (mk *MockStore) QueryTopics(projectUUID, userUUID, name, pageToken string, pageSize int32) ([]QTopic, int32, string, error) {
+func (mk *MockStore) QueryTopics(projectUUID, userUUID, name, pageToken string, pageSize int64) ([]QTopic, int64, string, error) {
 
 	var qTopics []QTopic
-	var totalSize int32
+	var totalSize int64
 	var nextPageToken string
 	var err error
 	var pg int
@@ -1556,7 +1556,7 @@ func (mk *MockStore) QueryTopics(projectUUID, userUUID, name, pageToken string, 
 
 		}
 
-		totalSize = int32(counter)
+		totalSize = int64(counter)
 
 		if len(qTopics) > 0 && len(qTopics) == int(pageSize)+1 {
 			nextPageToken = strconv.Itoa(qTopics[int(pageSize)].ID.(int))

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -697,11 +697,11 @@ func (mong *MongoStore) QueryUsers(projectUUID string, uuid string, name string)
 }
 
 // PaginatedQueryUsers returns a page of users
-func (mong *MongoStore) PaginatedQueryUsers(pageToken string, pageSize int32, projectUUID string) ([]QUser, int32, string, error) {
+func (mong *MongoStore) PaginatedQueryUsers(pageToken string, pageSize int64, projectUUID string) ([]QUser, int64, string, error) {
 
 	var qUsers []QUser
-	var totalSize int32
-	var limit int32
+	var totalSize int64
+	var limit int64
 	var size int
 	var nextPageToken string
 	var err error
@@ -740,7 +740,7 @@ func (mong *MongoStore) PaginatedQueryUsers(pageToken string, pageSize int32, pr
 			},
 		).Fatal(err.Error())
 	}
-	totalSize = int32(size)
+	totalSize = int64(size)
 
 	// now take into account if pagination is enabled and change the query accordingly
 	// first check if an pageToken is provided and whether or not is a valid bson ID
@@ -887,11 +887,11 @@ func (mong *MongoStore) QueryTopicsByACL(projectUUID, user string) ([]QTopic, er
 }
 
 // QueryTopics Query Subscription info from store
-func (mong *MongoStore) QueryTopics(projectUUID, userUUID, name, pageToken string, pageSize int32) ([]QTopic, int32, string, error) {
+func (mong *MongoStore) QueryTopics(projectUUID, userUUID, name, pageToken string, pageSize int64) ([]QTopic, int64, string, error) {
 
 	var err error
-	var totalSize int32
-	var limit int32
+	var totalSize int64
+	var limit int64
 	var nextPageToken string
 	var qTopics []QTopic
 	var ok bool
@@ -966,7 +966,7 @@ func (mong *MongoStore) QueryTopics(projectUUID, userUUID, name, pageToken strin
 			).Fatal(err.Error())
 		}
 
-		totalSize = int32(size)
+		totalSize = int64(size)
 
 		// if the amount of topics that were found was equal to the limit, its a sign that there are topics to populate the next page
 		// so pick the last element's pageToken to use as the starting point for the next page
@@ -1822,11 +1822,11 @@ func (mong *MongoStore) RemoveResource(col string, res interface{}) error {
 }
 
 // QuerySubs Query Subscription info from store
-func (mong *MongoStore) QuerySubs(projectUUID, userUUID, name, pageToken string, pageSize int32) ([]QSub, int32, string, error) {
+func (mong *MongoStore) QuerySubs(projectUUID, userUUID, name, pageToken string, pageSize int64) ([]QSub, int64, string, error) {
 
 	var err error
-	var totalSize int32
-	var limit int32
+	var totalSize int64
+	var limit int64
 	var nextPageToken string
 	var qSubs []QSub
 	var ok bool
@@ -1901,7 +1901,7 @@ func (mong *MongoStore) QuerySubs(projectUUID, userUUID, name, pageToken string,
 			).Fatal(err.Error())
 		}
 
-		totalSize = int32(size)
+		totalSize = int64(size)
 
 		// if the amount of subscriptions that were found was equal to the limit, its a sign that there are subscriptions to populate the next page
 		// so pick the last element's pageToken to use as the starting point for the next page

--- a/stores/store.go
+++ b/stores/store.go
@@ -10,8 +10,8 @@ type Store interface {
 	QuerySubsByTopic(projectUUID, topic string) ([]QSub, error)
 	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
 	QuerySubsByACL(projectUUID, user string) ([]QSub, error)
-	QuerySubs(projectUUID string, userUUID string, name string, pageToken string, pageSize int32) ([]QSub, int32, string, error)
-	QueryTopics(projectUUID string, userUUID string, name string, pageToken string, pageSize int32) ([]QTopic, int32, string, error)
+	QuerySubs(projectUUID string, userUUID string, name string, pageToken string, pageSize int64) ([]QSub, int64, string, error)
+	QueryTopics(projectUUID string, userUUID string, name string, pageToken string, pageSize int64) ([]QTopic, int64, string, error)
 	QueryDailyTopicMsgCount(projectUUID string, name string, date time.Time) ([]QDailyTopicMsgCount, error)
 	UpdateTopicLatestPublish(projectUUID string, name string, date time.Time) error
 	UpdateTopicPublishRate(projectUUID string, name string, rate float64) error
@@ -19,7 +19,7 @@ type Store interface {
 	UpdateSubConsumeRate(projectUUID string, name string, rate float64) error
 	RemoveTopic(projectUUID string, name string) error
 	RemoveSub(projectUUID string, name string) error
-	PaginatedQueryUsers(pageToken string, pageSize int32, projectUUID string) ([]QUser, int32, string, error)
+	PaginatedQueryUsers(pageToken string, pageSize int64, projectUUID string) ([]QUser, int64, string, error)
 	QueryUsers(projectUUID string, uuid string, name string) ([]QUser, error)
 	UpdateUser(uuid, fname, lname, org, desc string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error
 	AppendToUserProjects(userUUID string, projectUUID string, pRoles ...string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -34,7 +34,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	// retrieve all topics
 	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList, tpList)
-	suite.Equal(int32(4), ts1)
+	suite.Equal(int64(4), ts1)
 	suite.Equal("", pg1)
 
 	// retrieve first 2
@@ -44,7 +44,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 	tpList2, ts2, pg2, _ := store.QueryTopics("argo_uuid", "", "", "", 2)
 	suite.Equal(eTopList1st2, tpList2)
-	suite.Equal(int32(4), ts2)
+	suite.Equal(int64(4), ts2)
 	suite.Equal("1", pg2)
 
 	// retrieve the last one
@@ -53,7 +53,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 	tpList3, ts3, pg3, _ := store.QueryTopics("argo_uuid", "", "", "0", 1)
 	suite.Equal(eTopList3, tpList3)
-	suite.Equal(int32(4), ts3)
+	suite.Equal(int64(4), ts3)
 	suite.Equal("", pg3)
 
 	// retrieve a single topic
@@ -62,7 +62,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 	tpList4, ts4, pg4, _ := store.QueryTopics("argo_uuid", "", "topic1", "", 0)
 	suite.Equal(eTopList4, tpList4)
-	suite.Equal(int32(0), ts4)
+	suite.Equal(int64(0), ts4)
 	suite.Equal("", pg4)
 
 	// retrieve a single topic
@@ -81,7 +81,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 	tpList5, ts5, pg5, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 0)
 	suite.Equal(eTopList5, tpList5)
-	suite.Equal(int32(2), ts5)
+	suite.Equal(int64(2), ts5)
 	suite.Equal("", pg5)
 
 	// retrieve use's topic with pagination
@@ -91,13 +91,13 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	tpList6, ts6, pg6, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 1)
 	suite.Equal(eTopList6, tpList6)
-	suite.Equal(int32(2), ts6)
+	suite.Equal(int64(2), ts6)
 	suite.Equal("0", pg6)
 
 	// retrieve all subs
 	subList, ts1, pg1, err1 := store.QuerySubs("argo_uuid", "", "", "", 0)
 	suite.Equal(eSubList, subList)
-	suite.Equal(int32(4), ts1)
+	suite.Equal(int64(4), ts1)
 	suite.Equal("", pg3)
 
 	// retrieve first 2 subs
@@ -107,7 +107,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	subList2, ts2, pg2, err2 := store.QuerySubs("argo_uuid", "", "", "", 2)
 	suite.Equal(eSubListFirstPage, subList2)
-	suite.Equal(int32(4), ts2)
+	suite.Equal(int64(4), ts2)
 	suite.Equal("1", pg2)
 
 	// retrieve next 2 subs
@@ -118,7 +118,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	subList3, ts3, pg3, err3 := store.QuerySubs("argo_uuid", "", "", "1", 2)
 	suite.Equal(eSubListNextPage, subList3)
-	suite.Equal(int32(4), ts3)
+	suite.Equal(int64(4), ts3)
 	suite.Equal("", pg3)
 
 	// retrieve user's subs
@@ -130,7 +130,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	subList4, ts4, pg4, err4 := store.QuerySubs("argo_uuid", "uuid1", "", "", 0)
 
-	suite.Equal(int32(3), ts4)
+	suite.Equal(int64(3), ts4)
 	suite.Equal("", pg4)
 	suite.Equal(eSubList4, subList4)
 
@@ -141,7 +141,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	}
 	subList5, ts5, pg5, err5 := store.QuerySubs("argo_uuid", "uuid1", "", "", 2)
 
-	suite.Equal(int32(3), ts5)
+	suite.Equal(int64(3), ts5)
 	suite.Equal("1", pg5)
 	suite.Equal(eSubList5, subList5)
 
@@ -531,21 +531,21 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	suite.Equal(store2.UserList, qUsers1)
 	suite.Equal("", pg1)
-	suite.Equal(int32(9), ts1)
+	suite.Equal(int64(9), ts1)
 
 	suite.Equal(8, qUsers2[0].ID)
 	suite.Equal(7, qUsers2[1].ID)
 	suite.Equal("6", pg2)
-	suite.Equal(int32(2), ts2)
+	suite.Equal(int64(2), ts2)
 
 	suite.Equal(0, len(qUsers3))
 	suite.Equal("", pg3)
-	suite.Equal(int32(0), ts3)
+	suite.Equal(int64(0), ts3)
 
 	suite.Equal(4, qUsers4[0].ID)
 	suite.Equal(3, qUsers4[1].ID)
 	suite.Equal("2", pg4)
-	suite.Equal(int32(2), ts4)
+	suite.Equal(int64(2), ts4)
 
 	// test update topic latest publish time
 	e1ulp := store2.UpdateTopicLatestPublish("argo_uuid", "topic1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC))

--- a/subscriptions/subscription.go
+++ b/subscriptions/subscription.go
@@ -101,7 +101,7 @@ type AuthorizationHeader struct {
 type PaginatedSubscriptions struct {
 	Subscriptions []Subscription `json:"subscriptions"`
 	NextPageToken string         `json:"nextPageToken"`
-	TotalSize     int32          `json:"totalSize"`
+	TotalSize     int64          `json:"totalSize"`
 }
 
 // SubPullOptions holds info about a pull operation on a subscription
@@ -348,11 +348,11 @@ func VerifyPushEndpoint(sub Subscription, c *http.Client, store stores.Store) er
 }
 
 // Find searches the store for all subscriptions of a given project or a specific one
-func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store stores.Store) (PaginatedSubscriptions, error) {
+func Find(projectUUID, userUUID, name, pageToken string, pageSize int64, store stores.Store) (PaginatedSubscriptions, error) {
 
 	var err error
 	var qSubs []stores.QSub
-	var totalSize int32
+	var totalSize int64
 	var nextPageToken string
 	var pageTokenBytes []byte
 

--- a/subscriptions/subscription_test.go
+++ b/subscriptions/subscription_test.go
@@ -251,25 +251,25 @@ func (suite *SubTestSuite) TestGetSubsByProject() {
 
 	suite.Equal(expSubs1, result1.Subscriptions)
 	suite.Equal("", result1.NextPageToken)
-	suite.Equal(int32(4), result1.TotalSize)
+	suite.Equal(int64(4), result1.TotalSize)
 
 	suite.Equal(expSubs2, result2.Subscriptions)
 	suite.Equal("MQ==", result2.NextPageToken)
-	suite.Equal(int32(4), result2.TotalSize)
+	suite.Equal(int64(4), result2.TotalSize)
 
 	suite.Equal(expSubs3, result3.Subscriptions)
 	suite.Equal("", result3.NextPageToken)
-	suite.Equal(int32(4), result3.TotalSize)
+	suite.Equal(int64(4), result3.TotalSize)
 
 	suite.Equal("illegal base64 data at input byte 4", err.Error())
 
 	suite.Equal(expSubs4, result4.Subscriptions)
 	suite.Equal("", result4.NextPageToken)
-	suite.Equal(int32(3), result4.TotalSize)
+	suite.Equal(int64(3), result4.TotalSize)
 
 	suite.Equal(expSubs5, result5.Subscriptions)
 	suite.Equal("MQ==", result5.NextPageToken)
-	suite.Equal(int32(3), result5.TotalSize)
+	suite.Equal(int64(3), result5.TotalSize)
 }
 
 func (suite *SubTestSuite) TestLoadFromCfg() {

--- a/topics/topic.go
+++ b/topics/topic.go
@@ -35,7 +35,7 @@ type TopicMetrics struct {
 type PaginatedTopics struct {
 	Topics        []Topic `json:"topics"`
 	NextPageToken string  `json:"nextPageToken"`
-	TotalSize     int32   `json:"totalSize"`
+	TotalSize     int64   `json:"totalSize"`
 }
 
 // Empty returns true if Topics has no items
@@ -81,11 +81,11 @@ func FindMetric(projectUUID string, name string, store stores.Store) (TopicMetri
 }
 
 // Find searches and returns a specific topic or all topics of a given project
-func Find(projectUUID, userUUID, name, pageToken string, pageSize int32, store stores.Store) (PaginatedTopics, error) {
+func Find(projectUUID, userUUID, name, pageToken string, pageSize int64, store stores.Store) (PaginatedTopics, error) {
 
 	var err error
 	var qTopics []stores.QTopic
-	var totalSize int32
+	var totalSize int64
 	var nextPageToken string
 	var pageTokenBytes []byte
 


### PR DESCRIPTION
The error regarding 

"TLS InsecureSkipVerify may be true." is something that we cannot just remove right now as we use it for local dev and also as a fallback to debug when we encounter connection errors between ams and push server