### PR TITLE
AM-326 ams:Introduce trace id identifier in logs

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -32,55 +33,55 @@ func GetACLFromJSON(input []byte) (ACL, error) {
 }
 
 // ModACL is called to modify an acl
-func ModACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
+func ModACL(ctx context.Context, projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
 	// Transform user name to user uuid
 
 	userUUIDs := []string{}
 	for _, username := range acl {
-		userUUID := GetUUIDByName(username, store)
+		userUUID := GetUUIDByName(ctx, username, store)
 		userUUIDs = append(userUUIDs, userUUID)
 	}
 
-	return store.ModACL(projectUUID, resourceType, resourceName, userUUIDs)
+	return store.ModACL(ctx, projectUUID, resourceType, resourceName, userUUIDs)
 }
 
 // AppendToACL is used to append unique users to a topic's or sub's ACL
-func AppendToACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
+func AppendToACL(ctx context.Context, projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
 
 	// Transform user name to user uuid
 	userUUIDs := []string{}
 	for _, username := range acl {
-		userUUID := GetUUIDByName(username, store)
+		userUUID := GetUUIDByName(ctx, username, store)
 		userUUIDs = append(userUUIDs, userUUID)
 	}
 
-	return store.AppendToACL(projectUUID, resourceType, resourceName, userUUIDs)
+	return store.AppendToACL(ctx, projectUUID, resourceType, resourceName, userUUIDs)
 }
 
 // AppendToACL is used to remove users from a topic's or sub's acl
