### PR TITLE
Revert "AM-378 returnImmediately should be honored even when there are no new messages"

### DIFF
--- a/brokers/kafka.go
+++ b/brokers/kafka.go
@@ -308,8 +308,7 @@ func (b *KafkaBroker) Consume(ctx context.Context, topic string, offset int64, i
 	).Debug("Trying to consume")
 
 	// If tracked offset is equal or bigger than topic offset means no new messages
-	// and as a result we can return immediately if requested
-	if imm && offset >= loff {
+	if offset >= loff {
 		return []string{}, nil
 	}
 


### PR DESCRIPTION
This reverts commit 65e8e36d0327d49f718ab1291659abe0fca7a662.