-func RemoveFromACL(projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
+func RemoveFromACL(ctx context.Context, projectUUID string, resourceType string, resourceName string, acl []string, store stores.Store) error {
 
 	// Transform user name to user uuid
 	userUUIDs := []string{}
 	for _, username := range acl {
-		userUUID := GetUUIDByName(username, store)
+		userUUID := GetUUIDByName(ctx, username, store)
 		userUUIDs = append(userUUIDs, userUUID)
 	}
 
-	return store.RemoveFromACL(projectUUID, resourceType, resourceName, userUUIDs)
+	return store.RemoveFromACL(ctx, projectUUID, resourceType, resourceName, userUUIDs)
 }
 
 // GetACL returns an authorized list of user for the resource (topic or subscription)
-func GetACL(projectUUID string, resourceType string, resourceName string, store stores.Store) (ACL, error) {
+func GetACL(ctx context.Context, projectUUID string, resourceType string, resourceName string, store stores.Store) (ACL, error) {
 	result := ACL{}
-	acl, err := store.QueryACL(projectUUID, resourceType, resourceName)
+	acl, err := store.QueryACL(ctx, projectUUID, resourceType, resourceName)
 	if err != nil {
 		return result, err
 	}
 	for _, item := range acl.ACL {
 
 		// Get Username from user uuid
-		username := GetNameByUUID(item, store)
+		username := GetNameByUUID(ctx, item, store)
 		// if username is empty, meaning that the user with this id probably doesn't exists
 		// skip it and don't pollute the acl with empty ""
 		if username == "" {

--- a/brokers/broker.go
+++ b/brokers/broker.go
@@ -13,12 +13,12 @@ type Broker interface {
 	InitConfig()
 	Initialize(peers []string)
 	CloseConnections()
-	Publish(topic string, payload messages.Message) (string, string, int, int64, error)
-	GetMinOffset(topic string) int64
-	GetMaxOffset(topic string) int64
+	Publish(ctx context.Context, topic string, payload messages.Message) (string, string, int, int64, error)
+	GetMinOffset(ctx context.Context, topic string) int64
+	GetMaxOffset(ctx context.Context, topic string) int64
 	Consume(ctx context.Context, topic string, offset int64, imm bool, max int64) ([]string, error)
-	DeleteTopic(topic string) error
-	TimeToOffset(topic string, time time.Time) (int64, error)
+	DeleteTopic(ctx context.Context, topic string) error
+	TimeToOffset(ctx context.Context, topic string, time time.Time) (int64, error)
 }
 
 var ErrOffsetOff = errors.New("Offset is off")

--- a/brokers/mock.go
+++ b/brokers/mock.go
@@ -93,10 +93,10 @@ func (b *MockBroker) Initialize(peers []string) {
 }
 
 // Publish function publish a message to the broker
-func (b *MockBroker) Publish(topic string, msg messages.Message) (string, string, int, int64, error) {
+func (b *MockBroker) Publish(ctx context.Context, topic string, msg messages.Message) (string, string, int, int64, error) {
 	payload, _ := msg.ExportJSON()
 	b.MsgList = append(b.MsgList, payload)
-	off := b.GetMaxOffset(topic) - 1
+	off := b.GetMaxOffset(ctx, topic) - 1
 	msgID := strconv.FormatInt(off, 10)
 	// split the name that SHOULD come in the form of project_uuid.topic_name
 	s := strings.Split(topic, ".")
@@ -104,12 +104,12 @@ func (b *MockBroker) Publish(topic string, msg messages.Message) (string, string
 }
 
 // GetOffset returns a current topic's offset
-func (b *MockBroker) GetMaxOffset(topic string) int64 {
+func (b *MockBroker) GetMaxOffset(ctx context.Context, topic string) int64 {
 	return int64(len(b.MsgList) + 1)
 }
 
 // GetOffset returns a current topic's offset
-func (b *MockBroker) GetMinOffset(topic string) int64 {
+func (b *MockBroker) GetMinOffset(ctx context.Context, topic string) int64 {
 	return int64(len(b.MsgList))
 }
 
@@ -119,7 +119,7 @@ func (b *MockBroker) Consume(ctx context.Context, topic string, offset int64, im
 }
 
 // Delete topic from the broker
-func (b *MockBroker) DeleteTopic(topic string) error {
+func (b *MockBroker) DeleteTopic(ctx context.Context, topic string) error {
 
 	_, ok := b.Topics[topic]
 	if !ok {
@@ -130,7 +130,7 @@ func (b *MockBroker) DeleteTopic(topic string) error {
 	return nil
 }
 
-func (b *MockBroker) TimeToOffset(topic string, time time.Time) (int64, error) {
+func (b *MockBroker) TimeToOffset(ctx context.Context, topic string, time time.Time) (int64, error) {
 
 	topicTimeIndices, ok := b.TopicTimeIndices[topic]
 

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -25,7 +25,7 @@ type APIError struct {
 	Reason  string `json:"reason"`
 }
 
-// api err to be used when dealing with an invalid request body
+// APIErrorInvalidRequestBody to be used when dealing with an invalid request body
 var APIErrorInvalidRequestBody = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -39,7 +39,7 @@ var APIErrorInvalidRequestBody = func() APIErrorRoot {
 	}
 }
 
-// api err to be used when a name provided through the url parameters is not valid
+// APIErrorInvalidName to be used when a name provided through the url parameters is not valid
 var APIErrorInvalidName = func(key string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -53,7 +53,7 @@ var APIErrorInvalidName = func(key string) APIErrorRoot {
 	}
 }
 
-// api err to be used when data provided is invalid
+// APIErrorInvalidData to be used when data provided is invalid
 var APIErrorInvalidData = func(msg string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -67,7 +67,7 @@ var APIErrorInvalidData = func(msg string) APIErrorRoot {
 	}
 }
 
-// api err to be used when argument's provided are invalid according to the resource
+// APIErrorInvalidArgument to be used when argument's provided are invalid according to the resource
 var APIErrorInvalidArgument = func(resource string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -81,7 +81,7 @@ var APIErrorInvalidArgument = func(resource string) APIErrorRoot {
 	}
 }
 
-// api err to be used when a user is unauthorized
+// APIErrorUnauthorized to be used when a user is unauthorized
 var APIErrorUnauthorized = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -95,7 +95,7 @@ var APIErrorUnauthorized = func() APIErrorRoot {
 	}
 }
 
-// api err to be used when access to a resource is forbidden for the request user
+// APIErrorForbidden to be used when access to a resource is forbidden for the request user
 var APIErrorForbidden = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -109,13 +109,13 @@ var APIErrorForbidden = func() APIErrorRoot {
 	}
 }
 
-// api err to be used when access to a resource is forbidden for the request user
+// APIErrorForbiddenWithMsg to be used when access to a resource is forbidden for the request user
 var APIErrorForbiddenWithMsg = func(msg string) APIErrorRoot {
 	apiErrBody := APIErrorBody{Code: http.StatusForbidden, Message: fmt.Sprintf("Access to this resource is forbidden. %v", msg), Status: "FORBIDDEN"}
 	return APIErrorRoot{Body: apiErrBody}
 }
 
-// api err for dealing with absent resources
+// APIErrorNotFound for dealing with absent resources
 var APIErrorNotFound = func(resource string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -129,7 +129,7 @@ var APIErrorNotFound = func(resource string) APIErrorRoot {
 	}
 }
 
-// api err for dealing with  timeouts
+// APIErrorTimeout for dealing with  timeouts
 var APIErrorTimeout = func(msg string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -143,7 +143,7 @@ var APIErrorTimeout = func(msg string) APIErrorRoot {
 	}
 }
 
-// api err for dealing with already existing resources
+// APIErrorConflict for dealing with already existing resources
 var APIErrorConflict = func(resource string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -157,7 +157,7 @@ var APIErrorConflict = func(resource string) APIErrorRoot {
 	}
 }
 
-// api error to be used when push enabled false
+// APIErrorPushConflict to be used when push enabled false
 var APIErrorPushConflict = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -171,7 +171,7 @@ var APIErrorPushConflict = func() APIErrorRoot {
 	}
 }
 
-// api error to be used to format generic conflict errors
+// APIErrorGenericConflict to be used to format generic conflict errors
 var APIErrorGenericConflict = func(msg string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -185,7 +185,7 @@ var APIErrorGenericConflict = func(msg string) APIErrorRoot {
 	}
 }
 
-// api error to be used when push enabled false
+// APIErrorPullNoTopic to be used when push enabled false
 var APIErrorPullNoTopic = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -199,7 +199,7 @@ var APIErrorPullNoTopic = func() APIErrorRoot {
 	}
 }
 
-// api err for dealing with too large messages
+// APIErrTooLargeMessage for dealing with too large messages
 var APIErrTooLargeMessage = func(resource string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -213,7 +213,7 @@ var APIErrTooLargeMessage = func(resource string) APIErrorRoot {
 	}
 }
 
-// api err for dealing with generic internal errors
+// APIErrGenericInternal for dealing with generic internal errors
 var APIErrGenericInternal = func(msg string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -227,7 +227,7 @@ var APIErrGenericInternal = func(msg string) APIErrorRoot {
 	}
 }
 
-// api err for dealing with generic internal errors
+// APIErrPushVerification for dealing with generic internal errors
 var APIErrPushVerification = func(msg string) APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -241,7 +241,7 @@ var APIErrPushVerification = func(msg string) APIErrorRoot {
 	}
 }
 
-// api err for dealing with internal errors when marshaling json to struct
+// APIErrExportJSON for dealing with internal errors when marshaling json to struct
 var APIErrExportJSON = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -255,7 +255,7 @@ var APIErrExportJSON = func() APIErrorRoot {
 	}
 }
 
-// api err for dealing with internal errors when querying the datastore
+// APIErrQueryDatastore for dealing with internal errors when querying the datastore
 var APIErrQueryDatastore = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -269,7 +269,7 @@ var APIErrQueryDatastore = func() APIErrorRoot {
 	}
 }
 
-// api err for dealing with internal errors related to acknowledgement
+// APIErrHandlingAcknowledgement for dealing with internal errors related to acknowledgement
 var APIErrHandlingAcknowledgement = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -283,7 +283,7 @@ var APIErrHandlingAcknowledgement = func() APIErrorRoot {
 	}
 }
 
-// api err for dealing with generic backend errors
+// APIErrGenericBackend for dealing with generic backend errors
 var APIErrGenericBackend = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{
@@ -297,7 +297,7 @@ var APIErrGenericBackend = func() APIErrorRoot {
 	}
 }
 
-// api error to be used when push enabled true but push worker was not able to be retrieved
+// APIErrInternalPush to be used when push enabled true but push worker was not able to be retrieved
 var APIErrInternalPush = func() APIErrorRoot {
 
 	apiErrBody := APIErrorBody{

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -16,6 +16,7 @@ import (
 	gorillaContext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
+	"github.com/twinj/uuid"
 	"net/http"
 	"sort"
 	"time"
@@ -24,7 +25,8 @@ import (
 // WrapValidate handles validation
 func WrapValidate(hfn http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+		traceId := gorillaContext.Get(r, "trace_id").(string)
+		rCTX := context.WithValue(context.Background(), "trace_id", traceId)
 		urlVars := mux.Vars(r)
 
 		// sort keys
@@ -38,7 +40,7 @@ func WrapValidate(hfn http.HandlerFunc) http.HandlerFunc {
 		for _, key := range keys {
 			if validation.ValidName(urlVars[key]) == false {
 				err := APIErrorInvalidName(key)
-				respondErr(w, err)
+				respondErr(rCTX, w, err)
 				return
 			}
 		}
@@ -61,7 +63,11 @@ func WrapMockAuthConfig(hfn http.HandlerFunc, cfg *config.APICfg, brk brokers.Br
 		nStr := str.Clone()
 		defer nStr.Close()
 
-		projectUUID := projects.GetUUIDByName(urlVars["project"], nStr)
+		traceId := uuid.NewV4().String()
+		gorillaContext.Set(r, "trace_id", traceId)
+
+		projectUUID := projects.GetUUIDByName(context.WithValue(context.Background(), "trace_id", traceId),
+			urlVars["project"], nStr)
 		gorillaContext.Set(r, "auth_project_uuid", projectUUID)
 		gorillaContext.Set(r, "brk", brk)
 		gorillaContext.Set(r, "str", nStr)
@@ -86,6 +92,8 @@ func WrapConfig(hfn http.HandlerFunc, cfg *config.APICfg, brk brokers.Broker, st
 
 		nStr := str.Clone()
 		defer nStr.Close()
+		traceId := uuid.NewV4().String()
+		gorillaContext.Set(r, "trace_id", traceId)
 		gorillaContext.Set(r, "brk", brk)
 		gorillaContext.Set(r, "str", nStr)
 		gorillaContext.Set(r, "mgr", mgr)
@@ -107,6 +115,17 @@ func WrapLog(hfn http.Handler, name string) http.HandlerFunc {
 
 		start := time.Now()
 
+		log.WithFields(
+			log.Fields{
+				"type":      "request_log",
+				"method":    r.Method,
+				"path":      r.URL.Path,
+				"action":    name,
+				"requester": gorillaContext.Get(r, "auth_user_uuid"),
+				"trace_id":  gorillaContext.Get(r, "trace_id"),
+			},
+		).Info("New Request accepted . . .")
+
 		hfn.ServeHTTP(w, r)
 
 		log.WithFields(
@@ -117,6 +136,7 @@ func WrapLog(hfn http.Handler, name string) http.HandlerFunc {
 				"action":          name,
 				"requester":       gorillaContext.Get(r, "auth_user_uuid"),
 				"processing_time": time.Since(start).String(),
+				"trace_id":        gorillaContext.Get(r, "trace_id"),
 			},
 		).Info("")
 	})
@@ -125,6 +145,8 @@ func WrapLog(hfn http.Handler, name string) http.HandlerFunc {
 // WrapAuthenticate handle wrapper to apply authentication
 func WrapAuthenticate(hfn http.Handler, extractToken RequestTokenExtractStrategy) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceId := gorillaContext.Get(r, "trace_id").(string)
+		rCTX := context.WithValue(context.Background(), "trace_id", traceId)
 
 		urlVars := mux.Vars(r)
 
@@ -133,7 +155,7 @@ func WrapAuthenticate(hfn http.Handler, extractToken RequestTokenExtractStrategy
 		// if the url parameter 'key' is empty or absent, end the request with an unauthorized response
 		if apiKey == "" {
 			err := APIErrorUnauthorized()
-			respondErr(w, err)
+			respondErr(rCTX, w, err)
 			return
 		}
 
@@ -141,14 +163,14 @@ func WrapAuthenticate(hfn http.Handler, extractToken RequestTokenExtractStrategy
 		serviceToken := gorillaContext.Get(r, "auth_service_token").(string)
 
 		projectName := urlVars["project"]
-		projectUUID := projects.GetUUIDByName(urlVars["project"], refStr)
+		projectUUID := projects.GetUUIDByName(rCTX, urlVars["project"], refStr)
 
 		// In all cases instead of project create
 		if "projects:create" != mux.CurrentRoute(r).GetName() {
 			// Check if given a project name the project wasn't found
 			if projectName != "" && projectUUID == "" {
 				apiErr := APIErrorNotFound("project")
-				respondErr(w, apiErr)
+				respondErr(rCTX, w, apiErr)
 				return
 			}
 		}
@@ -163,10 +185,10 @@ func WrapAuthenticate(hfn http.Handler, extractToken RequestTokenExtractStrategy
 			return
 		}
 
-		roles, user := auth.Authenticate(projectUUID, apiKey, refStr)
+		roles, user := auth.Authenticate(rCTX, projectUUID, apiKey, refStr)
 
 		if len(roles) > 0 {
-			userUUID := auth.GetUUIDByName(user, refStr)
+			userUUID := auth.GetUUIDByName(rCTX, user, refStr)
 			gorillaContext.Set(r, "auth_roles", roles)
 			gorillaContext.Set(r, "auth_user", user)
 			gorillaContext.Set(r, "auth_user_uuid", userUUID)
@@ -174,7 +196,7 @@ func WrapAuthenticate(hfn http.Handler, extractToken RequestTokenExtractStrategy
 			hfn.ServeHTTP(w, r)
 		} else {
 			err := APIErrorUnauthorized()
-			respondErr(w, err)
+			respondErr(rCTX, w, err)
 		}
 
 	})
@@ -183,6 +205,8 @@ func WrapAuthenticate(hfn http.Handler, extractToken RequestTokenExtractStrategy
 // WrapAuthorize handle wrapper to apply authorization
 func WrapAuthorize(hfn http.Handler, routeName string, extractToken RequestTokenExtractStrategy) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceId := gorillaContext.Get(r, "trace_id").(string)
+		rCTX := context.WithValue(context.Background(), "trace_id", traceId)
 
 		refStr := gorillaContext.Get(r, "str").(stores.Store)
 		refRoles := gorillaContext.Get(r, "auth_roles").([]string)
@@ -195,17 +219,19 @@ func WrapAuthorize(hfn http.Handler, routeName string, extractToken RequestToken
 			return
 		}
 
-		if auth.Authorize(routeName, refRoles, refStr) {
+		if auth.Authorize(rCTX, routeName, refRoles, refStr) {
 			hfn.ServeHTTP(w, r)
 		} else {
 			err := APIErrorForbidden()
-			respondErr(w, err)
+			respondErr(rCTX, w, err)
 		}
 	})
 }
 
 // HealthCheck returns an ok message to make sure the service is up and running
 func HealthCheck(w http.ResponseWriter, r *http.Request) {
+	traceId := gorillaContext.Get(r, "trace_id").(string)
+	rCTX := context.WithValue(context.Background(), "trace_id", traceId)
 
 	var err error
 	var bytes []byte
@@ -235,16 +261,16 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 		tokenExtractStrategy := GetRequestTokenExtractStrategy(authOption)
 		token := tokenExtractStrategy(r)
 
-		user, _ := auth.GetUserByToken(token, refStr)
+		user, _ := auth.GetUserByToken(rCTX, token, refStr)
 
 		// if the user has a name, the token is valid
 		if user.Name == "" {
-			respondErr(w, APIErrorForbidden())
+			respondErr(rCTX, w, APIErrorForbidden())
 			return
 		}
 
 		if !auth.IsAdminViewer(user.ServiceRoles) && !auth.IsServiceAdmin(user.ServiceRoles) {
-			respondErr(w, APIErrorUnauthorized())
+			respondErr(rCTX, w, APIErrorUnauthorized())
 			return
 		}
 
@@ -255,7 +281,7 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if pushEnabled {
-		_, err := auth.GetPushWorker(pwToken, refStr)
+		_, err := auth.GetPushWorker(rCTX, pwToken, refStr)
 		if err != nil {
 			healthMsg.Status = "warning"
 		}
@@ -273,7 +299,7 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 
 	if bytes, err = json.MarshalIndent(healthMsg, "", " "); err != nil {
 		err := APIErrGenericInternal(err.Error())
-		respondErr(w, err)
+		respondErr(rCTX, w, err)
 		return
 	}
 
@@ -282,6 +308,8 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 
 // ListVersion displays version information about the service
 func ListVersion(w http.ResponseWriter, r *http.Request) {
+	traceId := gorillaContext.Get(r, "trace_id").(string)
+	rCTX := context.WithValue(context.Background(), "trace_id", traceId)
 
 	// Add content type header to the response
 	contentType := "application/json"
@@ -307,7 +335,7 @@ func ListVersion(w http.ResponseWriter, r *http.Request) {
 	token := tokenExtractStrategy(r)
 
 	if token != "" {
-		user, _ := auth.GetUserByToken(token, refStr)
+		user, _ := auth.GetUserByToken(rCTX, token, refStr)
 
 		// set uuid for logging
 		gorillaContext.Set(r, "auth_user_uuid", user.UUID)
@@ -323,7 +351,7 @@ func ListVersion(w http.ResponseWriter, r *http.Request) {
 	output, err := json.MarshalIndent(v, "", " ")
 	if err != nil {
 		err := APIErrGenericInternal(err.Error())
-		respondErr(w, err)
+		respondErr(rCTX, w, err)
 		return
 	}
 
@@ -337,9 +365,10 @@ func respondOK(w http.ResponseWriter, output []byte) {
 }
 
 // respondErr is used to finalize response writer with proper error codes and error output
-func respondErr(w http.ResponseWriter, apiErr APIErrorRoot) {
+func respondErr(ctx context.Context, w http.ResponseWriter, apiErr APIErrorRoot) {
 	log.WithFields(
 		log.Fields{
+			"trace_id":    ctx.Value("trace_id"),
 			"type":        "service_log",
 			"status_code": apiErr.Body.Code,
 		},
@@ -350,7 +379,8 @@ func respondErr(w http.ResponseWriter, apiErr APIErrorRoot) {
 	w.Write(output)
 }
 
-// A function type that refers to all the functions that can extract an api access token from the request
+// RequestTokenExtractStrategy is a function type that refers to all the functions
+// that can extract an api access token from the request
 type RequestTokenExtractStrategy func(r *http.Request) string
 
 // UrlKeyExtract extracts the api access token from the url parameter key

--- a/handlers/projects_test.go
+++ b/handlers/projects_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"github.com/ARGOeu/argo-messaging/auth"
 	"github.com/ARGOeu/argo-messaging/brokers"
@@ -717,7 +718,7 @@ func (suite *ProjectsHandlersTestSuite) TestProjectUserCreate() {
 		router.HandleFunc("/v1/projects/{project}/members/{user}", WrapMockAuthConfig(ProjectUserCreate, cfgKafka, &brk, str, &mgr, pc))
 		router.ServeHTTP(w, req)
 		if t.expectedStatusCode == 200 {
-			u, _ := auth.FindUsers("argo_uuid", "", t.user, true, str)
+			u, _ := auth.FindUsers(context.Background(), "argo_uuid", "", t.user, true, str)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{UUID}}", u.List[0].UUID, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{TOKEN}}", u.List[0].Token, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{CON}}", u.List[0].CreatedOn, 1)
@@ -936,7 +937,7 @@ func (suite *ProjectsHandlersTestSuite) TestProjectUserUpdate() {
 		router.HandleFunc("/v1/projects/{project}/members/{user}", WrapMockAuthConfig(ProjectUserUpdate, cfgKafka, &brk, str, &mgr, pc, t.authRole))
 		router.ServeHTTP(w, req)
 		if t.expectedStatusCode == 200 {
-			u, _ := auth.FindUsers("argo_uuid", "", t.user, true, str)
+			u, _ := auth.FindUsers(context.Background(), "argo_uuid", "", t.user, true, str)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{UUID}}", u.List[0].UUID, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{TOKEN}}", u.List[0].Token, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{CON}}", u.List[0].CreatedOn, 1)
@@ -1170,7 +1171,7 @@ func (suite *ProjectsHandlersTestSuite) TestProjectUserAdd() {
 		router.HandleFunc("/v1/projects/{project}/members/{user}:add", WrapMockAuthConfig(ProjectUserAdd, cfgKafka, &brk, str, &mgr, pc, t.authRole))
 		router.ServeHTTP(w, req)
 		if t.expectedStatusCode == 200 {
-			u, _ := auth.FindUsers("argo_uuid", "", t.user, true, str)
+			u, _ := auth.FindUsers(context.Background(), "argo_uuid", "", t.user, true, str)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{UUID}}", u.List[0].UUID, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{TOKEN}}", u.List[0].Token, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{CON}}", u.List[0].CreatedOn, 1)

--- a/handlers/registrations_test.go
+++ b/handlers/registrations_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"github.com/ARGOeu/argo-messaging/auth"
 	"github.com/ARGOeu/argo-messaging/brokers"
@@ -191,7 +192,7 @@ func (suite *RegistrationsHandlersTestSuite) TestAcceptRegisterUser() {
 		router.HandleFunc("/v1/registrations/{uuid}:accept", WrapMockAuthConfig(AcceptRegisterUser, cfgKafka, &brk, str, &mgr, pc))
 		router.ServeHTTP(w, req)
 		if t.expectedStatusCode == 200 {
-			u, _ := auth.FindUsers("", "", t.uname, true, str)
+			u, _ := auth.FindUsers(context.Background(), "", "", t.uname, true, str)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{UUID}}", u.List[0].UUID, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{TOKEN}}", u.List[0].Token, 1)
 			t.expectedResponse = strings.Replace(t.expectedResponse, "{{CON}}", u.List[0].CreatedOn, 1)

--- a/stores/store.go
+++ b/stores/store.go
@@ -1,79 +1,80 @@
 package stores
 
 import (
+	"context"
 	"time"
 )
 
 // Store encapsulates the generic store interface
 type Store interface {
 	Initialize()
-	QuerySubsByTopic(projectUUID, topic string) ([]QSub, error)
-	QueryTopicsByACL(projectUUID, user string) ([]QTopic, error)
-	QuerySubsByACL(projectUUID, user string) ([]QSub, error)
-	QuerySubs(projectUUID string, userUUID string, name string, pageToken string, pageSize int64) ([]QSub, int64, string, error)
-	QueryTopics(projectUUID string, userUUID string, name string, pageToken string, pageSize int64) ([]QTopic, int64, string, error)
-	QueryDailyTopicMsgCount(projectUUID string, name string, date time.Time) ([]QDailyTopicMsgCount, error)
-	UpdateTopicLatestPublish(projectUUID string, name string, date time.Time) error
-	UpdateTopicPublishRate(projectUUID string, name string, rate float64) error
-	UpdateSubLatestConsume(projectUUID string, name string, date time.Time) error
-	UpdateSubConsumeRate(projectUUID string, name string, rate float64) error
-	RemoveTopic(projectUUID string, name string) error
-	RemoveSub(projectUUID string, name string) error
-	PaginatedQueryUsers(pageToken string, pageSize int64, projectUUID string) ([]QUser, int64, string, error)
-	QueryUsers(projectUUID string, uuid string, name string) ([]QUser, error)
-	UpdateUser(uuid, fname, lname, org, desc string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error
-	AppendToUserProjects(userUUID string, projectUUID string, pRoles ...string) error
-	UpdateUserToken(uuid string, token string) error
-	RemoveUser(uuid string) error
-	QueryProjects(uuid string, name string) ([]QProject, error)
-	UpdateProject(projectUUID string, name string, description string, modifiedOn time.Time) error
-	RemoveProject(uuid string) error
-	RemoveProjectTopics(projectUUID string) error
-	RemoveProjectSubs(projectUUID string) error
-	RemoveProjectDailyMessageCounters(projectUUID string) error
-	QueryDailyProjectMsgCount(projectUUID string) ([]QDailyProjectMsgCount, error)
-	QueryTotalMessagesPerProject(projectUUIDs []string, startDate time.Time, endDate time.Time) ([]QProjectMessageCount, error)
-	RegisterUser(uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error
-	DeleteRegistration(uuid string) error
-	QueryRegistrations(regUUID, status, activationToken, name, email, org string) ([]QUserRegistration, error)
-	UpdateRegistration(regUUID, status, declineComment, modifiedBy, modifiedAt string) error
-	InsertUser(uuid string, projects []QProjectRoles, name string, firstName string, lastName string, org string, desc string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
-	InsertProject(uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
-	InsertOpMetric(hostname string, cpu float64, mem float64) error
-	InsertTopic(projectUUID string, name string, schemaUUID string, createdOn time.Time) error
-	LinkTopicSchema(projectUUID, name, schemaUUID string) error
-	IncrementTopicMsgNum(projectUUID string, name string, num int64) error
-	IncrementDailyTopicMsgCount(projectUUID string, topicName string, num int64, date time.Time) error
-	IncrementTopicBytes(projectUUID string, name string, totalBytes int64) error
-	IncrementSubBytes(projectUUID string, name string, totalBytes int64) error
-	IncrementSubMsgNum(projectUUID string, name string, num int64) error
-	InsertSub(projectUUID string, name string, topic string, offest int64, ack int, pushCfg QPushConfig, createdOn time.Time) error
-	HasProject(name string) bool
-	HasUsers(projectUUID string, users []string) (bool, []string)
-	QueryOneSub(projectUUID string, name string) (QSub, error)
-	QueryPushSubs() []QSub
-	HasResourceRoles(resource string, roles []string) bool
-	GetOpMetrics() []QopMetric
-	GetUserRoles(projectUUID string, token string) ([]string, string)
-	GetUserFromToken(token string) (QUser, error)
-	UpdateSubOffset(projectUUID string, name string, offset int64)
-	UpdateSubPull(projectUUID string, name string, offset int64, ts string) error
-	UpdateSubOffsetAck(projectUUID string, name string, offset int64, ts string) error
-	ModSubPush(projectUUID string, name string, pushCfg QPushConfig) error
-	QueryACL(projectUUID string, resource string, name string) (QAcl, error)
-	ExistsInACL(projectUUID string, resource string, resourceName string, userUUID string) error
-	ModACL(projectUUID string, resource string, name string, acl []string) error
-	AppendToACL(projectUUID string, resource string, name string, acl []string) error
-	RemoveFromACL(projectUUID string, resource string, name string, acl []string) error
-	ModAck(projectUUID string, name string, ack int) error
-	GetAllRoles() []string
-	InsertSchema(projectUUID, schemaUUID, name, schemaType, rawSchemaString string) error
-	QuerySchemas(projectUUID, schemaUUID, name string) ([]QSchema, error)
-	UpdateSchema(schemaUUID, name, schemaType, rawSchemaString string) error
-	DeleteSchema(schemaUUID string) error
-	UsersCount(startDate, endDate time.Time, projectUUIDs []string) (map[string]int64, error)
-	TopicsCount(startDate, endDate time.Time, projectUUIDs []string) (map[string]int64, error)
-	SubscriptionsCount(startDate, endDate time.Time, projectUUIDs []string) (map[string]int64, error)
+	QuerySubsByTopic(ctx context.Context, projectUUID, topic string) ([]QSub, error)
+	QueryTopicsByACL(ctx context.Context, projectUUID, user string) ([]QTopic, error)
+	QuerySubsByACL(ctx context.Context, projectUUID, user string) ([]QSub, error)
+	QuerySubs(ctx context.Context, projectUUID string, userUUID string, name string, pageToken string, pageSize int64) ([]QSub, int64, string, error)
+	QueryTopics(ctx context.Context, projectUUID string, userUUID string, name string, pageToken string, pageSize int64) ([]QTopic, int64, string, error)
+	QueryDailyTopicMsgCount(ctx context.Context, projectUUID string, name string, date time.Time) ([]QDailyTopicMsgCount, error)
+	UpdateTopicLatestPublish(ctx context.Context, projectUUID string, name string, date time.Time) error
+	UpdateTopicPublishRate(ctx context.Context, projectUUID string, name string, rate float64) error
+	UpdateSubLatestConsume(ctx context.Context, projectUUID string, name string, date time.Time) error
+	UpdateSubConsumeRate(ctx context.Context, projectUUID string, name string, rate float64) error
+	RemoveTopic(ctx context.Context, projectUUID string, name string) error
+	RemoveSub(ctx context.Context, projectUUID string, name string) error
+	PaginatedQueryUsers(ctx context.Context, pageToken string, pageSize int64, projectUUID string) ([]QUser, int64, string, error)
+	QueryUsers(ctx context.Context, projectUUID string, uuid string, name string) ([]QUser, error)
+	UpdateUser(ctx context.Context, uuid, fname, lname, org, desc string, projects []QProjectRoles, name string, email string, serviceRoles []string, modifiedOn time.Time) error
+	AppendToUserProjects(ctx context.Context, userUUID string, projectUUID string, pRoles ...string) error
+	UpdateUserToken(ctx context.Context, uuid string, token string) error
+	RemoveUser(ctx context.Context, uuid string) error
+	QueryProjects(ctx context.Context, uuid string, name string) ([]QProject, error)
+	UpdateProject(ctx context.Context, projectUUID string, name string, description string, modifiedOn time.Time) error
+	RemoveProject(ctx context.Context, uuid string) error
+	RemoveProjectTopics(ctx context.Context, projectUUID string) error
+	RemoveProjectSubs(ctx context.Context, projectUUID string) error
+	RemoveProjectDailyMessageCounters(ctx context.Context, projectUUID string) error
+	QueryDailyProjectMsgCount(ctx context.Context, projectUUID string) ([]QDailyProjectMsgCount, error)
+	QueryTotalMessagesPerProject(ctx context.Context, projectUUIDs []string, startDate time.Time, endDate time.Time) ([]QProjectMessageCount, error)
+	RegisterUser(ctx context.Context, uuid, name, firstName, lastName, email, org, desc, registeredAt, atkn, status string) error
+	DeleteRegistration(ctx context.Context, uuid string) error
+	QueryRegistrations(ctx context.Context, regUUID, status, activationToken, name, email, org string) ([]QUserRegistration, error)
+	UpdateRegistration(ctx context.Context, regUUID, status, declineComment, modifiedBy, modifiedAt string) error
+	InsertUser(ctx context.Context, uuid string, projects []QProjectRoles, name string, firstName string, lastName string, org string, desc string, token string, email string, serviceRoles []string, createdOn time.Time, modifiedOn time.Time, createdBy string) error
+	InsertProject(ctx context.Context, uuid string, name string, createdOn time.Time, modifiedOn time.Time, createdBy string, description string) error
+	InsertOpMetric(ctx context.Context, hostname string, cpu float64, mem float64) error
+	InsertTopic(ctx context.Context, projectUUID string, name string, schemaUUID string, createdOn time.Time) error
+	LinkTopicSchema(ctx context.Context, projectUUID, name, schemaUUID string) error
+	IncrementTopicMsgNum(ctx context.Context, projectUUID string, name string, num int64) error
+	IncrementDailyTopicMsgCount(ctx context.Context, projectUUID string, topicName string, num int64, date time.Time) error
+	IncrementTopicBytes(ctx context.Context, projectUUID string, name string, totalBytes int64) error
+	IncrementSubBytes(ctx context.Context, projectUUID string, name string, totalBytes int64) error
+	IncrementSubMsgNum(ctx context.Context, projectUUID string, name string, num int64) error
+	InsertSub(ctx context.Context, projectUUID string, name string, topic string, offest int64, ack int, pushCfg QPushConfig, createdOn time.Time) error
+	HasProject(ctx context.Context, name string) bool
+	HasUsers(ctx context.Context, projectUUID string, users []string) (bool, []string)
+	QueryOneSub(ctx context.Context, projectUUID string, name string) (QSub, error)
+	QueryPushSubs(ctx context.Context) []QSub
+	HasResourceRoles(ctx context.Context, resource string, roles []string) bool
+	GetOpMetrics(ctx context.Context) []QopMetric
+	GetUserRoles(ctx context.Context, projectUUID string, token string) ([]string, string)
+	GetUserFromToken(ctx context.Context, token string) (QUser, error)
+	UpdateSubOffset(ctx context.Context, projectUUID string, name string, offset int64)
+	UpdateSubPull(ctx context.Context, projectUUID string, name string, offset int64, ts string) error
+	UpdateSubOffsetAck(ctx context.Context, projectUUID string, name string, offset int64, ts string) error
+	ModSubPush(ctx context.Context, projectUUID string, name string, pushCfg QPushConfig) error
+	QueryACL(ctx context.Context, projectUUID string, resource string, name string) (QAcl, error)
+	ExistsInACL(ctx context.Context, projectUUID string, resource string, resourceName string, userUUID string) error
+	ModACL(ctx context.Context, projectUUID string, resource string, name string, acl []string) error
+	AppendToACL(ctx context.Context, projectUUID string, resource string, name string, acl []string) error
+	RemoveFromACL(ctx context.Context, projectUUID string, resource string, name string, acl []string) error
+	ModAck(ctx context.Context, projectUUID string, name string, ack int) error
+	GetAllRoles(ctx context.Context) []string
+	InsertSchema(ctx context.Context, projectUUID, schemaUUID, name, schemaType, rawSchemaString string) error
+	QuerySchemas(ctx context.Context, projectUUID, schemaUUID, name string) ([]QSchema, error)
+	UpdateSchema(ctx context.Context, schemaUUID, name, schemaType, rawSchemaString string) error
+	DeleteSchema(ctx context.Context, schemaUUID string) error
+	UsersCount(ctx context.Context, startDate, endDate time.Time, projectUUIDs []string) (map[string]int64, error)
+	TopicsCount(ctx context.Context, startDate, endDate time.Time, projectUUIDs []string) (map[string]int64, error)
+	SubscriptionsCount(ctx context.Context, startDate, endDate time.Time, projectUUIDs []string) (map[string]int64, error)
 	Clone() Store
 	Close()
 }

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -1,6 +1,7 @@
 package stores
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -13,6 +14,8 @@ type StoreTestSuite struct {
 }
 
 func (suite *StoreTestSuite) TestMockStore() {
+
+	ctx := context.Background()
 
 	store := NewMockStore("mockhost", "mockbase")
 	suite.Equal("mockhost", store.Server)
@@ -32,7 +35,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
 	}
 	// retrieve all topics
-	tpList, ts1, pg1, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
+	tpList, ts1, pg1, _ := store.QueryTopics(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList, tpList)
 	suite.Equal(int64(4), ts1)
 	suite.Equal("", pg1)
@@ -42,7 +45,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{3, "argo_uuid", "topic4", 0, 0, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, "", time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
 		{2, "argo_uuid", "topic3", 0, 0, time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, "schema_uuid_3", time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
 	}
-	tpList2, ts2, pg2, _ := store.QueryTopics("argo_uuid", "", "", "", 2)
+	tpList2, ts2, pg2, _ := store.QueryTopics(ctx, "argo_uuid", "", "", "", 2)
 	suite.Equal(eTopList1st2, tpList2)
 	suite.Equal(int64(4), ts2)
 	suite.Equal("1", pg2)
@@ -51,7 +54,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	eTopList3 := []QTopic{
 		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
 	}
-	tpList3, ts3, pg3, _ := store.QueryTopics("argo_uuid", "", "", "0", 1)
+	tpList3, ts3, pg3, _ := store.QueryTopics(ctx, "argo_uuid", "", "", "0", 1)
 	suite.Equal(eTopList3, tpList3)
 	suite.Equal(int64(4), ts3)
 	suite.Equal("", pg3)
@@ -60,26 +63,26 @@ func (suite *StoreTestSuite) TestMockStore() {
 	eTopList4 := []QTopic{
 		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
 	}
-	tpList4, ts4, pg4, _ := store.QueryTopics("argo_uuid", "", "topic1", "", 0)
+	tpList4, ts4, pg4, _ := store.QueryTopics(ctx, "argo_uuid", "", "topic1", "", 0)
 	suite.Equal(eTopList4, tpList4)
 	suite.Equal(int64(0), ts4)
 	suite.Equal("", pg4)
 
 	// retrieve a single topic
-	store.LinkTopicSchema("argo_uuid", "topic1", "schema_uuid_1")
+	store.LinkTopicSchema(ctx, "argo_uuid", "topic1", "schema_uuid_1")
 	eTopListSchema := []QTopic{
 		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, "schema_uuid_1", time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
 	}
-	tpListSchema, _, _, _ := store.QueryTopics("argo_uuid", "", "topic1", "", 0)
+	tpListSchema, _, _, _ := store.QueryTopics(ctx, "argo_uuid", "", "topic1", "", 0)
 	suite.Equal(eTopListSchema, tpListSchema)
-	store.LinkTopicSchema("argo_uuid", "topic1", "")
+	store.LinkTopicSchema(ctx, "argo_uuid", "topic1", "")
 
 	// retrieve user's topics
 	eTopList5 := []QTopic{
 		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}},
 		{0, "argo_uuid", "topic1", 0, 0, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, "", time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
 	}
-	tpList5, ts5, pg5, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 0)
+	tpList5, ts5, pg5, _ := store.QueryTopics(ctx, "argo_uuid", "uuid1", "", "", 0)
 	suite.Equal(eTopList5, tpList5)
 	suite.Equal(int64(2), ts5)
 	suite.Equal("", pg5)
@@ -89,13 +92,13 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{1, "argo_uuid", "topic2", 0, 0, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, "schema_uuid_1", time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}},
 	}
 
-	tpList6, ts6, pg6, _ := store.QueryTopics("argo_uuid", "uuid1", "", "", 1)
+	tpList6, ts6, pg6, _ := store.QueryTopics(ctx, "argo_uuid", "uuid1", "", "", 1)
 	suite.Equal(eTopList6, tpList6)
 	suite.Equal(int64(2), ts6)
 	suite.Equal("0", pg6)
 
 	// retrieve all subs
-	subList, ts1, pg1, err1 := store.QuerySubs("argo_uuid", "", "", "", 0)
+	subList, ts1, pg1, err1 := store.QuerySubs(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(eSubList, subList)
 	suite.Equal(int64(4), ts1)
 	suite.Equal("", pg3)
@@ -105,7 +108,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{3, "argo_uuid", "sub4", "topic4", 0, 0, "", "http_endpoint", "endpoint.foo", 1, "autogen", "auth-header-1", 10, "linear", 300, 0, 0, "push-id-1", true, "", "", "", true, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), 0, time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), []string{}},
 		{2, "argo_uuid", "sub3", "topic3", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", false, time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), 5.45, time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), []string{}}}
 
-	subList2, ts2, pg2, err2 := store.QuerySubs("argo_uuid", "", "", "", 2)
+	subList2, ts2, pg2, err2 := store.QuerySubs(ctx, "argo_uuid", "", "", "", 2)
 	suite.Equal(eSubListFirstPage, subList2)
 	suite.Equal(int64(4), ts2)
 	suite.Equal("1", pg2)
@@ -116,7 +119,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}},
 	}
 
-	subList3, ts3, pg3, err3 := store.QuerySubs("argo_uuid", "", "", "1", 2)
+	subList3, ts3, pg3, err3 := store.QuerySubs(ctx, "argo_uuid", "", "", "1", 2)
 	suite.Equal(eSubListNextPage, subList3)
 	suite.Equal(int64(4), ts3)
 	suite.Equal("", pg3)
@@ -128,7 +131,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{ID: 1, ProjectUUID: "argo_uuid", Name: "sub2", Topic: "topic2", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", MaxMessages: 0, Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, LatestConsume: time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), ConsumeRate: 8.99, CreatedOn: time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 	}
 
-	subList4, ts4, pg4, err4 := store.QuerySubs("argo_uuid", "uuid1", "", "", 0)
+	subList4, ts4, pg4, err4 := store.QuerySubs(ctx, "argo_uuid", "uuid1", "", "", 0)
 
 	suite.Equal(int64(3), ts4)
 	suite.Equal("", pg4)
@@ -139,7 +142,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{ID: 3, ProjectUUID: "argo_uuid", Name: "sub4", Topic: "topic4", Offset: 0, NextOffset: 0, PendingAck: "", PushType: "http_endpoint", PushEndpoint: "endpoint.foo", MaxMessages: 1, AuthorizationType: "autogen", AuthorizationHeader: "auth-header-1", Ack: 10, RetPolicy: "linear", RetPeriod: 300, MsgNum: 0, TotalBytes: 0, VerificationHash: "push-id-1", Verified: true, Base64Decode: true, LatestConsume: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC), ConsumeRate: 0, CreatedOn: time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 		{ID: 2, ProjectUUID: "argo_uuid", Name: "sub3", Topic: "topic3", Offset: 0, NextOffset: 0, PendingAck: "", PushEndpoint: "", MaxMessages: 0, Ack: 10, RetPolicy: "", RetPeriod: 0, MsgNum: 0, TotalBytes: 0, LatestConsume: time.Date(2019, 5, 8, 0, 0, 0, 0, time.UTC), ConsumeRate: 5.45, CreatedOn: time.Date(2020, 11, 21, 0, 0, 0, 0, time.UTC), ACL: []string{}},
 	}
-	subList5, ts5, pg5, err5 := store.QuerySubs("argo_uuid", "uuid1", "", "", 2)
+	subList5, ts5, pg5, err5 := store.QuerySubs(ctx, "argo_uuid", "uuid1", "", "", 2)
 
 	suite.Equal(int64(3), ts5)
 	suite.Equal("1", pg5)
@@ -152,7 +155,7 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Nil(err5)
 
 	// test retrieve subs by topic
-	subListByTopic, errSublistByTopic := store.QuerySubsByTopic("argo_uuid", "topic1")
+	subListByTopic, errSublistByTopic := store.QuerySubsByTopic(ctx, "argo_uuid", "topic1")
 	suite.Equal([]QSub{
 		{
 			ID:            0,
@@ -177,41 +180,41 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Nil(errSublistByTopic)
 
 	// Test ProjectUUID
-	suite.Equal(true, store.HasProject("ARGO"))
-	suite.Equal(false, store.HasProject("FOO"))
+	suite.Equal(true, store.HasProject(ctx, "ARGO"))
+	suite.Equal(false, store.HasProject(ctx, "FOO"))
 
 	// check query all
-	qdsAll, _ := store.QueryDailyTopicMsgCount("", "", time.Time{})
+	qdsAll, _ := store.QueryDailyTopicMsgCount(ctx, "", "", time.Time{})
 	suite.Equal(store.DailyTopicMsgCount, qdsAll)
 
 	// test daily count
-	store.IncrementDailyTopicMsgCount("argo_uuid", "topic1", 40, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
-	qds, _ := store.QueryDailyTopicMsgCount("argo_uuid", "topic1", time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
+	store.IncrementDailyTopicMsgCount(ctx, "argo_uuid", "topic1", 40, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
+	qds, _ := store.QueryDailyTopicMsgCount(ctx, "argo_uuid", "topic1", time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
 	suite.Equal(int64(80), qds[0].NumberOfMessages)
 
 	// check if the it was inserted since it wasn't present
-	store.IncrementDailyTopicMsgCount("argo_uuid", "some_other_topic", 70, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
-	qds2, _ := store.QueryDailyTopicMsgCount("argo_uuid", "some_other_topic", time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
+	store.IncrementDailyTopicMsgCount(ctx, "argo_uuid", "some_other_topic", 70, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
+	qds2, _ := store.QueryDailyTopicMsgCount(ctx, "argo_uuid", "some_other_topic", time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC))
 	suite.Equal(int64(70), qds2[0].NumberOfMessages)
 
 	// Test user
-	roles01, _ := store.GetUserRoles("argo_uuid", "S3CR3T")
-	roles02, _ := store.GetUserRoles("argo_uuid", "SecretKey")
+	roles01, _ := store.GetUserRoles(ctx, "argo_uuid", "S3CR3T")
+	roles02, _ := store.GetUserRoles(ctx, "argo_uuid", "SecretKey")
 	suite.Equal([]string{"consumer", "publisher"}, roles01)
 	suite.Equal([]string{}, roles02)
 
 	// Test roles
-	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin"}))
-	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin", "reader"}))
-	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin", "foo"}))
-	suite.Equal(false, store.HasResourceRoles("topics:list_all", []string{"foo"}))
-	suite.Equal(false, store.HasResourceRoles("topics:publish", []string{"reader"}))
-	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"admin"}))
-	suite.Equal(true, store.HasResourceRoles("topics:list_all", []string{"publisher"}))
-	suite.Equal(true, store.HasResourceRoles("topics:publish", []string{"publisher"}))
+	suite.Equal(true, store.HasResourceRoles(ctx, "topics:list_all", []string{"admin"}))
+	suite.Equal(true, store.HasResourceRoles(ctx, "topics:list_all", []string{"admin", "reader"}))
+	suite.Equal(true, store.HasResourceRoles(ctx, "topics:list_all", []string{"admin", "foo"}))
+	suite.Equal(false, store.HasResourceRoles(ctx, "topics:list_all", []string{"foo"}))
+	suite.Equal(false, store.HasResourceRoles(ctx, "topics:publish", []string{"reader"}))
+	suite.Equal(true, store.HasResourceRoles(ctx, "topics:list_all", []string{"admin"}))
+	suite.Equal(true, store.HasResourceRoles(ctx, "topics:list_all", []string{"publisher"}))
+	suite.Equal(true, store.HasResourceRoles(ctx, "topics:publish", []string{"publisher"}))
 
-	store.InsertTopic("argo_uuid", "topicFresh", "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.UTC))
-	store.InsertSub("argo_uuid", "subFresh", "topicFresh", 0, 10, QPushConfig{}, time.Date(2020, 12, 19, 0, 0, 0, 0, time.UTC))
+	store.InsertTopic(ctx, "argo_uuid", "topicFresh", "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.UTC))
+	store.InsertSub(ctx, "argo_uuid", "subFresh", "topicFresh", 0, 10, QPushConfig{}, time.Date(2020, 12, 19, 0, 0, 0, 0, time.UTC))
 
 	eTopList2 := []QTopic{
 		{4, "argo_uuid", "topicFresh", 0, 0, time.Time{}, 0, "", time.Date(2020, 9, 11, 0, 0, 0, 0, time.UTC), []string{}},
@@ -228,34 +231,34 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{1, "argo_uuid", "sub2", "topic2", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", false, time.Date(2019, 5, 7, 0, 0, 0, 0, time.UTC), 8.99, time.Date(2020, 11, 20, 0, 0, 0, 0, time.UTC), []string{}},
 		{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}}
 
-	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", "", 0)
+	tpList, _, _, _ = store.QueryTopics(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList2, tpList)
-	subList, _, _, _ = store.QuerySubs("argo_uuid", "", "", "", 0)
+	subList, _, _, _ = store.QuerySubs(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(eSubList2, subList)
 
 	// Test delete on topic
-	err := store.RemoveTopic("argo_uuid", "topicFresh")
+	err := store.RemoveTopic(ctx, "argo_uuid", "topicFresh")
 	suite.Equal(nil, err)
-	tpList, _, _, _ = store.QueryTopics("argo_uuid", "", "", "", 0)
+	tpList, _, _, _ = store.QueryTopics(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(eTopList, tpList)
-	err = store.RemoveTopic("argo_uuid", "topicFresh")
+	err = store.RemoveTopic(ctx, "argo_uuid", "topicFresh")
 	suite.Equal("not found", err.Error())
 
 	// Test delete on subscription
-	err = store.RemoveSub("argo_uuid", "subFresh")
+	err = store.RemoveSub(ctx, "argo_uuid", "subFresh")
 	suite.Equal(nil, err)
-	subList, _, _, _ = store.QuerySubs("argo_uuid", "", "", "", 0)
+	subList, _, _, _ = store.QuerySubs(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(eSubList, subList)
-	err = store.RemoveSub("argo_uuid", "subFresh")
+	err = store.RemoveSub(ctx, "argo_uuid", "subFresh")
 	suite.Equal("not found", err.Error())
 
-	sb, err := store.QueryOneSub("argo_uuid", "sub1")
+	sb, err := store.QueryOneSub(ctx, "argo_uuid", "sub1")
 	esb := QSub{0, "argo_uuid", "sub1", "topic1", 0, 0, "", "", "", 0, "", "", 10, "", 0, 0, 0, "", false, "", "", "", false, time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC), 10, time.Date(2020, 11, 19, 0, 0, 0, 0, time.UTC), []string{}}
 	suite.Equal(esb, sb)
 
 	// Test modify ack deadline in store
-	store.ModAck("argo_uuid", "sub1", 66)
-	subAck, _ := store.QueryOneSub("argo_uuid", "sub1")
+	store.ModAck(ctx, "argo_uuid", "sub1", 66)
+	subAck, _ := store.QueryOneSub(ctx, "argo_uuid", "sub1")
 	suite.Equal(66, subAck.Ack)
 
 	// Test mod push sub
@@ -273,8 +276,8 @@ func (suite *StoreTestSuite) TestMockStore() {
 		MattermostUsername:  "",
 		MattermostChannel:   "",
 	}
-	e1 := store.ModSubPush("argo_uuid", "sub1", qCfg)
-	sub1, _ := store.QueryOneSub("argo_uuid", "sub1")
+	e1 := store.ModSubPush(ctx, "argo_uuid", "sub1", qCfg)
+	sub1, _ := store.QueryOneSub(ctx, "argo_uuid", "sub1")
 	suite.Nil(e1)
 	suite.Equal("example.com", sub1.PushEndpoint)
 	suite.Equal(int64(3), sub1.MaxMessages)
@@ -285,97 +288,97 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal("auth-h-1", sub1.AuthorizationHeader)
 	suite.True(sub1.Verified)
 
-	e2 := store.ModSubPush("argo_uuid", "unknown", QPushConfig{})
+	e2 := store.ModSubPush(ctx, "argo_uuid", "unknown", QPushConfig{})
 	suite.Equal("not found", e2.Error())
 
 	// exists in acl
-	existsE1 := store.ExistsInACL("argo_uuid", "topics", "topic1", "uuid1")
+	existsE1 := store.ExistsInACL(ctx, "argo_uuid", "topics", "topic1", "uuid1")
 	suite.Nil(existsE1)
 
-	existsE2 := store.ExistsInACL("argo_uuid", "topics", "topic1", "unknown")
+	existsE2 := store.ExistsInACL(ctx, "argo_uuid", "topics", "topic1", "unknown")
 	suite.Equal("not found", existsE2.Error())
 
 	// Query ACLS
 	ExpectedACL01 := QAcl{[]string{"uuid1", "uuid2"}}
-	QAcl01, _ := store.QueryACL("argo_uuid", "topics", "topic1")
+	QAcl01, _ := store.QueryACL(ctx, "argo_uuid", "topics", "topic1")
 	suite.Equal(ExpectedACL01, QAcl01)
 
 	ExpectedACL02 := QAcl{[]string{"uuid1", "uuid2", "uuid4"}}
-	QAcl02, _ := store.QueryACL("argo_uuid", "topics", "topic2")
+	QAcl02, _ := store.QueryACL(ctx, "argo_uuid", "topics", "topic2")
 	suite.Equal(ExpectedACL02, QAcl02)
 
 	ExpectedACL03 := QAcl{[]string{"uuid3"}}
-	QAcl03, _ := store.QueryACL("argo_uuid", "topics", "topic3")
+	QAcl03, _ := store.QueryACL(ctx, "argo_uuid", "topics", "topic3")
 	suite.Equal(ExpectedACL03, QAcl03)
 
 	ExpectedACL04 := QAcl{[]string{"uuid1", "uuid2"}}
-	QAcl04, _ := store.QueryACL("argo_uuid", "subscriptions", "sub1")
+	QAcl04, _ := store.QueryACL(ctx, "argo_uuid", "subscriptions", "sub1")
 	suite.Equal(ExpectedACL04, QAcl04)
 
 	ExpectedACL05 := QAcl{[]string{"uuid1", "uuid3"}}
-	QAcl05, _ := store.QueryACL("argo_uuid", "subscriptions", "sub2")
+	QAcl05, _ := store.QueryACL(ctx, "argo_uuid", "subscriptions", "sub2")
 	suite.Equal(ExpectedACL05, QAcl05)
 
 	ExpectedACL06 := QAcl{[]string{"uuid4", "uuid2", "uuid1"}}
-	QAcl06, _ := store.QueryACL("argo_uuid", "subscriptions", "sub3")
+	QAcl06, _ := store.QueryACL(ctx, "argo_uuid", "subscriptions", "sub3")
 	suite.Equal(ExpectedACL06, QAcl06)
 
 	ExpectedACL07 := QAcl{[]string{"uuid2", "uuid4", "uuid7"}}
-	QAcl07, _ := store.QueryACL("argo_uuid", "subscriptions", "sub4")
+	QAcl07, _ := store.QueryACL(ctx, "argo_uuid", "subscriptions", "sub4")
 	suite.Equal(ExpectedACL07, QAcl07)
 
-	QAcl08, err08 := store.QueryACL("argo_uuid", "subscr", "sub4ss")
+	QAcl08, err08 := store.QueryACL(ctx, "argo_uuid", "subscr", "sub4ss")
 	suite.Equal(QAcl{}, QAcl08)
 	suite.Equal(errors.New("not found"), err08)
 
 	// test mod acl
-	eModACL1 := store.ModACL("argo_uuid", "topics", "topic1", []string{"u1", "u2"})
+	eModACL1 := store.ModACL(ctx, "argo_uuid", "topics", "topic1", []string{"u1", "u2"})
 	suite.Nil(eModACL1)
 	tACL := store.TopicsACL["topic1"].ACL
 	suite.Equal([]string{"u1", "u2"}, tACL)
 
-	eModACL2 := store.ModACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u2"})
+	eModACL2 := store.ModACL(ctx, "argo_uuid", "subscriptions", "sub1", []string{"u1", "u2"})
 	suite.Nil(eModACL2)
 	sACL := store.SubsACL["sub1"].ACL
 	suite.Equal([]string{"u1", "u2"}, sACL)
 
-	eModACL3 := store.ModACL("argo_uuid", "mistype", "sub1", []string{"u1", "u2"})
+	eModACL3 := store.ModACL(ctx, "argo_uuid", "mistype", "sub1", []string{"u1", "u2"})
 	suite.Equal("wrong resource type", eModACL3.Error())
 
 	// test append acl
-	eAppACL1 := store.AppendToACL("argo_uuid", "topics", "topic1", []string{"u3", "u4", "u4"})
+	eAppACL1 := store.AppendToACL(ctx, "argo_uuid", "topics", "topic1", []string{"u3", "u4", "u4"})
 	suite.Nil(eAppACL1)
 	tACLapp := store.TopicsACL["topic1"].ACL
 	suite.Equal([]string{"u1", "u2", "u3", "u4"}, tACLapp)
 
-	eAppACL2 := store.AppendToACL("argo_uuid", "subscriptions", "sub1", []string{"u3", "u4", "u4"})
+	eAppACL2 := store.AppendToACL(ctx, "argo_uuid", "subscriptions", "sub1", []string{"u3", "u4", "u4"})
 	suite.Nil(eAppACL2)
 	sACLapp := store.SubsACL["sub1"].ACL
 	suite.Equal([]string{"u1", "u2", "u3", "u4"}, sACLapp)
 
-	eAppACL3 := store.AppendToACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
+	eAppACL3 := store.AppendToACL(ctx, "argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
 	suite.Equal("wrong resource type", eAppACL3.Error())
 
 	// test remove acl
-	eRemACL1 := store.RemoveFromACL("argo_uuid", "topics", "topic1", []string{"u1", "u4", "u5"})
+	eRemACL1 := store.RemoveFromACL(ctx, "argo_uuid", "topics", "topic1", []string{"u1", "u4", "u5"})
 	suite.Nil(eRemACL1)
 	tACLRem := store.TopicsACL["topic1"].ACL
 	suite.Equal([]string{"u2", "u3"}, tACLRem)
 
-	eRemACL2 := store.RemoveFromACL("argo_uuid", "subscriptions", "sub1", []string{"u1", "u4", "u5"})
+	eRemACL2 := store.RemoveFromACL(ctx, "argo_uuid", "subscriptions", "sub1", []string{"u1", "u4", "u5"})
 	suite.Nil(eRemACL2)
 	sACLRem := store.SubsACL["sub1"].ACL
 	suite.Equal([]string{"u2", "u3"}, sACLRem)
 
-	eRemACL3 := store.RemoveFromACL("argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
+	eRemACL3 := store.RemoveFromACL(ctx, "argo_uuid", "mistype", "sub1", []string{"u3", "u4", "u4"})
 	suite.Equal("wrong resource type", eRemACL3.Error())
 
 	//Check has users
-	allFound, notFound := store.HasUsers("argo_uuid", []string{"UserA", "UserB", "FooUser"})
+	allFound, notFound := store.HasUsers(ctx, "argo_uuid", []string{"UserA", "UserB", "FooUser"})
 	suite.Equal(false, allFound)
 	suite.Equal([]string{"FooUser"}, notFound)
 
-	allFound, notFound = store.HasUsers("argo_uuid", []string{"UserA", "UserB"})
+	allFound, notFound = store.HasUsers(ctx, "argo_uuid", []string{"UserA", "UserB"})
 	suite.Equal(true, allFound)
 	suite.Equal([]string(nil), notFound)
 
@@ -390,17 +393,17 @@ func (suite *StoreTestSuite) TestMockStore() {
 	expProj3 := []QProject{qPr, qPr2}
 	expProj4 := []QProject{}
 
-	projectOut1, err := store.QueryProjects("", "ARGO")
+	projectOut1, err := store.QueryProjects(ctx, "", "ARGO")
 	suite.Equal(expProj1, projectOut1)
 	suite.Equal(nil, err)
-	projectOut2, err := store.QueryProjects("", "ARGO2")
+	projectOut2, err := store.QueryProjects(ctx, "", "ARGO2")
 	suite.Equal(expProj2, projectOut2)
 	suite.Equal(nil, err)
-	projectOut3, err := store.QueryProjects("", "")
+	projectOut3, err := store.QueryProjects(ctx, "", "")
 	suite.Equal(expProj3, projectOut3)
 	suite.Equal(nil, err)
 
-	projectOut4, err := store.QueryProjects("", "FOO")
+	projectOut4, err := store.QueryProjects(ctx, "", "FOO")
 
 	suite.Equal(expProj4, projectOut4)
 	suite.Equal(errors.New("not found"), err)
@@ -408,57 +411,57 @@ func (suite *StoreTestSuite) TestMockStore() {
 	qPr3 := QProject{UUID: "argo_uuid3", Name: "ARGO3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "simple project"}
 	expProj5 := []QProject{qPr, qPr2, qPr3}
 	expProj6 := []QProject{qPr3}
-	store.InsertProject("argo_uuid3", "ARGO3", created, modified, "uuid1", "simple project")
-	projectOut5, err := store.QueryProjects("", "")
+	store.InsertProject(ctx, "argo_uuid3", "ARGO3", created, modified, "uuid1", "simple project")
+	projectOut5, err := store.QueryProjects(ctx, "", "")
 	suite.Equal(expProj5, projectOut5)
 	suite.Equal(nil, err)
 
-	projectOut6, err := store.QueryProjects("argo_uuid2", "ARGO3")
+	projectOut6, err := store.QueryProjects(ctx, "argo_uuid2", "ARGO3")
 	suite.Equal(expProj6, projectOut6)
 	suite.Equal(nil, err)
 	// Test queries by uuid
-	projectOut7, err := store.QueryProjects("argo_uuid2", "")
+	projectOut7, err := store.QueryProjects(ctx, "argo_uuid2", "")
 	suite.Equal(expProj2, projectOut7)
 	suite.Equal(nil, err)
-	projectOut8, err := store.QueryProjects("foo_uuidNone", "")
+	projectOut8, err := store.QueryProjects(ctx, "foo_uuidNone", "")
 	suite.Equal(expProj4, projectOut8)
 	suite.Equal(errors.New("not found"), err)
 
 	// Test update project
 	modified = time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)
 	expPr1 := QProject{UUID: "argo_uuid3", Name: "ARGO3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "a modified description"}
-	store.UpdateProject("argo_uuid3", "", "a modified description", modified)
-	prUp1, _ := store.QueryProjects("argo_uuid3", "")
+	store.UpdateProject(ctx, "argo_uuid3", "", "a modified description", modified)
+	prUp1, _ := store.QueryProjects(ctx, "argo_uuid3", "")
 	suite.Equal(expPr1, prUp1[0])
 	expPr2 := QProject{UUID: "argo_uuid3", Name: "ARGO_updated3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "a modified description"}
-	store.UpdateProject("argo_uuid3", "ARGO_updated3", "", modified)
-	prUp2, _ := store.QueryProjects("argo_uuid3", "")
+	store.UpdateProject(ctx, "argo_uuid3", "ARGO_updated3", "", modified)
+	prUp2, _ := store.QueryProjects(ctx, "argo_uuid3", "")
 	suite.Equal(expPr2, prUp2[0])
 	expPr3 := QProject{UUID: "argo_uuid3", Name: "ARGO_3", CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1", Description: "a newly modified description"}
-	store.UpdateProject("argo_uuid3", "ARGO_3", "a newly modified description", modified)
-	prUp3, _ := store.QueryProjects("argo_uuid3", "")
+	store.UpdateProject(ctx, "argo_uuid3", "ARGO_3", "a newly modified description", modified)
+	prUp3, _ := store.QueryProjects(ctx, "argo_uuid3", "")
 	suite.Equal(expPr3, prUp3[0])
 
 	// Test Sub Update Pull
-	err = store.UpdateSubPull("argo_uuid", "sub4", 4, "2016-10-11T12:00:35:15Z")
-	qSubUpd, _, _, err := store.QuerySubs("argo_uuid", "", "sub4", "", 0)
+	err = store.UpdateSubPull(ctx, "argo_uuid", "sub4", 4, "2016-10-11T12:00:35:15Z")
+	qSubUpd, _, _, err := store.QuerySubs(ctx, "argo_uuid", "", "sub4", "", 0)
 	var nxtOff int64 = 4
 	suite.Equal(qSubUpd[0].NextOffset, nxtOff)
 	suite.Equal("2016-10-11T12:00:35:15Z", qSubUpd[0].PendingAck)
 	// Test RemoveProjectTopics
-	store.RemoveProjectTopics("argo_uuid")
-	resTop, _, _, _ := store.QueryTopics("argo_uuid", "", "", "", 0)
+	store.RemoveProjectTopics(ctx, "argo_uuid")
+	resTop, _, _, _ := store.QueryTopics(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(0, len(resTop))
-	store.RemoveProjectSubs("argo_uuid")
-	resSub, _, _, _ := store.QuerySubs("argo_uuid", "", "", "", 0)
+	store.RemoveProjectSubs(ctx, "argo_uuid")
+	resSub, _, _, _ := store.QuerySubs(ctx, "argo_uuid", "", "", "", 0)
 	suite.Equal(0, len(resSub))
-	store.RemoveProjectDailyMessageCounters("argo_uuid")
-	resMc, _ := store.QueryDailyProjectMsgCount("argo_uuid")
+	store.RemoveProjectDailyMessageCounters(ctx, "argo_uuid")
+	resMc, _ := store.QueryDailyProjectMsgCount(ctx, "argo_uuid")
 	suite.Equal(0, len(resMc))
 
 	// Test RemoveProject
-	store.RemoveProject("argo_uuid")
-	resProj, err := store.QueryProjects("argo_uuid", "")
+	store.RemoveProject(ctx, "argo_uuid")
+	resProj, err := store.QueryProjects(ctx, "argo_uuid", "")
 	suite.Equal([]QProject{}, resProj)
 	suite.Equal(errors.New("not found"), err)
 
@@ -467,16 +470,16 @@ func (suite *StoreTestSuite) TestMockStore() {
 	qRoles := []QProjectRoles{QProjectRoles{"argo_uuid", []string{"admin"}}, QProjectRoles{"argo_uuid2", []string{"admin", "viewer"}}}
 	expUsr10 := QUser{UUID: "user_uuid10", Projects: qRoleAdmin1, Name: "newUser1", FirstName: "fname", LastName: "lname", Organization: "org1", Description: "desc1", Token: "A3B94A94V3A", Email: "fake@email.com", ServiceRoles: []string{}, CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1"}
 	expUsr11 := QUser{UUID: "user_uuid11", Projects: qRoles, Name: "newUser2", Token: "BX312Z34NLQ", Email: "fake@email.com", ServiceRoles: []string{}, CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1"}
-	store.InsertUser("user_uuid10", qRoleAdmin1, "newUser1", "fname", "lname", "org1", "desc1", "A3B94A94V3A", "fake@email.com", []string{}, created, modified, "uuid1")
-	store.InsertUser("user_uuid11", qRoles, "newUser2", "", "", "", "", "BX312Z34NLQ", "fake@email.com", []string{}, created, modified, "uuid1")
-	usr10, _ := store.QueryUsers("argo_uuid", "user_uuid10", "")
-	usr11, _ := store.QueryUsers("argo_uuid", "", "newUser2")
+	store.InsertUser(ctx, "user_uuid10", qRoleAdmin1, "newUser1", "fname", "lname", "org1", "desc1", "A3B94A94V3A", "fake@email.com", []string{}, created, modified, "uuid1")
+	store.InsertUser(ctx, "user_uuid11", qRoles, "newUser2", "", "", "", "", "BX312Z34NLQ", "fake@email.com", []string{}, created, modified, "uuid1")
+	usr10, _ := store.QueryUsers(ctx, "argo_uuid", "user_uuid10", "")
+	usr11, _ := store.QueryUsers(ctx, "argo_uuid", "", "newUser2")
 
 	suite.Equal(expUsr10, usr10[0])
 	suite.Equal(expUsr11, usr11[0])
 
-	rolesA, usernameA := store.GetUserRoles("argo_uuid", "BX312Z34NLQ")
-	rolesB, usernameB := store.GetUserRoles("argo_uuid2", "BX312Z34NLQ")
+	rolesA, usernameA := store.GetUserRoles(ctx, "argo_uuid", "BX312Z34NLQ")
+	rolesB, usernameB := store.GetUserRoles(ctx, "argo_uuid2", "BX312Z34NLQ")
 	suite.Equal("newUser2", usernameA)
 	suite.Equal("newUser2", usernameB)
 
@@ -485,13 +488,13 @@ func (suite *StoreTestSuite) TestMockStore() {
 
 	// Test Update User
 	usrUpdated := QUser{UUID: "user_uuid11", Projects: qRoles, Name: "updated_name", Token: "BX312Z34NLQ", Email: "fake@email.com", ServiceRoles: []string{"service_admin"}, CreatedOn: created, ModifiedOn: modified, CreatedBy: "uuid1"}
-	store.UpdateUser("user_uuid11", "", "", "", "", nil, "updated_name", "", []string{"service_admin"}, modified)
-	usr11, _ = store.QueryUsers("", "user_uuid11", "")
+	store.UpdateUser(ctx, "user_uuid11", "", "", "", "", nil, "updated_name", "", []string{"service_admin"}, modified)
+	usr11, _ = store.QueryUsers(ctx, "", "user_uuid11", "")
 	suite.Equal(usrUpdated, usr11[0])
 
 	// test append project to user
-	errUserPrj := store.AppendToUserProjects("uuid1", "p1_uuid", "r1", "r2")
-	usr, _ := store.QueryUsers("", "uuid1", "")
+	errUserPrj := store.AppendToUserProjects(ctx, "uuid1", "p1_uuid", "r1", "r2")
+	usr, _ := store.QueryUsers(ctx, "", "uuid1", "")
 	suite.Equal([]QProjectRoles{
 		{
 			ProjectUUID: "argo_uuid",
@@ -505,29 +508,29 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Nil(errUserPrj)
 
 	// Test Remove User
-	store.RemoveUser("user_uuid11")
-	usr11, err = store.QueryUsers("", "user_uuid11", "")
+	store.RemoveUser(ctx, "user_uuid11")
+	usr11, err = store.QueryUsers(ctx, "", "user_uuid11", "")
 	suite.Equal(errors.New("not found"), err)
 
-	usrGet, _ := store.GetUserFromToken("A3B94A94V3A")
+	usrGet, _ := store.GetUserFromToken(ctx, "A3B94A94V3A")
 	suite.Equal(usr10[0], usrGet)
 
 	// test paginated query users
 	store2 := NewMockStore("", "")
 
 	// return all users in one page
-	qUsers1, ts1, pg1, _ := store2.PaginatedQueryUsers("", 0, "")
+	qUsers1, ts1, pg1, _ := store2.PaginatedQueryUsers(ctx, "", 0, "")
 
 	// return a page with the first 2
-	qUsers2, ts2, pg2, _ := store2.PaginatedQueryUsers("", 2, "")
+	qUsers2, ts2, pg2, _ := store2.PaginatedQueryUsers(ctx, "", 2, "")
 
 	// empty store
 	store3 := NewMockStore("", "")
 	store3.UserList = []QUser{}
-	qUsers3, ts3, pg3, _ := store3.PaginatedQueryUsers("", 0, "")
+	qUsers3, ts3, pg3, _ := store3.PaginatedQueryUsers(ctx, "", 0, "")
 
 	// use page token "5" to grab another 2 results
-	qUsers4, ts4, pg4, _ := store2.PaginatedQueryUsers("4", 2, "")
+	qUsers4, ts4, pg4, _ := store2.PaginatedQueryUsers(ctx, "4", 2, "")
 
 	suite.Equal(store2.UserList, qUsers1)
 	suite.Equal("", pg1)
@@ -548,40 +551,40 @@ func (suite *StoreTestSuite) TestMockStore() {
 	suite.Equal(int64(2), ts4)
 
 	// test update topic latest publish time
-	e1ulp := store2.UpdateTopicLatestPublish("argo_uuid", "topic1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC))
+	e1ulp := store2.UpdateTopicLatestPublish(ctx, "argo_uuid", "topic1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC))
 	suite.Nil(e1ulp)
-	tpc, _, _, _ := store2.QueryTopics("argo_uuid", "", "topic1", "", 0)
+	tpc, _, _, _ := store2.QueryTopics(ctx, "argo_uuid", "", "topic1", "", 0)
 	suite.Equal(time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC), tpc[0].LatestPublish)
 
 	// test update topic publishing rate
-	e1upr := store2.UpdateTopicPublishRate("argo_uuid", "topic1", 8.44)
+	e1upr := store2.UpdateTopicPublishRate(ctx, "argo_uuid", "topic1", 8.44)
 	suite.Nil(e1upr)
-	tpc2, _, _, _ := store2.QueryTopics("argo_uuid", "", "topic1", "", 0)
+	tpc2, _, _, _ := store2.QueryTopics(ctx, "argo_uuid", "", "topic1", "", 0)
 	suite.Equal(8.44, tpc2[0].PublishRate)
 
 	// test update topic latest publish time
-	scre1 := store2.UpdateSubLatestConsume("argo_uuid", "sub1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC))
+	scre1 := store2.UpdateSubLatestConsume(ctx, "argo_uuid", "sub1", time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC))
 	suite.Nil(scre1)
-	spc, _, _, _ := store2.QuerySubs("argo_uuid", "", "sub1", "", 0)
+	spc, _, _, _ := store2.QuerySubs(ctx, "argo_uuid", "", "sub1", "", 0)
 	suite.Equal(time.Date(2019, 8, 8, 0, 0, 0, 0, time.UTC), spc[0].LatestConsume)
 
 	// test update topic publishing rate
-	scre2 := store2.UpdateSubConsumeRate("argo_uuid", "sub1", 8.44)
+	scre2 := store2.UpdateSubConsumeRate(ctx, "argo_uuid", "sub1", 8.44)
 	suite.Nil(scre2)
-	spc2, _, _, _ := store2.QuerySubs("argo_uuid", "", "sub1", "", 0)
+	spc2, _, _, _ := store2.QuerySubs(ctx, "argo_uuid", "", "sub1", "", 0)
 	suite.Equal(8.44, spc2[0].ConsumeRate)
 
 	// test QueryTotalMessagesPerProject
 	expectedQpmc := []QProjectMessageCount{
 		{ProjectUUID: "argo_uuid", NumberOfMessages: 30, AverageDailyMessages: 7},
 	}
-	qpmc, qpmcerr1 := store2.QueryTotalMessagesPerProject([]string{"argo_uuid"}, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC), time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC))
+	qpmc, qpmcerr1 := store2.QueryTotalMessagesPerProject(ctx, []string{"argo_uuid"}, time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC), time.Date(2018, 10, 4, 0, 0, 0, 0, time.UTC))
 	suite.Equal(expectedQpmc, qpmc)
 	suite.Nil(qpmcerr1)
 
 	// test InsertSchema
-	eis := store.InsertSchema("argo_uuid", "uuid1", "s1-insert", "json", "raw")
-	qs1, _ := store.QuerySchemas("argo_uuid", "uuid1", "s1-insert")
+	eis := store.InsertSchema(ctx, "argo_uuid", "uuid1", "s1-insert", "json", "raw")
+	qs1, _ := store.QuerySchemas(ctx, "argo_uuid", "uuid1", "s1-insert")
 	suite.Equal(QSchema{
 		ProjectUUID: "argo_uuid",
 		UUID:        "uuid1",
@@ -599,32 +602,32 @@ func (suite *StoreTestSuite) TestMockStore() {
 		{UUID: "schema_uuid_2", ProjectUUID: "argo_uuid", Type: "json", Name: "schema-2", RawSchema: s},
 		{UUID: "schema_uuid_3", ProjectUUID: "argo_uuid", Type: "avro", Name: "schema-3", RawSchema: avros},
 	}
-	qqs1, _ := store2.QuerySchemas("argo_uuid", "", "")
-	qqs2, _ := store2.QuerySchemas("argo_uuid", "schema_uuid_1", "")
-	qqs3, _ := store2.QuerySchemas("argo_uuid", "schema_uuid_1", "schema-1")
+	qqs1, _ := store2.QuerySchemas(ctx, "argo_uuid", "", "")
+	qqs2, _ := store2.QuerySchemas(ctx, "argo_uuid", "schema_uuid_1", "")
+	qqs3, _ := store2.QuerySchemas(ctx, "argo_uuid", "schema_uuid_1", "schema-1")
 	suite.Equal(expectedSchemas, qqs1)
 	suite.Equal(expectedSchemas[0], qqs2[0])
 	suite.Equal(expectedSchemas[0], qqs3[0])
 
 	// test update schema
-	store2.UpdateSchema("schema_uuid_1", "new-name", "new-type", "new-raw-schema")
+	store2.UpdateSchema(ctx, "schema_uuid_1", "new-name", "new-type", "new-raw-schema")
 	eus := QSchema{UUID: "schema_uuid_1", ProjectUUID: "argo_uuid", Type: "new-type", Name: "new-name", RawSchema: "new-raw-schema"}
-	qus, _ := store2.QuerySchemas("argo_uuid", "schema_uuid_1", "")
+	qus, _ := store2.QuerySchemas(ctx, "argo_uuid", "schema_uuid_1", "")
 	suite.Equal(eus, qus[0])
 
 	//test delete schema
 	store4 := NewMockStore("", "")
 
-	ed := store4.DeleteSchema("schema_uuid_1")
-	expd, _ := store4.QuerySchemas("argo_uuid", "schema_uuid_1", "")
+	ed := store4.DeleteSchema(ctx, "schema_uuid_1")
+	expd, _ := store4.QuerySchemas(ctx, "argo_uuid", "schema_uuid_1", "")
 	// check that topic-1 no longer has any schema_uuid associated with it
-	qtd, _, _, _ := store4.QueryTopics("argo_uuid", "", "topic2", "", 1)
+	qtd, _, _, _ := store4.QueryTopics(ctx, "argo_uuid", "", "topic2", "", 1)
 	suite.Equal("", qtd[0].SchemaUUID)
 	suite.Equal([]QSchema{}, expd)
 	suite.Nil(ed)
 
 	// test user registration
-	store.RegisterUser("ruuid1", "n1", "f1", "l1", "e1", "o1", "d1", "time", "atkn", "pending")
+	store.RegisterUser(ctx, "ruuid1", "n1", "f1", "l1", "e1", "o1", "d1", "time", "atkn", "pending")
 	expur1 := []QUserRegistration{{
 		UUID:            "ruuid1",
 		Name:            "n1",
@@ -638,10 +641,10 @@ func (suite *StoreTestSuite) TestMockStore() {
 		Status:          "pending",
 	}}
 
-	ur1, _ := store.QueryRegistrations("ruuid1", "pending", "atkn", "n1", "e1", "o1")
+	ur1, _ := store.QueryRegistrations(ctx, "ruuid1", "pending", "atkn", "n1", "e1", "o1")
 	suite.Equal(expur1, ur1)
 
-	ur12, _ := store.QueryRegistrations("ruuid1", "", "", "", "", "")
+	ur12, _ := store.QueryRegistrations(ctx, "ruuid1", "", "", "", "", "")
 	suite.Equal(expur1, ur12)
 
 	expur2 := []QUserRegistration{{
@@ -658,22 +661,22 @@ func (suite *StoreTestSuite) TestMockStore() {
 		ModifiedBy:      "uuid1",
 		ModifiedAt:      "2020-05-17T22:26:58Z",
 	}}
-	store.UpdateRegistration("ur-uuid1", "accepted", "", "uuid1", "2020-05-17T22:26:58Z")
-	ur2, _ := store.QueryRegistrations("ur-uuid1", "accepted", "", "", "", "")
+	store.UpdateRegistration(ctx, "ur-uuid1", "accepted", "", "uuid1", "2020-05-17T22:26:58Z")
+	ur2, _ := store.QueryRegistrations(ctx, "ur-uuid1", "accepted", "", "", "", "")
 	suite.Equal(expur2, ur2)
 
 	suite.Equal(2, len(store.UserRegistrations))
-	_ = store.DeleteRegistration("ruuid1")
+	_ = store.DeleteRegistration(ctx, "ruuid1")
 	suite.Equal(1, len(store.UserRegistrations))
 
-	dErr := store.DeleteRegistration("unknown")
+	dErr := store.DeleteRegistration(ctx, "unknown")
 	suite.Equal("not found", dErr.Error())
 
 	sdate := time.Date(2008, 11, 19, 8, 0, 0, 0, time.UTC)
 	edate := time.Date(2020, 11, 21, 6, 0, 0, 0, time.UTC)
-	tc, _ := store3.TopicsCount(sdate, edate, []string{})
-	sc, _ := store3.SubscriptionsCount(sdate, edate, []string{})
-	uc, _ := store2.UsersCount(sdate, edate, []string{})
+	tc, _ := store3.TopicsCount(ctx, sdate, edate, []string{})
+	sc, _ := store3.SubscriptionsCount(ctx, sdate, edate, []string{})
+	uc, _ := store2.UsersCount(ctx, sdate, edate, []string{})
 
 	suite.Equal(map[string]int64{"argo_uuid": 3}, tc)
 	suite.Equal(map[string]int64{"argo_uuid": 3}, sc)


### PR DESCRIPTION
Added a new parameter that should be present in all logs that take place after a user has executed any request against the system.
The **trace_id** parameter will assist in grouping logs of the same originator making it easier to check what happened during a specific flow.

The most idiomatic way to add request-scoped parameters is through the standard context package.
It's common in go to propagate context as a first parameter in each function.

The biggest change is the store interface which had all its methods to accept a context as first argument.
This change also helps in the migration to the new mongo official driver, which expects context on all its calls.